### PR TITLE
infra(argocd): add claude-agent read-only local account and RBAC

### DIFF
--- a/infra/terraform/argocd.tf
+++ b/infra/terraform/argocd.tf
@@ -21,6 +21,30 @@ resource "helm_release" "argocd" {
   namespace        = kubernetes_namespace.argocd.metadata[0].name
   create_namespace = false
 
+  # Read-only local account for the claude-agent MCP.
+  # Token is minted manually: `argocd account generate-token --account claude-agent`
+  values = [
+    yamlencode({
+      configs = {
+        cm = {
+          "accounts.claude-agent"         = "apiKey"
+          "accounts.claude-agent.enabled" = "true"
+        }
+        rbac = {
+          "policy.csv" = <<-EOT
+            p, role:readonly-apps, applications, get, */*, allow
+            p, role:readonly-apps, applications, list, */*, allow
+            p, role:readonly-apps, logs, get, */*, allow
+            p, role:readonly-apps, clusters, get, *, allow
+            p, role:readonly-apps, projects, get, *, allow
+            p, role:readonly-apps, repositories, get, *, allow
+            g, claude-agent, role:readonly-apps
+          EOT
+        }
+      }
+    })
+  ]
+
   # Server configuration
   set {
     name  = "server.service.type"


### PR DESCRIPTION
## Summary
- Adds a local Argo account `claude-agent` with a `readonly-apps` RBAC role (get/list on applications, logs, clusters, projects, repositories — no sync/update/delete).
- Token is minted out-of-band via `argocd account generate-token --account claude-agent` and lives in `nas:~/projects/claude-agent/.env` as `ARGOCD_TOKEN` for the `argocd-mcp` server in the `claude-agent` container.

## Why
So the claude-agent's MCP layer can read Argo state (applications, sync status, logs) without any ability to mutate.

## Notes
- Side-fix applied out-of-band to unwedge the Helm upgrade that was failing on `argocd-repo-server` env drift: removed a manually-edited plain-value `ARGOCD_GIT_REQUEST_TIMEOUT=10m` env entry. The configmap `argocd-cmd-params-cm` has the same value (600s) via `reposerver.git.request.timeout`, so functionally a no-op; Helm now re-adds the env entry with `valueFrom` on each apply.
- Verified with a real token: `GET /api/v1/applications` returns 200; `POST /applications/.../sync` returns 403 with `permission denied: applications, sync`.

## Test plan
- [x] `terraform plan` shows 0 changes after apply
- [x] argocd-mcp shows `✓ Connected` from the claude-agent container
- [x] Read API works with the token
- [x] Write API denied by RBAC