### PR TITLE
fix(session-song): stop emailing admins when a throwaway player's song fails

### DIFF
--- a/apps/web/src/lib/tasks/session-song.ts
+++ b/apps/web/src/lib/tasks/session-song.ts
@@ -382,6 +382,36 @@ async function notifyAdminsOfSongFailure({
   failureKind: string
 }) {
   try {
+    // Suppress noise from throwaway players (daily smoke test / debug / e2e).
+    // The smoke CronJob completes a debug session — which triggers this async
+    // song task — then the debug cleanup deletes the throwaway player. The task
+    // then fails with "player not found" and would otherwise email every admin
+    // once or twice every morning. Mirror the cleanup's own throwaway criteria
+    // (see api/debug/cleanup) so only these synthetic failures are silenced;
+    // real students are never expungeable/deleted, so their failures still page.
+    const [player] = await db
+      .select({
+        name: schema.players.name,
+        emoji: schema.players.emoji,
+        isExpungeable: schema.players.isExpungeable,
+      })
+      .from(schema.players)
+      .where(eq(schema.players.id, input.playerId))
+      .limit(1)
+
+    const isThrowawayPlayer =
+      !player || // already deleted by the smoke/debug cleanup before the task resolved
+      player.isExpungeable ||
+      (player.name.startsWith('Debug-') && player.emoji === '🐛') ||
+      player.name.endsWith(' Test Child')
+
+    if (isThrowawayPlayer) {
+      console.info(
+        `[session-song] Skipping admin failure notification for throwaway player (song ${songId}, player ${input.playerId})`
+      )
+      return
+    }
+
     const admins = await db
       .select({ id: schema.users.id })
       .from(schema.users)


### PR DESCRIPTION
## Problem

Admins get 1–2 **"Session song failed for Unknown player"** emails every morning (~08:0x America/Chicago). They are pure noise — no real student is affected.

## Root cause

The daily **smoke CronJob** exercises the full practice flow against prod:

1. `POST /api/debug/practice-session` creates a throwaway player (`Debug-<ts>`, emoji 🐛, `isExpungeable: true`) and completes a session.
2. Completing the session fires the **async `session-song` task** (ElevenLabs generation) in the background.
3. `POST /api/debug/cleanup` then deletes the throwaway player.
4. The still-running song task resolves, tries to look the player up, fails with *"player not found"*, and `notifyAdminsOfSongFailure` emails **every** admin.

So the failure is real for the *task*, but the "player" is a synthetic row that was intentionally deleted. Nothing actionable.

## Fix

Guard `notifyAdminsOfSongFailure` (in `apps/web/src/lib/tasks/session-song.ts`) with the **same throwaway criteria the debug cleanup itself uses** (`apps/web/src/app/api/debug/cleanup/route.ts`):

- `isExpungeable` (primary signal — set on every debug/smoke player)
- legacy `Debug-*` name **+** 🐛 emoji
- `"* Test Child"` name (e2e fixtures)
- **or the player row is already gone** (`!player`) — the common case here, since cleanup deletes it before the async task resolves

When it matches, we `console.info(...)` and return instead of emailing. Real students are never expungeable or deleted mid-flight, so genuine song failures still page admins unchanged.

## Why at the notification layer

This silences the synthetic failures **without** touching the generation pipeline, the smoke test, or the cleanup ordering — the song task is *supposed* to fail once its player is gone; we just shouldn't treat that as an admin-actionable incident. The `console.info` keeps it visible in logs for debugging.

## Testing / verification notes

- Verified `input.playerId` and `songId` are already in scope in the function (the event payload below the guard uses `input.playerId`).
- The drizzle `select` mirrors the existing `getPlayerName` query in the same file; columns (`name`, `emoji`, `isExpungeable`) confirmed against `apps/web/src/db/schema/players.ts` (`name`/`emoji` are `notNull()` text, `isExpungeable` is `notNull()` boolean).
- Did not run the full monorepo `tsc` locally — a fresh clone needs the private `@tidepool`/`@eink` Gitea registry auth to install. Types verified by inspection against the schema + existing patterns; CI typecheck will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)