### PR TITLE
Add AbacusLink modular-column joint prototype

### DIFF
--- a/apps/web/docs/abacus-studio/modular-columns-spec.md
+++ b/apps/web/docs/abacus-studio/modular-columns-spec.md
@@ -5,13 +5,25 @@ and sized; the numbers below are analytical and need one coupon print to confirm
 (see §9). The existing monolith is untouched and stays the default.
 
 **Companion files**
-- `apps/web/public/scad/abacus-link.scad` — the joint geometry + a printable
-  two-piece test coupon. Geometry source of truth for the joint.
+- `apps/web/public/scad/abacus-link.scad` — the joint geometry, as a LIBRARY
+  (`include`d by `abacus.scad`; it emits nothing on its own). Source of truth for
+  the joint's shape.
+- `apps/web/public/scad/abacus.scad` — consumes it: the `link_*` knobs, the two
+  modular dimension floors, and the `link_coupon` / `link_column` part passes.
 - `apps/web/src/components/create/abacus/abacus-link.ts` — the TS mirror of the
   joint's derived chain and its fit guards, same relationship `derived()` and
-  `feetEffective()` have to `abacus.scad`.
+  `feetEffective()` have to `abacus.scad`. `linkParamsOf()` is the bridge that
+  runs those guards against a real design rather than against coupon defaults.
+- `apps/web/src/components/create/abacus/ModularColumnsPanel.tsx` — the studio
+  surface: the mode toggle, the size delta, the fit verdict, the ramp sweep, and
+  the two plate downloads. Behind the `abacus.modular_columns` feature flag,
+  default off.
 - `master-model-spec.md` — the monolith this builds on. Read §1 (anatomy) and §4
   (locked vs proportional) first; this document assumes both.
+
+**What exists today:** everything above. What it does *not* do yet is make the
+assembled abacus modular — see §7 → *Code changes* for why that waits, and §9 for
+what to print first.
 
 ---
 
@@ -521,16 +533,25 @@ pocket overlapping the latch slot. Both of those render, slice, print and click
 together while being wrong, which is why they are pinned in CI rather than left
 to the scad's `assert()`.
 
-0. **Render it.** `part="coupon"` through the studio's worker or desktop
-   OpenSCAD, and confirm every `assert` passes and the mesh is manifold. This
-   step has not been done.
-1. **Coupon** (`abacus-link.scad`, `part="coupon"`) — two half-modules carrying
-   one full interface. Print, then measure: seam gap (target **0.00 mm** at the
-   chevron flanks, ~0.12 mm at the relieved flats — the whole point of the cam),
-   Z step across the seam (target < 0.05 mm), insertion force (predicted ~15 N
-   peak), release force, and retention force to failure. Sweep `link_ramp` over
-   8° / 12° / 16° and `link_fit` over three values on one plate — all three ramp
-   rungs are legal geometries, so the sweep is a define change and nothing else.
+0. **Render it.** Open Storybook → *Create/Abacus/Parts* → `LinkCoupon` and
+   `LinkColumnPair`. Those stories drive the real WASM worker, so this is the
+   first time the joint is solved by a machine at all — expect to fix asserts and
+   winding here. Check three things by eye: the chevron teeth mesh, the latch
+   tongue stands clear inside its slot, and the release bore opens into the slot
+   *past* the shoulder rather than through it.
+1. **Coupon** — studio → *3D print* rail → **Modular columns (prototype)** →
+   *Download joint coupon*, or the story's own Download STL. Two half-modules
+   carrying one full interface. Print, then measure: seam gap (target **0.00 mm**
+   at the chevron flanks, ~0.12 mm at the relieved flats — the whole point of the
+   cam), Z step across the seam (target < 0.05 mm), insertion force (predicted
+   ~15 N peak), release force, and retention force to failure. Sweep `link_ramp`
+   over 8° / 12° / 16° with the panel's slider and print all three on one plate —
+   every rung is a legal geometry, so the sweep is a define change and nothing
+   else.
+1b. **Column pair** — the same panel's second button: two real column modules
+   with their captive beads. This is the one that answers whether halving the web
+   disturbed capture. Check the beads still slide and still can't lift out, then
+   click the two modules together and check the top faces are flush.
 2. **Cycle life** — 100 insert/release cycles on one coupon, re-measure seam gap.
    The flexure root is the fatigue site.
 3. **Creep** — leave a coupon clamped for a week at room temperature and

--- a/apps/web/docs/abacus-studio/modular-columns-spec.md
+++ b/apps/web/docs/abacus-studio/modular-columns-spec.md
@@ -1,0 +1,544 @@
+# Modular Columns — the AbacusLink interface
+
+**Status:** design proposal. Nothing here ships yet. The mechanism is specified
+and sized; the numbers below are analytical and need one coupon print to confirm
+(see §9). The existing monolith is untouched and stays the default.
+
+**Companion files**
+- `apps/web/public/scad/abacus-link.scad` — the joint geometry + a printable
+  two-piece test coupon. Geometry source of truth for the joint.
+- `apps/web/src/components/create/abacus/abacus-link.ts` — the TS mirror of the
+  joint's derived chain and its fit guards, same relationship `derived()` and
+  `feetEffective()` have to `abacus.scad`.
+- `master-model-spec.md` — the monolith this builds on. Read §1 (anatomy) and §4
+  (locked vs proportional) first; this document assumes both.
+
+---
+
+## 0. The idea
+
+One column = one printed module. Modules snap together; special left and right
+end caps carry their half of the frame. An abacus becomes a **stack** instead of
+a slab.
+
+The product case writes itself: the abacus grows with the kid one place value at
+a time, columns are swappable, and a specialty column is a thing you can make,
+trade, or sell. Three consequences are less obvious and are worth as much:
+
+1. **Single-extruder full colour.** Today a multicolour abacus needs an AMS and
+   `abacus-plan.ts` quantizes every bead role onto ≤ 8 loaded spools. A stack of
+   modules is N separate objects, so a colour change is a *plate* change, not a
+   layer change. Anyone with a bone-stock printer can make a place-value-coloured
+   abacus by printing four modules in blue, three in red, and so on. The whole
+   filament-quantization apparatus becomes optional rather than load-bearing.
+2. **Failure is cheap.** A failed 6-hour monolith is a 6-hour loss. A failed
+   module is 25 minutes. This matters enormously for classrooms and print farms.
+3. **A column is a complete product.** One module with four earth beads and one
+   heaven bead is a legitimate toy on its own — and it's the natural free/sample
+   SKU, the thing you hand a kid to see if the interface feels good.
+
+And one real cost, stated up front: **the abacus grows ~14% wider and 3.5 mm
+deeper** — 192.5 × 100.5 mm becomes 220.0 × 104.0 mm at 13 columns (§5).
+
+---
+
+## 1. What is actually hard
+
+Split a slab into segments and you have replaced material with joints. Take each
+load direction in turn, in the frame of the monolith (X = long axis / column
+direction, Y = bead slide axis, Z = thickness):
+
+| Load | Resisted by | Lever arm available at a seam | Verdict |
+|---|---|---|---|
+| **X separation** (pulling columns apart) | latch tension | — | easy, positive interlock |
+| **M_z** — in-plane splay | X tension/compression couple | **100.5 mm** (front strip ↔ back strip) | trivially easy |
+| **M_x** — torsion about the long axis | Z-shear couple | **~90 mm** (front strip ↔ back strip) | easy, given Z-shear capacity |
+| **M_y** — sag about the long axis | X tension/compression couple | **8 mm** (`frame_h`) | **the whole problem** |
+
+Everything except M_y has a lever arm an order of magnitude larger than the slab
+is thick, because the abacus is 100 mm deep and only 8 mm tall. M_y is the one
+direction where the joint's couple arm is the slab thickness, and that is the
+entire structural design problem. The rest of this document is about M_y.
+
+### Where the joint can even have features
+
+A seam plane is 100.5 mm of Y, but the module is only *thick* in three places —
+everywhere else the bead channels open through both faces and the seam is two
+1.25 mm channel walls face to face. In outer coordinates at defaults:
+
+```
+Y   0.0 ─────── 13.0    STATION F   front strip   (border band + shelf)
+   13.0 ─────── 61.5    earth channel — walls only
+   61.5 ─────── 69.0    STATION B   the reckoning bar
+   69.0 ─────── 87.5    heaven channel — walls only
+   87.5 ────── 100.5    STATION K   back strip
+```
+
+**F, B and K are the only places a joint feature can reach into X.** They are
+also, conveniently, spread across the full depth — 100 mm between F and K is a
+huge torsional lever arm for free.
+
+(Those coordinates are the monolith's, at `border_w` 5.25. Modular mode widens
+the border and the two strips grow to 14.75 mm — see §5 for why it has to.)
+
+---
+
+## 2. The load case that sets the spec
+
+Three things want stiffness, and only one of them is structural.
+
+**(a) Sag between feet.** The monolith already concedes this: `feet_span = 110`
+comes from capping mid-span deflection at 0.3 mm under a 25 N hand press. But
+modular columns each carry their own feet, so **the unsupported run collapses
+from 110 mm to one column pitch**. This load case gets *easier*, not harder. The
+whole `feet_span` / intermediate-feet derivation in `abacus.scad` becomes dead
+code in modular mode.
+
+**(b) Handling.** Picked up by one end, waved, twisted. Nothing breaks, but a
+stack that visibly droops or creaks reads as a toy that fell apart, and the
+product story is the opposite of that.
+
+**(c) Marker coplanarity — the real spec.** `arucoDetection.ts` finds four
+corner markers and fits a **homography**, which assumes the four points are
+coplanar. TL and BL live on the left end cap, TR and BR on the right. If the
+stack twists, TL/BR rise while TR/BL fall, the planarity assumption breaks, and
+the rectification skews — silently. Not noise: a *systematic* misread of column
+positions.
+
+Two useful facts fall out of thinking about it this way:
+
+- **A uniform seam gap is free.** N identical gaps just make the marker rectangle
+  slightly larger, and a homography maps the measured rectangle onto the model
+  rectangle — a uniform scale error is absorbed exactly. What the CV cannot
+  absorb is *non-uniform* gaps and *out-of-plane* warp.
+- **The seams are a gift to the CV.** They are high-contrast lines at exactly
+  known pitch, running the full depth. That is a free column-registration signal
+  the monolith does not have.
+
+So the spec is not "as stiff as the monolith." It is:
+
+> **Keep the four marker centres coplanar under handling, and keep the top faces
+> of adjacent modules flush and rattle-free.**
+
+---
+
+## 3. The key result: a *closed* joint is as stiff as the material it replaces
+
+This is the observation the whole design hangs on, so here it is with numbers.
+
+At a column centre the monolith's bending section is only the three solid
+stations, `b = 13 + 7.5 + 13 = 33.5 mm` at `h = 8`:
+
+```
+I_column-centre = 33.5 · 8³ / 12  ≈  1.4 × 10³ mm⁴
+```
+
+At a **seam plane** the section is the full depth — stations *plus* the channel
+walls, which are continuous there:
+
+```
+I_seam = 100.5 · 8³ / 12  ≈  4.3 × 10³ mm⁴
+```
+
+The seam is a *locally strong* station, three times the section of the weakest
+part of the monolith. So the joint doesn't have to be clever; it has to be
+**closed**. The rotational stiffness one pitch of monolith provides is
+
+```
+k_θ = E·I/p = 2000 MPa · 1429 mm⁴ / 13 mm ≈ 2.2 × 10⁵ N·mm/rad
+```
+
+A butt joint held in compression behaves as a bed of springs of contact modulus
+κ over its face, giving `k_θ = κ · I_seam`, so matching the monolith needs
+
+```
+κ ≥ 2.2e5 / 4288 ≈ 51 N/mm³
+```
+
+Two pressed FDM faces have asperities on the order of 0.02 mm that close under a
+few MPa — κ in the hundreds of N/mm³. **An order of magnitude of margin.** A
+closed, preloaded butt joint is not a compromise; it is as stiff as the slab.
+
+### Which means the problem is not stiffness. It is *gapping*.
+
+A joint under moment M with axial preload P over face area A stays fully closed
+while the bending stress at the extreme fibre stays under the preload stress:
+
+```
+M · c / I_seam  ≤  P / A        with c = 4, A = 804 mm²
+⇒  M_gap = P · h/6 = 1.33 · P        [N·mm per N of preload]
+```
+
+Once it gaps, the joint becomes a hinge, and hinges in series are how a stack
+turns into a chain. Suppose the latch retains with a residual clearance `c` —
+the assembly play any snap fit needs to go together. The joint can hinge by
+
+```
+θ ≈ c / h
+```
+
+At a modest `c = 0.05 mm` and `h = 8`, that's 0.36° **per joint**. Cantilever a
+13-column stack from one end and let all twelve joints hinge: the far end lands
+
+```
+Σ θ·(L − xᵢ)  =  0.00625 rad × 1170 mm  ≈  7.3 mm      [linkHingeDroop, pinned]
+```
+
+out of plane. Seven millimetres of droop from five hundredths of a millimetre of
+latch slop, and that is with a *good* snap fit. This single number is why the
+obvious design — puzzle tabs and a click — does not work, and it dictates
+everything in §4:
+
+> **The latch must not merely retain. It must drive the seam shut, and the
+> assembled clearance must be zero regardless of the manufactured clearance.**
+
+---
+
+## 4. The joint: chevron for Z, cam latch for X
+
+Two mechanisms, one job each, and — this is the constraint that kills most
+designs — **both must print flat with no supports**, because the beads are
+captive print-in-place and the build orientation is not negotiable.
+
+That rules out a great deal. Any feature that reaches sideways in X has a
+horizontal underside. Any Z undercut is an overhang. What *is* free is anything
+prismatic in Z (vertical walls print perfectly) and anything whose faces stay
+within 45° of vertical.
+
+### 4a. Chevron — Z registration and Z shear
+
+Each seam face carries a **two-tooth chevron** running along Y: an isosceles
+ridge on one face, the matching groove on the other.
+
+```
+        ← X →                    tooth height  h_t = 4.0 mm   (frame_h / 2)
+   ╱▔▔▔╲        z = 8            tooth depth   d_t = 1.6 mm
+  ╱     ╲                        flank angle   arctan(1.6/2) = 38.7° from vertical
+  ╲     ╱       z = 4            self-support limit is 45° → 6.3° of margin
+   ╲___╱        z = 0
+```
+
+- **Printable.** Every flank is 38.7° off vertical, comfortably inside the
+  self-supporting limit, in both the ridge and the groove.
+- **Self-centring in Z.** You physically cannot assemble two modules with their
+  top faces out of step — the teeth won't mesh. This is what guarantees marker
+  coplanarity, and it does it by construction rather than by tolerance.
+- **Locks Z shear.** Sliding 0.1 mm in Z requires the modules to separate by
+  0.08 mm in X (`Δx = Δz · d_t / (h_t/2)`). With X locked, Z is locked. Torsion,
+  which is Z-shear across the 100 mm F↔K span, is therefore carried by geometry,
+  not friction.
+- Lives at stations F, B, K only. A 1.6 mm ridge cannot sit on a 2.25 mm channel
+  wall, and the wall regions are **relieved by 0.3 mm** so nothing there can hold
+  the real contact pads off their seats. That relief is visible from above as a
+  fine line down the middle of each web — which is exactly the right thing to
+  look like, given the product is "these are separate columns."
+
+### 4b. Cam latch — X preload and take-up
+
+At stations F and K, a **cantilever flexure** rooted in the module's right face
+reaches into a pocket in the neighbour's left face.
+
+- The beam runs along **Y**, the hook protrudes in **X**, and every surface is
+  vertical — prismatic in Z, therefore support-free by construction, and 8 mm
+  tall, therefore very stiff about the axis that matters.
+- The engaging face is **not perpendicular to X**. It is a ramp at **α = 8°** to
+  the flexure's travel direction. As the spring drives the hook in, the ramp
+  pulls the two modules together in X.
+
+That inclined face is the whole trick:
+
+```
+take-up   Δx  =  t · tan α       1.1 mm of barb travel → 0.155 mm of X take-up
+force     Fx  =  Fn / tan α      7.4 N of spring → 52.8 N of clamp per station
+self-lock     tan 8° = 0.141  <  μ_PLA ≈ 0.3   (friction angle 16.7°)
+```
+
+- **Assembled clearance is zero, by construction.** The flexure keeps advancing
+  until the chevron flanks bottom out. Manufacturing spread is consumed by
+  flexure travel, not by joint slop — 0.155 mm of it, against the ±0.1 mm a
+  well-tuned FDM printer varies by. This is the fix for the 7.3 mm droop.
+- **The preload is the SEATED force, not the full-travel force.** What a seam
+  holds depends on how far the barb still had to go when the chevron bottomed —
+  nominally half the barb height. Quoting full travel would overstate the
+  preload by exactly 2×, which is the sort of error that survives all the way to
+  a part that feels loose in the hand. `linkMechanics()` reports both, and the
+  full-travel figure is labelled as what it actually is: the insertion peak, and
+  the deflection the tongue's fibre stress has to be checked at (41 MPa, against
+  PLA's ~55 MPa yield, and transient).
+- **Self-locking.** At 8° the joint cannot be driven open by load; it can only be
+  released by pushing the flexure back. Under overload the load path becomes
+  bearing on the wedge face (~6 × 5 mm of PLA at 40 MPa ≈ 1200 N), so the joint
+  gets stronger rather than hinging.
+- **Creep-compensating.** PLA under sustained preload creeps, and a bolted joint
+  would slowly loosen. A *spring-driven wedge* does the opposite: as the material
+  relaxes, the flexure advances the wedge and the clamp is maintained. The one
+  mechanism that would otherwise be the long-term risk is the one that answers it.
+- **Deliberate release.** The flexure's free end continues to a **button on the
+  outer wall** — front wall at station F, back wall at station K. Squeeze both,
+  and the column releases. Two-handed, impossible by accident, obvious once shown.
+
+### 4c. Station B — passive key
+
+Mid-depth, unreachable from outside, so no latch and no button. Station B gets
+the chevron and a close-fitting alignment tongue only. It contributes Z-shear
+capacity and compression-side bearing, and it braces the free ends of the two
+channel walls. F and K do all the retaining.
+
+**One tongue per station, not two.** Doubling up would double the clamp, but the
+release poke has to reach a tongue from an outer wall, and the second tongue's
+shoulder is exactly the material the second bore would have to drill through. A
+seam gets its two tongues by having two *stations* instead — front strip
+released from the front wall, back strip from the back wall. Which is also what
+makes release two-handed, and two-handed is what makes it impossible by accident.
+
+### 4d. Preload budget
+
+`M_gap = P · h/6` from §3, at the shipped geometry (13 columns, 15 mm pitch,
+L = 195 mm, ~130 g). Clamp per seam is **105.7 N**, so `M_gap` = **141 N·mm**:
+
+| Case | M at worst joint | P needed | |
+|---|---|---|---|
+| 25 N press, foot under every column | 94 N·mm | 70 N | **closed** |
+| Carried by one end, static | 125 N·mm | 94 N | **closed** |
+| 25 N press, feet every 3rd column | 281 N·mm | 211 N | opens onto the wedge |
+| Carried by one end, shaken at 3 g | 374 N·mm | 281 N | opens onto the wedge |
+| Deliberate two-handed bend, 50 N mid-span | 2438 N·mm | 1828 N | opens onto the wedge |
+
+So preload buys the two cases the abacus actually lives in — sitting on a table
+being used, and being carried — and those are the ones where "as stiff as the
+slab" has to be literally true. **Everything past that is not a failure, it is a
+different regime:** the joint opens onto the self-locking wedge face and carries
+the rest in bearing (≈ 1200 N of PLA in shear before anything breaks). It gets
+softer, it does not come apart, and because the cam re-seats on release, it does
+not stay bent. That is the correct behaviour for a thing a child will lean on.
+
+The ramp is the knob that trades the two halves of this against each other, and
+all three rungs of the coupon sweep are legal geometries:
+
+| `link_ramp` | take-up | clamp / seam |
+|---|---|---|
+| 8° *(default)* | 0.155 mm | 106 N |
+| 12° | 0.234 mm | 70 N |
+| 16° | 0.315 mm | 52 N |
+
+More take-up means more printer spread swallowed; less clamp means a lower
+threshold before the wedge takes over. Which end of that is right is a question
+about real printers, which is why it is a sweep and not a decision.
+
+---
+
+## 5. What it costs: the web bump
+
+The seam splits the web between channels down its middle, so each module carries
+a 1.25 mm half-wall where the monolith had a continuous 2.5 mm one. That is too
+thin: the earth channel's wall spans 48.5 mm unsupported between stations F and
+B, and at 1.25 mm its lateral stiffness is
+
+```
+k = 192·E·I/L³ = 192 · 2000 · (8·1.25³/12) / 48.5³  ≈  4.4 N/mm
+```
+
+— a 1 N sideways push on a bead bows the wall a quarter of a millimetre. Beads
+would feel loose and columns would rub.
+
+**Modular mode raises `web` from 2.5 to 4.5**, giving each module a 2.25 mm
+half-wall:
+
+```
+k = 192 · 2000 · (8·2.25³/12) / 48.5³  ≈  25.5 N/mm     per wall
+```
+
+and, because two walls now flank each channel where the monolith had one:
+
+```
+2 · 2.25³ = 22.8    vs.    2.5³ = 15.6        →  1.46× stiffer than the monolith
+```
+
+The channel walls end up **stiffer than the monolith's**, not weaker. The price
+is pitch:
+
+```
+col_pitch   13.0 → 15.0 mm
+13 columns  192.5 → 220.0 mm outer width      (+14.3%)
+            (field_w = 2·13.0 + 12·15.0 = 206, plus 2 × the widened border)
+```
+
+That is the honest cost of modularity and it is the main thing to weigh. Note it
+gets cheaper as the abacus gets bigger: `web` scales with `S` while the printable
+wall minimum does not, so **modular mode has a size floor** — below roughly
+`S = 0.8` the half-wall stops being printable. That degradation has precedent in
+this model: `feet_crossbar` already falls back to a dovetail below `S ≈ 0.725`
+rather than refusing to render.
+
+### Foot pockets, and the second thing this costs
+
+Each module gets its own foot pockets at stations F and K, on the bottom face.
+Writing the collision guard as a real box-disjoint test rather than a one-axis
+check (`linkFit` → `foot-hits-slot`) immediately turned up something the
+eyeball missed: **the foot and the latch cannot share the strip on X.** The slot
+runs from the seam out to x = 8.2 of a 15 mm pitch, leaving 6.8 mm of clear
+width — less than even the smallest `BUMPER_PRESETS` entry needs with walls.
+
+So they are separated on **Y** instead: outer wall, then the latch, then the
+foot inboard of it. That does not fit in the monolith's 13 mm strip either, so
+modular mode also raises **`border_w` 5.25 → 7.0**, giving a 14.75 mm strip:
+
+```
+outer depth   100.5 → 104.0 mm      (+3.5)
+foot preset   capped at 1/4" (6.35 mm) — the largest that clears the slot
+```
+
+The widened border is not pure cost: it also widens the ArUco tile shelf and
+adds bending material exactly where §1 says all the bending material is.
+
+The existing `feetFit()` guard needs a modular variant that measures against the
+module rather than the frame; `linkFit()` is that guard for the joint's half.
+
+Two consequences:
+- Every column standing on its own rubber feet is what collapses load case (a) —
+  and over-constraint is a non-issue because rubber bumpers are compliant, so 26
+  feet self-level rather than rock.
+- 26 bumpers is a lot to peel and stick. The pocket should be an **affordance on
+  every module, not an obligation** — stick them on the ends and every third
+  column and the abacus is still flat and still quiet. Note from §4d that this
+  is exactly the configuration that drops out of the fully-closed regime under a
+  hand press, so "feet everywhere" and "as stiff as the slab" are the same
+  choice. Worth saying so in the studio rather than leaving it to be discovered.
+
+---
+
+## 6. What modularity does *not* touch
+
+Worth stating loudly, because it's the main derisking argument:
+
+**The captive-track geometry is untouched.** A bead channel never crosses a seam.
+Each module owns its complete channel with full-thickness walls on both sides, so
+the spool profile, the waist capture, the `clearance` spine, and the constant-
+clearance proof in `master-model-spec.md` §5 all carry over verbatim. Capture is
+intra-module.
+
+This is also why the seam goes down the **middle** of the web rather than along a
+channel wall. The alternative — each module owning one full web and borrowing its
+neighbour's — keeps the 13 mm pitch and needs no web bump, but a lone module
+would have an open-sided channel and its beads would fall out. That kills both
+"a column is a complete product" and safe shipping, and it makes bead retention
+depend on assembly tolerance. Not worth 26 mm of width.
+
+---
+
+## 7. Architecture
+
+The interface, not the parts, is the product. Name it **AbacusLink** and version
+it, because a secondhand market for specialty columns is a compatibility promise.
+
+### The interface contract
+
+Frozen by the interface (a specialty column may not vary these):
+- column pitch, frame height, outer depth
+- the Y layout — shelf, earth channel span, bar position, heaven channel span
+- the chevron profile, the latch geometry, the foot pocket positions
+- the top-face plane
+
+Free (this is where a specialty column lives):
+- everything inside the channel: bead count within the envelope, bead colours,
+  bead shape, markings, a decimal-point column, a blank spacer, a counting frame,
+  a column that isn't an abacus column at all
+
+**Open question, and it's the big one:** the Y layout is derived from the bead
+stack (`s_fd` falls out of `earth`, `throw`, `bar`). Freezing it means a 5-earth
+column or a 2-heaven suanpan column can never be link-compatible unless the
+envelope is generous from day one. See §8.
+
+### Code changes
+
+Additive throughout. The monolith stays the default and stays byte-stable.
+
+- **`Params`** gains `link_mode: 'mono' | 'modular'` and `web_modular: 4.5`.
+  `derived()` and the scad both take `web_eff = link_mode == 'modular' ?
+  max(web, web_modular) : web`. One knob, mirrored the way `feet_*` already is.
+- **New part passes.** `only="column"` with `-Dcolumn_index=i`, plus
+  `only="end_left"` / `only="end_right"`. These slot straight into the existing
+  `ExportPass` / `INSPECT_PARTS` vocabulary and are pinned by
+  `export-defines.test.ts` like every other pass.
+- **`abacus-link.ts`** — the derived chain for the joint plus `linkFit()`, the
+  mirror of the scad's asserts, exactly as `feetEffective()` / `feetFit()` mirror
+  the foot asserts today. This is what lets the inspector refuse a bad
+  combination *before* an export and name the knob that fixes it.
+- **`abacus-3mf-assembly.ts` — the one genuinely disruptive change.** That module
+  exists to weld everything into *one* object so OrcaSlicer's auto-arrange can't
+  scatter the captive beads. Modular needs **N objects, each internally welded**
+  (a module plus its own beads plus its own markers), which puts arrange back on
+  the table for object *placement*. The saving grace: 13 modules at 15 × 101 mm
+  tile to 195 × 101 mm, so a full abacus still fits one 256 mm plate. The
+  existing project-file trick (`Metadata/project_settings.config` ⇒
+  `need_arrange=0`) still applies; the transform now has to be computed per
+  object instead of once.
+- **`abacus-plan.ts`** is unaffected in v1 and gets *less* load-bearing over
+  time: per-module colour makes AMS quantization optional rather than required.
+- **`intentOf` / the paper lane** are entirely unaffected. Column count is column
+  count.
+- **Snapshot schema.** `link_mode` is one additive key; the existing parser drops
+  unknowns, so old designs load as `mono`. **Per-column identity is not needed
+  for v1** — a modular abacus where every module is identical except its colour
+  needs no schema change at all. Swappable *specialty* columns eventually want
+  `AbacusDesign.columns: ColumnSpec[]` instead of a scalar `cols`, and that is a
+  real migration. Deliberately deferred.
+
+---
+
+## 8. Decisions I need from you
+
+1. **Size classes vs. continuous scale — the consequential one.** A secondhand
+   market needs a *frozen* interface, and `scale_factor` is a continuum. My
+   recommendation: modular mode offers a small number of named, frozen classes
+   (say `LINK-15` at S = 1.0 and `LINK-22` at S ≈ 1.5) and refuses arbitrary
+   scales; monolith keeps the continuous slider. Alternative is that every abacus
+   is its own island, which forfeits most of the point.
+2. **The size bump** (§5). Accept 220.0 × 104.0 mm for 13 columns, or trade some
+   of it back by accepting a floppier channel wall / a smaller foot?
+3. **Swapping a middle column requires sliding columns off one end.** I think
+   that is fine and even good — place value grows *leftward*, so the common
+   operation ("add a place value") only ever touches the left end cap. A
+   lift-straight-out design is possible but gives up the chevron, and with it the
+   Z registration that guarantees marker coplanarity. Confirm?
+4. **Bead-envelope generosity** (§7). Freeze the Y layout at today's 4-earth /
+   1-heaven soroban, or pad the envelope now so a 5-earth or 2-heaven suanpan
+   column can be link-compatible later? Padding costs depth on every abacus ever
+   printed; not padding closes the door permanently.
+5. **Feet**: pocket on every module (my recommendation — affordance, not
+   obligation), or only on the end caps plus every Nth column?
+
+---
+
+## 9. Validation, in order
+
+Nothing here should be believed before the coupon prints. There is no headless
+OpenSCAD in this repo, so **none of the geometry is CI-verifiable** — the `.scad`
+has not been through an evaluator even once. What *is* verified is the arithmetic
+in `abacus-link.ts` (21 tests), including both of the joint's silent failure
+modes: relief that lets the flats bottom out before the chevron seats, and a foot
+pocket overlapping the latch slot. Both of those render, slice, print and click
+together while being wrong, which is why they are pinned in CI rather than left
+to the scad's `assert()`.
+
+0. **Render it.** `part="coupon"` through the studio's worker or desktop
+   OpenSCAD, and confirm every `assert` passes and the mesh is manifold. This
+   step has not been done.
+1. **Coupon** (`abacus-link.scad`, `part="coupon"`) — two half-modules carrying
+   one full interface. Print, then measure: seam gap (target **0.00 mm** at the
+   chevron flanks, ~0.12 mm at the relieved flats — the whole point of the cam),
+   Z step across the seam (target < 0.05 mm), insertion force (predicted ~15 N
+   peak), release force, and retention force to failure. Sweep `link_ramp` over
+   8° / 12° / 16° and `link_fit` over three values on one plate — all three ramp
+   rungs are legal geometries, so the sweep is a define change and nothing else.
+2. **Cycle life** — 100 insert/release cycles on one coupon, re-measure seam gap.
+   The flexure root is the fatigue site.
+3. **Creep** — leave a coupon clamped for a week at room temperature and
+   re-measure. The prediction in §4b is that the seam gap stays 0.00 because the
+   flexure takes up the relaxation. If it doesn't, the material choice changes
+   (PETG / PLA+) before the design does.
+4. **Five-column stack + two end caps** — cantilever droop from one end, twist
+   under a hand couple, and marker coplanarity measured through the *real*
+   `arucoDetection.ts` pipeline against a monolith of the same column count. That
+   comparison is the acceptance test.
+5. Only then integrate into `abacus.scad`.

--- a/apps/web/public/scad/abacus-link.scad
+++ b/apps/web/public/scad/abacus-link.scad
@@ -1,0 +1,292 @@
+// abacus-link.scad — the AbacusLink modular-column joint + its test coupon
+// ---------------------------------------------------------------------------
+// SPEC: apps/web/docs/abacus-studio/modular-columns-spec.md
+// TS MIRROR: src/components/create/abacus/abacus-link.ts (the derived chain and
+// the fit guards; this file stays the source of truth for the GEOMETRY, exactly
+// as abacus.scad does for the monolith).
+//
+// STATUS: unrendered. There is no headless OpenSCAD in this repo (see
+// __tests__/export-defines.test.ts), so nothing here has been through the
+// evaluator. Render `part="coupon"` in the studio or on the desktop before
+// spending filament on it.
+//
+// WHY THIS IS A SEPARATE FILE. abacus.scad's captive-track geometry is the
+// hardest-won thing in the model, and a seam never crosses a bead channel — so
+// the joint can be designed, printed and measured entirely on its own. This
+// file is that experiment. Once the coupon passes §9 of the spec, these modules
+// get `include`d by abacus.scad rather than copied into it.
+//
+// THE ORIENTATION CONSTRAINT that shapes every decision below: the beads are
+// captive and print in place, so the build orientation is FLAT (frame bottom on
+// the bed) and is not negotiable. Therefore:
+//   - anything prismatic in Z is free            (vertical walls print perfectly)
+//   - anything within 45° of vertical is free    (self-supporting)
+//   - anything else needs support, and support inside a snap fit is not a thing
+// The chevron obeys the second rule; the latch obeys the first. Neither needs a
+// single support interface.
+//
+// FRAME. The seam plane is x = 0. Module A is at x < 0 and presents the MALE
+// face (chevron ridge + latch tongue, both reaching into +x). Module B starts at
+// x = link_relief and presents the FEMALE face (chevron groove + latch slot).
+// Every module is male on its right and female on its left, so they chain and
+// the stack is loaded from one end. y runs from the outer wall at y = 0 inward;
+// z is the slab height.
+//
+// ONE TONGUE PER STATION, NOT TWO. Doubling the tongues would double the clamp,
+// but the release poke has to reach a tongue from the outer wall, and the second
+// tongue's shoulder is exactly the material the second bore would have to drill
+// through. So a seam gets two tongues by having two STATIONS — one at the front
+// strip released from the front wall, one at the back strip released from the
+// back wall. That is also what makes release two-handed, and two-handed is what
+// makes it impossible by accident.
+
+/* ===== the interface — FROZEN once a size class ships ===================== */
+link_h        = 8;     // seam height = frame_h · S
+link_pitch    = 15;    // modular col_pitch: bead 10 + 2·clearance + web 4.5
+link_station  = 14.75; // Y depth of the station this coupon models (front strip)
+                       // = border_w 7.0 + shelf 7.75. The monolith's 5.25 border
+                       // gives a 13.0 strip, and 13.0 holds a latch OR a foot,
+                       // not both — the foot-vs-slot assert below is what found
+                       // that. Modular mode buys the extra 1.75 by widening the
+                       // border, at +3.5 mm on the abacus's overall depth.
+
+/* ---- chevron: Z registration and Z shear --------------------------------- */
+// Two teeth across the height. The flank angle off vertical is
+// atan(link_tooth_d / (link_h/link_teeth/2)) = 38.7° at these values — inside
+// the 45° self-support limit with 6.3° to spare, in BOTH the ridge and the
+// groove. Push link_tooth_d past link_h/(2·link_teeth) and the groove roof
+// becomes an unprintable overhang; that is what the first assert is for.
+link_teeth    = 2;
+link_tooth_d  = 1.6;   // ridge protrusion into +x
+link_back     = 0.6;   // profile backing, buried in A — keeps the polygon simple
+link_fit      = 0.10;  // per-face groove clearance (what lets it go together)
+link_relief   = 0.25;  // flat-face standoff: the chevron flanks are the ONLY
+                       // contact, so nothing else can hold them off their seat
+
+/* ---- cam latch: X preload, take-up, retention ---------------------------- */
+// A cantilever along X springing in Y, prismatic in Z over the full height —
+// support-free by construction, and 8 mm tall, so it is stiff about the axis
+// that matters and compliant about the one it needs to be.
+//
+// The barb's proximal face is a ramp at link_ramp off the Y axis. That single
+// angle does three jobs: it converts the spring's Y force into X clamp at
+// 1/tan(ramp), it drives the seam shut so the ASSEMBLED clearance is zero
+// whatever the manufactured clearance was, and — being below the PLA-on-PLA
+// friction angle (~16.7°) — it self-locks, so load cannot back it out.
+link_ramp     = 8;     // cam/retain ramp, degrees off the Y axis. SELF-LOCKING
+                       // REQUIRES < ~16.7. Coupon sweep: 8 / 12 / 16.
+link_lead     = 40;    // insertion lead-in, degrees off the X axis (shallow, so
+                       // pushing two modules together is a kid-force operation)
+link_beam_t   = 1.8;   // tongue thickness in Y
+link_beam_l   = 12;    // tongue length in X — the stress lever. Shortening this
+                       // raises clamp force as 1/L³ but beam stress as 1/L²;
+                       // 12 mm keeps peak fibre stress ≈ 30 MPa, under PLA yield.
+link_beam_x0  = -5;    // tongue root, inside A
+link_beam_y0  = 2.6;   // tongue's near face, measured from the outer wall. The
+                       // barb reaches 0.9 nearer still, so this sets the outer
+                       // wall's remaining thickness (1.55 mm) — the wall the
+                       // release bore goes through.
+link_bump     = 1.1;   // barb height = the cam travel = the tolerance the joint
+                       // can swallow (take-up = link_bump · tan(link_ramp)).
+                       // NOTE the preload a seated seam holds comes from the
+                       // travel REMAINING when the chevron bottoms — nominally
+                       // half of this — not from the full height. The full
+                       // height is the insertion peak. See linkMechanics().
+link_slot     = 1.4;   // spring room on the tongue's far side. MUST exceed
+                       // link_bump or the barb cannot deflect past the throat.
+link_release  = 2.6;   // release-poke bore through the outer wall
+
+/* ---- per-module stick-on foot -------------------------------------------- */
+// Affordance, not obligation (spec §5): every module gets the pocket, you stick
+// feet on as many as you want.
+//
+// The foot and the latch slot compete for the same strip, and the slot wins on
+// X — it runs from the seam out to x = 8.2 of a 15 mm pitch, which leaves less
+// clear width than even the smallest bumper needs. So they are separated in Y
+// instead: latch inboard-of-the-wall, foot inboard of the latch. That is what
+// sets link_station, and it caps the preset at 1/4" — the largest BUMPER_PRESETS
+// entry that fits behind the slot in a widened strip.
+link_foot     = true;
+link_foot_w   = 6.35;  // 1/4"
+link_foot_d   = 1.2;
+link_foot_x   = 7.5;   // module-local — centred, since Y is what separates it
+link_foot_y   = 10.0;
+
+part = "coupon";       // coupon | male | female | assembled | ridge
+$fn  = 48;
+
+/* ===== derived ============================================================ */
+link_th       = link_h / link_teeth;                  // one tooth's height
+link_flank    = atan(link_tooth_d / (link_th / 2));   // chevron flank, off VERTICAL
+link_beam_x1  = link_beam_x0 + link_beam_l;           // tongue tip
+link_barb_x   = link_beam_x1 - 3.4;                   // where the barb bears
+link_cam_run  = link_bump * tan(link_ramp);           // cam face's x-run
+link_lead_run = link_bump / tan(link_lead);           // lead-in face's x-run
+link_takeup   = link_cam_run;                         // X drawn per full travel
+link_slot_end = link_beam_x1 + 1.2;                   // slot's far wall
+link_bore_x   = link_beam_x1 - 0.5;                   // bore lands PAST the barb
+// The two footprints that have to stay out of each other's way, as bounding
+// boxes in the module's own frame: [x0, y0, x1, y1].
+link_slot_bb  = [link_relief - 0.1,       link_beam_y0 - link_bump - 0.15,
+                 link_slot_end,           link_beam_y0 + link_beam_t + link_slot];
+link_foot_bb  = [link_foot_x - link_foot_w / 2, link_foot_y - link_foot_w / 2,
+                 link_foot_x + link_foot_w / 2, link_foot_y + link_foot_w / 2];
+
+/* ===== coherence floors =================================================== */
+assert(link_tooth_d <= link_th / 2 + 0.001,
+       "chevron flank steeper than 45° — the groove roof needs support. Lower link_tooth_d or raise link_teeth.");
+assert(link_ramp > 0 && link_ramp < 16.7,
+       "cam ramp outside the self-locking band (0 < ramp < atan(mu_PLA) ~ 16.7°)");
+// Closing a link_fit normal gap on a flank inclined link_flank off vertical
+// costs link_fit / cos(link_flank) of X travel. The flats have to stay clear of
+// each other over at least that much, or they bottom out first and the chevron
+// never seats — which loses the Z registration the markers depend on, silently.
+assert(link_relief > link_fit / cos(link_flank) + 0.05,
+       "flat relief too small — the seam faces would bottom out before the chevron flanks seat");
+assert(link_takeup >= 0.12,
+       "cam take-up under 0.12 mm cannot swallow a normal print's spread — raise link_bump or link_ramp");
+assert(link_slot > link_bump + 0.2,
+       "slot narrower than the barb's travel — the tongue would bind on insertion");
+// The bore has to open into the slot BEYOND the shoulder. Drill it at or before
+// the barb and it removes the very material the barb bears on — which is a
+// silent failure: the part renders, prints, clicks, and holds nothing.
+assert(link_bore_x - link_release / 2 > link_barb_x + link_lead_run,
+       "release bore would eat the latch shoulder — move link_bore_x toward the tongue tip");
+assert(link_beam_y0 - link_bump > 1.2,
+       "outer wall left in front of the barb is thinner than a printable wall — raise link_beam_y0");
+assert(link_slot_bb[3] < link_station,
+       "latch slot runs past the station into the bead channel — raise link_station or shrink the tongue");
+// Foot vs. latch. These two want the same strip, and the slot wins on X (it
+// spans the seam out to link_slot_end, leaving less clear width than any bumper
+// needs), so the only way past each other is Y. Stated as a real box-disjoint
+// test rather than a one-axis check, because a one-axis check is what would let
+// a future pitch/preset change quietly reintroduce the overlap.
+link_bb_clear = 0.8;
+assert(link_foot_bb[1] > link_slot_bb[3] + link_bb_clear ||
+       link_foot_bb[3] < link_slot_bb[1] - link_bb_clear ||
+       link_foot_bb[0] > link_slot_bb[2] + link_bb_clear ||
+       link_foot_bb[2] < link_slot_bb[0] - link_bb_clear,
+       "foot pocket overlaps the latch slot — move link_foot_y past the slot, shrink link_foot_w, or widen the station");
+assert(link_foot_bb[0] > link_relief + 0.8 && link_foot_bb[2] < link_relief + link_pitch - 0.8 &&
+       link_foot_bb[1] > 0.8 && link_foot_bb[3] < link_station - 0.8,
+       "foot pocket runs off the module's solid strip — smaller link_foot_w, or a bigger pitch/station");
+
+/* ===== chevron ============================================================ */
+// XZ profile of the ridge, sitting on the seam plane: flat back buried in A,
+// teeth reaching into +x. `each` is deliberately avoided so this parses on
+// older evaluators.
+function link_ridge_pts() = concat(
+  [[-link_back, 0], [0, 0]],
+  [for (i = [0 : 2 * link_teeth - 1]) let (k = floor(i / 2))
+     i % 2 == 0 ? [link_tooth_d, (k + 0.5) * link_th] : [0, (k + 1) * link_th]],
+  [[-link_back, link_h]]);
+
+// Cross-section in X-Z, extruded along Y — the same helper shape as
+// abacus.scad's prism_xz, so the two files stay idiomatically identical.
+module link_prism_xz(pts, y0, y1, grow = 0)
+  translate([0, (y0 + y1) / 2, 0])
+    rotate([90, 0, 0])
+      linear_extrude(height = y1 - y0, center = true)
+        offset(r = grow) polygon(pts);
+
+module link_ridge(y0, y1)  link_prism_xz(link_ridge_pts(), y0, y1);
+// The groove is the ridge grown by link_fit on every face — so the ridge floats
+// free until the cam pulls it in and the FLANKS bear, which is what centres the
+// two modules in Z and makes the top faces flush by construction rather than by
+// tolerance. Overshot in Y so the cut breaks cleanly out of both station ends.
+module link_groove(y0, y1) link_prism_xz(link_ridge_pts(), y0 - 0.1, y1 + 0.1, link_fit);
+
+/* ===== cam latch ========================================================== */
+// Everything here is a plan-view (XY) profile extruded through the full height:
+// no overhang exists anywhere in the latch, at any angle.
+//
+// The barb protrudes in −y and the slot's shoulder is the B material at −y, so
+// disengaging pushes the tongue +y — i.e. INWARD from the outer wall at y = 0,
+// which is the one direction a poke can reach an interior column from.
+module link_tongue_2d() {
+  y = link_beam_y0;
+  union() {
+    translate([link_beam_x0, y]) square([link_beam_l, link_beam_t]);
+    // barb: cam face on the −x side (short and steep — that IS the mechanical
+    // advantage), insertion lead-in on the +x side (long and shallow). As the
+    // barb travels −y the face's x grows, so the spring draws A into B.
+    polygon([[link_barb_x - link_cam_run,  y],
+             [link_barb_x,                 y - link_bump],
+             [link_barb_x + link_lead_run, y]]);
+  }
+}
+
+// The slot: a throat only as wide as the bare tongue, so the barb must deflect
+// to pass it, then an opening past the shoulder where the barb springs home.
+// The shoulder face is cut on the same ramp as the barb's, so they bear flat.
+module link_slot_2d() {
+  y = link_beam_y0;
+  union() {
+    translate([link_relief - 0.1, y - 0.05])
+      square([link_barb_x - link_relief + 0.1, link_beam_t + link_slot]);
+    polygon([[link_barb_x - link_cam_run, y - 0.05],
+             [link_barb_x,                y - link_bump - 0.15],
+             [link_slot_end,              y - link_bump - 0.15],
+             [link_slot_end,              y + link_beam_t + link_slot],
+             [link_barb_x - link_cam_run, y + link_beam_t + link_slot]]);
+  }
+}
+
+module link_tongue() linear_extrude(link_h) link_tongue_2d();
+module link_slot()   linear_extrude(link_h) link_slot_2d();
+
+// Release bore: from the outer wall at y = 0, in +y, onto the tongue's TIP —
+// past the barb, so it opens into slot void instead of into the shoulder. Poke
+// with a pencil, a paperclip, or the AbacusLink key, and the tongue lifts off
+// its shoulder. One bore per station; a real module is released by squeezing
+// the front and back bores together.
+module link_release_bore()
+  translate([link_bore_x, -0.1, link_h / 2])
+    rotate([-90, 0, 0])
+      cylinder(h = link_beam_y0 + 0.5, d = link_release);
+
+/* ===== foot pocket ======================================================== */
+// Straight-walled, not the monolith's dovetail: this one is only ever a seat for
+// an adhesive bumper, and a module has no room to spare around it.
+module link_foot_pocket(x)
+  translate([x, link_foot_y, -0.01])
+    cylinder(h = link_foot_d + 0.01, d = link_foot_w);
+
+/* ===== the two coupon halves ============================================== */
+// Each is a plain block of one column pitch carrying one real interface, so what
+// the coupon measures is what the abacus gets. A is male on its right face, B is
+// female on its left — the same handedness every module has. Module-local x is
+// measured from each block's own female (left) face.
+module link_male_half() {
+  difference() {
+    union() {
+      translate([-link_pitch, 0, 0]) cube([link_pitch, link_station, link_h]);
+      link_ridge(0, link_station);
+      link_tongue();
+    }
+    if (link_foot) link_foot_pocket(-link_pitch + link_foot_x);
+  }
+}
+
+module link_female_half() {
+  difference() {
+    translate([link_relief, 0, 0]) cube([link_pitch, link_station, link_h]);
+    link_groove(0, link_station);
+    link_slot();
+    link_release_bore();
+    if (link_foot) link_foot_pocket(link_relief + link_foot_x);
+  }
+}
+
+/* ===== dispatch =========================================================== */
+if (part == "male")           link_male_half();
+else if (part == "female")    link_female_half();
+else if (part == "ridge")     link_ridge(0, link_station);
+else if (part == "assembled") {                         // preview only — the two
+  link_male_half();                                     // halves in their seated
+  link_female_half();                                   // pose, relief gap visible
+}
+else {                                                  // "coupon": print pose —
+  link_male_half();                                     // both halves flat on the
+  translate([link_pitch + 6, 0, 0]) link_female_half(); // bed, clear of each other
+}

--- a/apps/web/public/scad/abacus-link.scad
+++ b/apps/web/public/scad/abacus-link.scad
@@ -1,20 +1,17 @@
-// abacus-link.scad — the AbacusLink modular-column joint + its test coupon
+// abacus-link.scad — the AbacusLink modular-column joint (LIBRARY)
 // ---------------------------------------------------------------------------
 // SPEC: apps/web/docs/abacus-studio/modular-columns-spec.md
 // TS MIRROR: src/components/create/abacus/abacus-link.ts (the derived chain and
 // the fit guards; this file stays the source of truth for the GEOMETRY, exactly
 // as abacus.scad does for the monolith).
 //
-// STATUS: unrendered. There is no headless OpenSCAD in this repo (see
-// __tests__/export-defines.test.ts), so nothing here has been through the
-// evaluator. Render `part="coupon"` in the studio or on the desktop before
-// spending filament on it.
-//
-// WHY THIS IS A SEPARATE FILE. abacus.scad's captive-track geometry is the
-// hardest-won thing in the model, and a seam never crosses a bead channel — so
-// the joint can be designed, printed and measured entirely on its own. This
-// file is that experiment. Once the coupon passes §9 of the spec, these modules
-// get `include`d by abacus.scad rather than copied into it.
+// THIS FILE EMITS NOTHING ON ITS OWN. It is `include`d by abacus.scad, and
+// `include` inlines top-level statements — so a top-level `part=` dispatch here
+// would render a coupon into every abacus, and top-level `assert()`s would fire
+// on designs that never asked for a joint. Everything is therefore a module or a
+// function, every module takes its dimensions as PARAMETERS rather than reading
+// the includer's globals, and the checks live in `link_assert()` for the
+// consumer to call under its own `link_mode`.
 //
 // THE ORIENTATION CONSTRAINT that shapes every decision below: the beads are
 // captive and print in place, so the build orientation is FLAT (frame bottom on
@@ -25,161 +22,107 @@
 // The chevron obeys the second rule; the latch obeys the first. Neither needs a
 // single support interface.
 //
-// FRAME. The seam plane is x = 0. Module A is at x < 0 and presents the MALE
-// face (chevron ridge + latch tongue, both reaching into +x). Module B starts at
-// x = link_relief and presents the FEMALE face (chevron groove + latch slot).
-// Every module is male on its right and female on its left, so they chain and
-// the stack is loaded from one end. y runs from the outer wall at y = 0 inward;
-// z is the slab height.
+// FRAME. Every module is MALE on its right face and FEMALE on its left, so they
+// chain and the stack is loaded from one end. The male face carries the chevron
+// ridge and the latch tongue, both reaching into +x past the module's own right
+// wall; the female face carries the groove and the slot, both cut into +x from
+// the module's left wall. All of the modules below are authored in a LOCAL frame
+// whose origin is the joint plane, x = 0, with the ridge reaching into +x — the
+// caller translates them onto whichever wall they belong to.
 //
 // ONE TONGUE PER STATION, NOT TWO. Doubling the tongues would double the clamp,
-// but the release poke has to reach a tongue from the outer wall, and the second
+// but the release poke has to reach a tongue from an outer wall, and the second
 // tongue's shoulder is exactly the material the second bore would have to drill
 // through. So a seam gets two tongues by having two STATIONS — one at the front
 // strip released from the front wall, one at the back strip released from the
 // back wall. That is also what makes release two-handed, and two-handed is what
 // makes it impossible by accident.
 
-/* ===== the interface — FROZEN once a size class ships ===================== */
-link_h        = 8;     // seam height = frame_h · S
-link_pitch    = 15;    // modular col_pitch: bead 10 + 2·clearance + web 4.5
-link_station  = 14.75; // Y depth of the station this coupon models (front strip)
-                       // = border_w 7.0 + shelf 7.75. The monolith's 5.25 border
-                       // gives a 13.0 strip, and 13.0 holds a latch OR a foot,
-                       // not both — the foot-vs-slot assert below is what found
-                       // that. Modular mode buys the extra 1.75 by widening the
-                       // border, at +3.5 mm on the abacus's overall depth.
-
-/* ---- chevron: Z registration and Z shear --------------------------------- */
-// Two teeth across the height. The flank angle off vertical is
-// atan(link_tooth_d / (link_h/link_teeth/2)) = 38.7° at these values — inside
-// the 45° self-support limit with 6.3° to spare, in BOTH the ridge and the
-// groove. Push link_tooth_d past link_h/(2·link_teeth) and the groove roof
-// becomes an unprintable overhang; that is what the first assert is for.
-link_teeth    = 2;
-link_tooth_d  = 1.6;   // ridge protrusion into +x
-link_back     = 0.6;   // profile backing, buried in A — keeps the polygon simple
-link_fit      = 0.10;  // per-face groove clearance (what lets it go together)
-link_relief   = 0.25;  // flat-face standoff: the chevron flanks are the ONLY
-                       // contact, so nothing else can hold them off their seat
-
-/* ---- cam latch: X preload, take-up, retention ---------------------------- */
-// A cantilever along X springing in Y, prismatic in Z over the full height —
-// support-free by construction, and 8 mm tall, so it is stiff about the axis
-// that matters and compliant about the one it needs to be.
-//
-// The barb's proximal face is a ramp at link_ramp off the Y axis. That single
-// angle does three jobs: it converts the spring's Y force into X clamp at
-// 1/tan(ramp), it drives the seam shut so the ASSEMBLED clearance is zero
-// whatever the manufactured clearance was, and — being below the PLA-on-PLA
-// friction angle (~16.7°) — it self-locks, so load cannot back it out.
-link_ramp     = 8;     // cam/retain ramp, degrees off the Y axis. SELF-LOCKING
-                       // REQUIRES < ~16.7. Coupon sweep: 8 / 12 / 16.
-link_lead     = 40;    // insertion lead-in, degrees off the X axis (shallow, so
+/* ===== interface constants ================================================
+   These are the joint's own proportions and are NOT scaled by the abacus's
+   scale_factor: a latch tongue is a spring and a bumper is real hardware, so
+   both live in absolute millimetres, exactly like `clearance` and the feet in
+   abacus.scad. What DOES follow the design is the joint's envelope — height,
+   pitch, station depth — which every module below takes as a parameter. */
+link_teeth     = 2;    // chevron teeth across the seam height
+link_tooth_d   = 1.6;  // ridge protrusion into +x
+link_back      = 0.6;  // profile backing, buried in the male module
+link_lead      = 40;   // insertion lead-in, degrees off the X axis (shallow, so
                        // pushing two modules together is a kid-force operation)
-link_beam_t   = 1.8;   // tongue thickness in Y
-link_beam_l   = 12;    // tongue length in X — the stress lever. Shortening this
+link_beam_t    = 1.8;  // tongue thickness in Y
+link_beam_l    = 12;   // tongue length in X — the stress lever. Shortening this
                        // raises clamp force as 1/L³ but beam stress as 1/L²;
-                       // 12 mm keeps peak fibre stress ≈ 30 MPa, under PLA yield.
-link_beam_x0  = -5;    // tongue root, inside A
-link_beam_y0  = 2.6;   // tongue's near face, measured from the outer wall. The
-                       // barb reaches 0.9 nearer still, so this sets the outer
-                       // wall's remaining thickness (1.55 mm) — the wall the
-                       // release bore goes through.
-link_bump     = 1.1;   // barb height = the cam travel = the tolerance the joint
-                       // can swallow (take-up = link_bump · tan(link_ramp)).
-                       // NOTE the preload a seated seam holds comes from the
-                       // travel REMAINING when the chevron bottoms — nominally
-                       // half of this — not from the full height. The full
-                       // height is the insertion peak. See linkMechanics().
-link_slot     = 1.4;   // spring room on the tongue's far side. MUST exceed
-                       // link_bump or the barb cannot deflect past the throat.
-link_release  = 2.6;   // release-poke bore through the outer wall
+                       // 12 mm keeps the insertion-peak fibre stress ≈ 41 MPa,
+                       // under PLA's ~55 MPa yield.
+link_beam_x0   = -5;   // tongue root, inside the male module
+link_beam_y0   = 2.6;  // tongue's near face, from the station's outer edge. The
+                       // barb reaches link_bump nearer still, so this sets the
+                       // outer wall's remaining thickness — the wall the release
+                       // bore passes through.
+link_release_d = 2.6;  // release-poke bore
+link_barb_back = 3.4;  // barb's setback from the tongue tip
+link_slot_over = 1.2;  // slot's reach past the tongue tip
 
-/* ---- per-module stick-on foot -------------------------------------------- */
-// Affordance, not obligation (spec §5): every module gets the pocket, you stick
-// feet on as many as you want.
-//
-// The foot and the latch slot compete for the same strip, and the slot wins on
-// X — it runs from the seam out to x = 8.2 of a 15 mm pitch, which leaves less
-// clear width than even the smallest bumper needs. So they are separated in Y
-// instead: latch inboard-of-the-wall, foot inboard of the latch. That is what
-// sets link_station, and it caps the preset at 1/4" — the largest BUMPER_PRESETS
-// entry that fits behind the slot in a widened strip.
-link_foot     = true;
-link_foot_w   = 6.35;  // 1/4"
-link_foot_d   = 1.2;
-link_foot_x   = 7.5;   // module-local — centred, since Y is what separates it
-link_foot_y   = 10.0;
+/* the module-local X of the far wall of a latch slot, and of the release bore.
+   Hoisted to functions because the consumer needs both to keep a foot pocket
+   clear of the slot, and a second copy of either would be a second truth. */
+function link_beam_x1()  = link_beam_x0 + link_beam_l;
+function link_barb_x()   = link_beam_x1() - link_barb_back;
+function link_slot_end() = link_beam_x1() + link_slot_over;
+function link_bore_x()   = link_beam_x1() - 0.5;
+/* Chevron flank angle off VERTICAL. 45° is where the groove's roof stops being
+   printable, so this is the number the first assert guards. */
+function link_flank(h)   = atan(link_tooth_d / (h / link_teeth / 2));
+/* X travel that closes a `fit` normal gap on the flank — what the flat relief
+   has to exceed, or the flats bottom out before the chevron seats. */
+function link_seat_travel(h, fit) = fit / cos(link_flank(h));
+/* X the cam draws per full barb travel. */
+function link_takeup(ramp, bump)  = bump * tan(ramp);
 
-part = "coupon";       // coupon | male | female | assembled | ridge
-$fn  = 48;
+/* ===== the checks =========================================================
+   A module rather than top-level asserts, so including this file is free and
+   only a consumer that actually builds a joint pays for the guards. Mirrored
+   one-for-one, in this order, by linkFit() in abacus-link.ts — which is the copy
+   that runs in CI, since no headless OpenSCAD exists in this repo. */
+module link_assert(h, pitch, station, ramp, fit, relief, bump, slot) {
+  assert(link_tooth_d <= h / link_teeth / 2 + 0.001,
+         "chevron flank steeper than 45° — the groove roof needs support. Lower link_tooth_d or raise link_teeth.");
+  assert(ramp > 0 && ramp < 16.7,
+         "cam ramp outside the self-locking band (0 < ramp < atan(mu_PLA) ~ 16.7°)");
+  // Closing a `fit` normal gap on a flank inclined link_flank off vertical costs
+  // fit/cos(flank) of X travel. The flats have to stay clear over at least that
+  // much or they bottom out first and the chevron never seats — which loses the
+  // Z registration the ArUco markers depend on, silently.
+  assert(relief > link_seat_travel(h, fit) + 0.05,
+         "flat relief too small — the seam faces would bottom out before the chevron flanks seat");
+  assert(link_takeup(ramp, bump) >= 0.12,
+         "cam take-up under 0.12 mm cannot swallow a normal print's spread — raise link_bump or link_ramp");
+  assert(slot > bump + 0.2,
+         "slot narrower than the barb's travel — the tongue would bind on insertion");
+  assert(link_beam_y0 - bump > 1.2,
+         "outer wall left in front of the barb is thinner than a printable wall");
+  // The bore has to open into the slot BEYOND the shoulder. Drill it at or
+  // before the barb and it removes the very material the barb bears on — which
+  // is a silent failure: the part renders, prints, clicks, and holds nothing.
+  assert(link_bore_x() - link_release_d / 2 > link_barb_x() + bump / tan(link_lead),
+         "release bore would eat the latch shoulder — move link_bore_x toward the tongue tip");
+  assert(link_beam_y0 + link_beam_t + slot < station,
+         "latch slot runs past the station into the bead channel — widen border_w or shrink the tongue");
+  assert(link_slot_end() + 1.0 < pitch,
+         "latch slot runs past the module's far wall — raise the modular web/pitch");
+}
 
-/* ===== derived ============================================================ */
-link_th       = link_h / link_teeth;                  // one tooth's height
-link_flank    = atan(link_tooth_d / (link_th / 2));   // chevron flank, off VERTICAL
-link_beam_x1  = link_beam_x0 + link_beam_l;           // tongue tip
-link_barb_x   = link_beam_x1 - 3.4;                   // where the barb bears
-link_cam_run  = link_bump * tan(link_ramp);           // cam face's x-run
-link_lead_run = link_bump / tan(link_lead);           // lead-in face's x-run
-link_takeup   = link_cam_run;                         // X drawn per full travel
-link_slot_end = link_beam_x1 + 1.2;                   // slot's far wall
-link_bore_x   = link_beam_x1 - 0.5;                   // bore lands PAST the barb
-// The two footprints that have to stay out of each other's way, as bounding
-// boxes in the module's own frame: [x0, y0, x1, y1].
-link_slot_bb  = [link_relief - 0.1,       link_beam_y0 - link_bump - 0.15,
-                 link_slot_end,           link_beam_y0 + link_beam_t + link_slot];
-link_foot_bb  = [link_foot_x - link_foot_w / 2, link_foot_y - link_foot_w / 2,
-                 link_foot_x + link_foot_w / 2, link_foot_y + link_foot_w / 2];
-
-/* ===== coherence floors =================================================== */
-assert(link_tooth_d <= link_th / 2 + 0.001,
-       "chevron flank steeper than 45° — the groove roof needs support. Lower link_tooth_d or raise link_teeth.");
-assert(link_ramp > 0 && link_ramp < 16.7,
-       "cam ramp outside the self-locking band (0 < ramp < atan(mu_PLA) ~ 16.7°)");
-// Closing a link_fit normal gap on a flank inclined link_flank off vertical
-// costs link_fit / cos(link_flank) of X travel. The flats have to stay clear of
-// each other over at least that much, or they bottom out first and the chevron
-// never seats — which loses the Z registration the markers depend on, silently.
-assert(link_relief > link_fit / cos(link_flank) + 0.05,
-       "flat relief too small — the seam faces would bottom out before the chevron flanks seat");
-assert(link_takeup >= 0.12,
-       "cam take-up under 0.12 mm cannot swallow a normal print's spread — raise link_bump or link_ramp");
-assert(link_slot > link_bump + 0.2,
-       "slot narrower than the barb's travel — the tongue would bind on insertion");
-// The bore has to open into the slot BEYOND the shoulder. Drill it at or before
-// the barb and it removes the very material the barb bears on — which is a
-// silent failure: the part renders, prints, clicks, and holds nothing.
-assert(link_bore_x - link_release / 2 > link_barb_x + link_lead_run,
-       "release bore would eat the latch shoulder — move link_bore_x toward the tongue tip");
-assert(link_beam_y0 - link_bump > 1.2,
-       "outer wall left in front of the barb is thinner than a printable wall — raise link_beam_y0");
-assert(link_slot_bb[3] < link_station,
-       "latch slot runs past the station into the bead channel — raise link_station or shrink the tongue");
-// Foot vs. latch. These two want the same strip, and the slot wins on X (it
-// spans the seam out to link_slot_end, leaving less clear width than any bumper
-// needs), so the only way past each other is Y. Stated as a real box-disjoint
-// test rather than a one-axis check, because a one-axis check is what would let
-// a future pitch/preset change quietly reintroduce the overlap.
-link_bb_clear = 0.8;
-assert(link_foot_bb[1] > link_slot_bb[3] + link_bb_clear ||
-       link_foot_bb[3] < link_slot_bb[1] - link_bb_clear ||
-       link_foot_bb[0] > link_slot_bb[2] + link_bb_clear ||
-       link_foot_bb[2] < link_slot_bb[0] - link_bb_clear,
-       "foot pocket overlaps the latch slot — move link_foot_y past the slot, shrink link_foot_w, or widen the station");
-assert(link_foot_bb[0] > link_relief + 0.8 && link_foot_bb[2] < link_relief + link_pitch - 0.8 &&
-       link_foot_bb[1] > 0.8 && link_foot_bb[3] < link_station - 0.8,
-       "foot pocket runs off the module's solid strip — smaller link_foot_w, or a bigger pitch/station");
-
-/* ===== chevron ============================================================ */
-// XZ profile of the ridge, sitting on the seam plane: flat back buried in A,
-// teeth reaching into +x. `each` is deliberately avoided so this parses on
-// older evaluators.
-function link_ridge_pts() = concat(
-  [[-link_back, 0], [0, 0]],
-  [for (i = [0 : 2 * link_teeth - 1]) let (k = floor(i / 2))
-     i % 2 == 0 ? [link_tooth_d, (k + 0.5) * link_th] : [0, (k + 1) * link_th]],
-  [[-link_back, link_h]]);
+/* ===== chevron ============================================================
+   XZ profile of the ridge, sitting on the joint plane: flat back buried in the
+   male module, teeth reaching into +x. `each` is deliberately avoided so this
+   parses on older evaluators. */
+function link_ridge_pts(h) =
+  let (th = h / link_teeth)
+  concat(
+    [[-link_back, 0], [0, 0]],
+    [for (i = [0 : 2 * link_teeth - 1]) let (k = floor(i / 2))
+       i % 2 == 0 ? [link_tooth_d, (k + 0.5) * th] : [0, (k + 1) * th]],
+    [[-link_back, h]]);
 
 // Cross-section in X-Z, extruded along Y — the same helper shape as
 // abacus.scad's prism_xz, so the two files stay idiomatically identical.
@@ -189,104 +132,100 @@ module link_prism_xz(pts, y0, y1, grow = 0)
       linear_extrude(height = y1 - y0, center = true)
         offset(r = grow) polygon(pts);
 
-module link_ridge(y0, y1)  link_prism_xz(link_ridge_pts(), y0, y1);
-// The groove is the ridge grown by link_fit on every face — so the ridge floats
+module link_ridge(h, y0, y1) link_prism_xz(link_ridge_pts(h), y0, y1);
+// The groove is the ridge grown by `fit` on every face — so the ridge floats
 // free until the cam pulls it in and the FLANKS bear, which is what centres the
-// two modules in Z and makes the top faces flush by construction rather than by
-// tolerance. Overshot in Y so the cut breaks cleanly out of both station ends.
-module link_groove(y0, y1) link_prism_xz(link_ridge_pts(), y0 - 0.1, y1 + 0.1, link_fit);
+// two modules in Z and makes their top faces flush by construction rather than
+// by tolerance. Overshot in Y so the cut breaks cleanly out of both station ends.
+module link_groove(h, y0, y1, fit) link_prism_xz(link_ridge_pts(h), y0 - 0.1, y1 + 0.1, fit);
 
-/* ===== cam latch ========================================================== */
-// Everything here is a plan-view (XY) profile extruded through the full height:
-// no overhang exists anywhere in the latch, at any angle.
-//
-// The barb protrudes in −y and the slot's shoulder is the B material at −y, so
-// disengaging pushes the tongue +y — i.e. INWARD from the outer wall at y = 0,
-// which is the one direction a poke can reach an interior column from.
-module link_tongue_2d() {
+/* ===== cam latch ==========================================================
+   Everything here is a plan-view (XY) profile extruded through the full height:
+   no overhang exists anywhere in the latch, at any angle.
+
+   The barb protrudes in −y and the slot's shoulder is the material at −y, so
+   disengaging pushes the tongue +y — i.e. INWARD from the outer wall, which is
+   the one direction a release poke can reach an interior column from. `yEdge` is
+   the station's outer edge; the caller passes the abacus's y=0 or y=outer_d wall
+   and a sign, and the whole latch mirrors with it. */
+module link_tongue_2d(ramp, bump) {
   y = link_beam_y0;
   union() {
     translate([link_beam_x0, y]) square([link_beam_l, link_beam_t]);
     // barb: cam face on the −x side (short and steep — that IS the mechanical
     // advantage), insertion lead-in on the +x side (long and shallow). As the
-    // barb travels −y the face's x grows, so the spring draws A into B.
-    polygon([[link_barb_x - link_cam_run,  y],
-             [link_barb_x,                 y - link_bump],
-             [link_barb_x + link_lead_run, y]]);
+    // barb travels −y the face's x grows, so the spring draws the modules shut.
+    polygon([[link_barb_x() - link_takeup(ramp, bump), y],
+             [link_barb_x(),                          y - bump],
+             [link_barb_x() + bump / tan(link_lead),  y]]);
   }
 }
 
 // The slot: a throat only as wide as the bare tongue, so the barb must deflect
-// to pass it, then an opening past the shoulder where the barb springs home.
-// The shoulder face is cut on the same ramp as the barb's, so they bear flat.
-module link_slot_2d() {
+// to pass it, then an opening past the shoulder where the barb springs home. The
+// shoulder is cut on the same ramp as the barb's, so the two bear flat.
+module link_slot_2d(ramp, bump, slot, relief) {
   y = link_beam_y0;
   union() {
-    translate([link_relief - 0.1, y - 0.05])
-      square([link_barb_x - link_relief + 0.1, link_beam_t + link_slot]);
-    polygon([[link_barb_x - link_cam_run, y - 0.05],
-             [link_barb_x,                y - link_bump - 0.15],
-             [link_slot_end,              y - link_bump - 0.15],
-             [link_slot_end,              y + link_beam_t + link_slot],
-             [link_barb_x - link_cam_run, y + link_beam_t + link_slot]]);
+    translate([relief - 0.1, y - 0.05])
+      square([link_barb_x() - relief + 0.1, link_beam_t + slot]);
+    polygon([[link_barb_x() - link_takeup(ramp, bump), y - 0.05],
+             [link_barb_x(),                          y - bump - 0.15],
+             [link_slot_end(),                        y - bump - 0.15],
+             [link_slot_end(),                        y + link_beam_t + slot],
+             [link_barb_x() - link_takeup(ramp, bump), y + link_beam_t + slot]]);
   }
 }
 
-module link_tongue() linear_extrude(link_h) link_tongue_2d();
-module link_slot()   linear_extrude(link_h) link_slot_2d();
+/* The latch trio, each placed against a station's outer edge. `dir` is +1 when
+   the station's outer wall is at low y (the front strip) and −1 when it is at
+   high y (the back strip); `yEdge` is that wall's y. Mirroring both together is
+   what keeps each station's release bore pointing at its OWN outer wall. */
+// `mirror`, not `scale([1,-1,1])` — the same transform, but the one that says
+// what it means, and the one the evaluator treats as a reflection rather than a
+// degenerate-looking scale.
+module link_at_station(yEdge, dir)
+  translate([0, yEdge, 0])
+    mirror([0, dir < 0 ? 1 : 0, 0])
+      children();
 
-// Release bore: from the outer wall at y = 0, in +y, onto the tongue's TIP —
-// past the barb, so it opens into slot void instead of into the shoulder. Poke
-// with a pencil, a paperclip, or the AbacusLink key, and the tongue lifts off
-// its shoulder. One bore per station; a real module is released by squeezing
-// the front and back bores together.
-module link_release_bore()
-  translate([link_bore_x, -0.1, link_h / 2])
-    rotate([-90, 0, 0])
-      cylinder(h = link_beam_y0 + 0.5, d = link_release);
+module link_tongue(h, yEdge, dir, ramp, bump)
+  link_at_station(yEdge, dir) linear_extrude(h) link_tongue_2d(ramp, bump);
 
-/* ===== foot pocket ======================================================== */
-// Straight-walled, not the monolith's dovetail: this one is only ever a seat for
-// an adhesive bumper, and a module has no room to spare around it.
-module link_foot_pocket(x)
-  translate([x, link_foot_y, -0.01])
-    cylinder(h = link_foot_d + 0.01, d = link_foot_w);
+module link_slot(h, yEdge, dir, ramp, bump, slot, relief)
+  link_at_station(yEdge, dir) linear_extrude(h) link_slot_2d(ramp, bump, slot, relief);
 
-/* ===== the two coupon halves ============================================== */
-// Each is a plain block of one column pitch carrying one real interface, so what
-// the coupon measures is what the abacus gets. A is male on its right face, B is
-// female on its left — the same handedness every module has. Module-local x is
-// measured from each block's own female (left) face.
-module link_male_half() {
-  difference() {
-    union() {
-      translate([-link_pitch, 0, 0]) cube([link_pitch, link_station, link_h]);
-      link_ridge(0, link_station);
-      link_tongue();
+// Release bore: from the outer wall inward, onto the tongue's TIP — past the
+// barb, so it opens into slot void instead of into the shoulder. Poke with a
+// pencil, a paperclip, or the AbacusLink key, and the tongue lifts off its
+// shoulder. One bore per station; a module is released by squeezing the front
+// and back bores together.
+module link_release_bore(h, yEdge, dir, bump)
+  link_at_station(yEdge, dir)
+    translate([link_bore_x(), -0.1, h / 2])
+      rotate([-90, 0, 0])
+        cylinder(h = link_beam_y0 + 0.5, d = link_release_d);
+
+/* ===== the two faces ======================================================
+   Composed so a consumer never has to remember which half goes where: a module
+   UNIONs link_male_face onto its right wall and DIFFERENCEs link_female_face out
+   of its left. `stations` is a list of [yEdge, dir, y0, y1] rows — the front
+   strip, the reckoning bar, the back strip — so the same call covers all three
+   and the bar (which gets a chevron but no latch, having no outer wall to be
+   released from) is expressed by passing dir = 0. */
+module link_male_face(h, stations, ramp, bump) {
+  for (s = stations) {
+    link_ridge(h, s[2], s[3]);
+    if (s[1] != 0) link_tongue(h, s[0], s[1], ramp, bump);
+  }
+}
+
+module link_female_face(h, stations, ramp, bump, slot, relief, fit) {
+  for (s = stations) {
+    link_groove(h, s[2], s[3], fit);
+    if (s[1] != 0) {
+      link_slot(h, s[0], s[1], ramp, bump, slot, relief);
+      link_release_bore(h, s[0], s[1], bump);
     }
-    if (link_foot) link_foot_pocket(-link_pitch + link_foot_x);
   }
-}
-
-module link_female_half() {
-  difference() {
-    translate([link_relief, 0, 0]) cube([link_pitch, link_station, link_h]);
-    link_groove(0, link_station);
-    link_slot();
-    link_release_bore();
-    if (link_foot) link_foot_pocket(link_relief + link_foot_x);
-  }
-}
-
-/* ===== dispatch =========================================================== */
-if (part == "male")           link_male_half();
-else if (part == "female")    link_female_half();
-else if (part == "ridge")     link_ridge(0, link_station);
-else if (part == "assembled") {                         // preview only — the two
-  link_male_half();                                     // halves in their seated
-  link_female_half();                                   // pose, relief gap visible
-}
-else {                                                  // "coupon": print pose —
-  link_male_half();                                     // both halves flat on the
-  translate([link_pitch + 6, 0, 0]) link_female_half(); // bed, clear of each other
 }

--- a/apps/web/public/scad/abacus.scad
+++ b/apps/web/public/scad/abacus.scad
@@ -99,6 +99,41 @@ feet_proud    = 1.6;       // printed: stand-off below the bottom face (ABSOLUTE
                            // ≈8 layers @0.2 = support base + interface + z gap)
 feet_retention = "crossbar"; // printed: crossbar (linked loop) | dovetail (flare only)
 
+/* ===== modular columns — the AbacusLink prototype (see
+   docs/abacus-studio/modular-columns-spec.md) =====
+   "mono" is the shipped one-piece abacus and is BYTE-STABLE: every derivation
+   below reduces to its pre-modular form when link_mode == "mono".
+
+   "modular" does exactly ONE thing in this revision — it raises two dimension
+   floors so the design on screen is the one the joint coupon is cut from. The
+   assembled abacus is still rendered as a single solid; only the `only=`
+   part passes (link_coupon, link_column) emit modular geometry. That is
+   deliberate: analyzeShells() identifies the frame as "the one shell wider than
+   a column pitch", which every column module fails, so making the assembly N
+   solids breaks the viewer's whole recolor pass. That comes after the coupon
+   proves the latch.
+
+   Why the two floors: the seam splits the web between channels down its middle,
+   so each module keeps only half of it, and half of 2.5 is thinner than a
+   printable wall. And the front/back strips have to hold a latch tongue AND a
+   foot pocket, which do not fit in the mono border's 13.0 mm strip. */
+link_mode   = "mono";   // mono | modular
+link_web    = 4.5;      // modular floor on `web` — 2.25 mm of wall per module
+link_border = 7.0;      // modular floor on `border_w` — a 14.75 mm strip
+link_ramp   = 8;        // cam ramp, degrees off the tongue's travel. SELF-LOCKING
+                        // REQUIRES < ~16.7 (atan of PLA-on-PLA friction).
+link_fit    = 0.10;     // per-face chevron groove clearance
+link_relief = 0.25;     // flat-face standoff — the chevron flanks are the ONLY
+                        // contact, so nothing else may hold them off their seat
+link_bump   = 1.1;      // barb height = cam travel = the spread the joint can
+                        // swallow (take-up = link_bump · tan(link_ramp))
+link_slot_w = 1.4;      // spring room on the tongue's far side. MUST exceed
+                        // link_bump or the barb can't deflect past the throat.
+link_foot_w = 6.35;     // 1/4" stick-on bumper — the largest that clears the slot
+link_foot_d = 1.2;
+assert(link_mode == "mono" || link_mode == "modular",
+       "link_mode must be mono | modular");
+
 /* ===== myabacus style (driven by abaci.one AbacusDisplayConfig) ===== */
 color_scheme  = "place-value";  // monochrome | place-value | heaven-earth | alternating
 color_palette = "default";      // default | colorblind | mnemonic | grayscale | nature
@@ -138,6 +173,10 @@ inlay_plugs  = false;  // true → also model the white/black inlay solids (3MF 
                        // engravings (flush plugs would WELD into the frame shell and
                        // vanish — color() is inert on binstl; see SPEC).
 only         = "";     // part passes: "" | "marker_black" | "marker_white" | "text_plugs" | "feet"
+                       // Plus the AbacusLink prototype slices — "link_coupon" |
+                       // "link_column" — which are inspection parts too, but
+                       // print-ready ones: each emits TWO pieces in print pose so
+                       // the seam between them is what you test.
                        // "feet" renders the printed foot solids (pocket fill + stand-off,
                        // crossbar voided) — emitted UNCONDITIONALLY; the TS caller gates.
                        // Plus the INSPECTION slices — "bead" | "bead_capture" | "bead_cap"
@@ -157,11 +196,33 @@ $fn = fn;
    `clearance` and `print_gap` are deliberately excluded so print gaps stay absolute
    as the abacus grows — the mixed-scaling spine. All downstream geometry uses the
    s_* working dims, every one of which now composes from the intent knobs. */
+/* The modular floors. Derived HERE, not up with the knobs, because they read
+   `only`: a link part pass IS modular geometry — asking for the coupon while
+   link_mode still says "mono" would otherwise hand you a coupon cut to a pitch
+   no modular abacus will ever have, which is the sort of fixture that passes its
+   test and teaches you nothing.
+   max() rather than assignment, so a design that already asked for a fatter web
+   or a wider brim keeps it — the floor raises, never lowers. */
+// Written as a predicate over its argument rather than testing `only` inline,
+// because export-defines.test.ts pins the part vocabulary by scanning this file
+// for comparisons against `only`, and requires exactly ONE dispatch branch per
+// name. A second comparison here would read as a duplicate branch — so the
+// chain at the bottom of the file stays the single mention of each.
+function is_link_part(o) = o == "link_coupon" || o == "link_column";
+link_part    = is_link_part(only);
+modular      = link_mode == "modular" || link_part;
+web_eff      = modular ? max(web, link_web) : web;
+border_w_eff = modular ? max(border_w, link_border) : border_w;
+
 S      = scale_factor;
 s_fh   = frame_h * S;
 s_bd   = bead_dia * S;   s_bl  = bead_len * S;
-s_bw   = border_w * S;   s_cr  = corner_r * S;
+s_bw   = border_w_eff * S;   s_cr  = corner_r * S;
 chamf  = min(top_chamfer, s_fh * 0.4);      // effective top-rim chamfer
+
+/* The modular-column joint. A LIBRARY — it emits nothing and only defines
+   modules/functions, so including it costs a mono render exactly nothing. */
+include <abacus-link.scad>
 
 /* effective tile inset: the tile hugs the top-face edge (inset = chamf) and the
    rounded-corner arc TRIMS its white quiet-zone corner — the tile 2D is clipped
@@ -192,7 +253,7 @@ m_y     = s_shelf;
    one bead + throw, resting UP (also 0). The field depth FALLS OUT of the
    stack — there is no way to position beads outside the frame or through the
    bar, because the frame is built around wherever the beads landed. */
-s_cp   = s_bd + 2 * clearance + web * S;    // column pitch (13.0 at defaults)
+s_cp   = s_bd + 2 * clearance + web_eff * S;  // column pitch (13.0 mono, 15.0 modular)
 s_em   = s_shelf + clearance + s_bd / 2;    // field edge → first column center
 s_ep   = s_bl + print_gap;                  // printed inter-bead rest pitch (10)
 s_elo  = s_shelf + clearance + s_bl / 2;    // bottom-most earth center   (12)
@@ -207,7 +268,14 @@ frame_w   = field_w + 2 * s_bw;             // OUTER width  (192.5 at defaults)
 outer_d   = s_fd + 2 * s_bw;                // OUTER depth  (100.5 at defaults)
 
 /* coherence floors — the few things intent knobs could still under-specify */
-assert(web * S >= 1.2,  "web thinner than a printable wall — raise web");
+/* In modular mode the seam halves the web, so the wall that has to survive is
+   half of it — which is what gives modular mode a size floor the monolith
+   does not have. Same shape as the feet_crossbar degrade: the joint is the
+   thing with an absolute minimum, inside a frame that scales. */
+assert(web_eff * S / (modular ? 2 : 1) >= 1.2,
+       modular
+         ? "modular half-web thinner than a printable wall — raise size or link_web"
+         : "web thinner than a printable wall — raise web");
 assert(bar * S >= 2,    "reckoning bar too thin to survive — raise bar");
 assert(throw * S >= 2,  "throw < 2mm: beads can't express set/unset — raise throw");
 /* feet pockets: corner-tucked like the markers. feet_c (pocket center
@@ -728,15 +796,21 @@ module outer_solid() {
   else
     linear_extrude(s_fh) rounded_rect(frame_w, outer_d, s_cr);
 }
-module feet_pocket_at(k) {   // mouth at z=0, seat floor at z=feet_depth_eff (dovetail)
-  translate([FEET_POS[k][0], FEET_POS[k][1], -0.01]) {
+// mouth at z=0, seat floor at z=feet_depth_eff (dovetail). Split from
+// feet_pocket_at so the modular column pass can seat a bumper at its OWN
+// per-module position without a second copy of the pocket profile.
+module feet_pocket_xy(x, y, mouth = undef, seat = undef, depth = undef) {
+  m = is_undef(mouth) ? feet_mouth : mouth;
+  st = is_undef(seat) ? feet_seat : seat;
+  dp = is_undef(depth) ? feet_depth_eff : depth;
+  translate([x, y, -0.01]) {
     if (feet_shape == "circle")
-      cylinder(h = feet_depth_eff + 0.01, d1 = feet_mouth, d2 = feet_seat);
+      cylinder(h = dp + 0.01, d1 = m, d2 = st);
     else
-      linear_extrude(feet_depth_eff + 0.01, scale = feet_seat / feet_mouth)
-        square(feet_mouth, center = true);
+      linear_extrude(dp + 0.01, scale = st / m) square(m, center = true);
   }
 }
+module feet_pocket_at(k) feet_pocket_xy(FEET_POS[k][0], FEET_POS[k][1]);
 /* The retention bar runs ALONG the border strip its foot sits on (FEET_POS
    order: 4 corners, then bottom/top-strip pairs, then left/right-strip pairs)
    so both rooted ends stay in solid strip material — never hanging into a
@@ -774,6 +848,141 @@ module foot_at(k) {
     if (feet_crossbar) xbar_at(k);
   }
 }
+/* ===== modular column parts (AbacusLink prototype) ========================
+   Two `only=` slices, both cut from the CURRENT design's derived dims — so what
+   goes on the plate is a true proxy for the abacus on screen, not a fixture with
+   its own numbers that could drift from it.
+
+   THE THREE STATIONS. A seam plane is the full outer_d deep, but the module is
+   only THICK in three places; everywhere else the seam is two channel walls face
+   to face, far too thin to carry a joint feature. Those three are the front
+   strip, the reckoning bar, and the back strip, and they fall out of the same
+   derivation the channels do rather than being measured off a drawing:
+
+     [outer edge, mirror dir, y0, y1]   dir 0 = chevron but no latch (the bar has
+                                        no outer wall to be released from)  */
+function link_stations() = [
+  [0,       1, 0,                     strip_y],
+  [0,       0, s_bw + s_ehi + s_bl / 2 + clearance,
+               s_bw + s_hlo - s_bl / 2 - clearance],
+  [outer_d, -1, outer_d - strip_y,    outer_d]
+];
+/* Per-module foot seats: one on each end strip, pushed inboard of the latch slot
+   in Y (they cannot clear it in X — the slot eats the seam end of the strip, and
+   what is left over is narrower than the smallest bumper). Measured off the
+   slot's FAR edge, which is link_slot_w past the tongue — not off the barb,
+   which is on the near side and would put the pocket through the slot.
+   linkFit()'s foot-hits-slot guard is the mirror of this arithmetic, and
+   link_assert's station check is what keeps the pair inside the strip. */
+function link_foot_y() =
+  link_beam_y0 + link_beam_t + link_slot_w + 0.8 + link_foot_w / 2;
+// ALWAYS an adhesive seat — straight-walled, mouth == seat — whatever feet_mode
+// says. The monolith's "printed" mode co-prints TPU feet into dovetailed pockets
+// with a crossbar threaded through them; doing that per module is a separate
+// unsolved problem (each foot would need its own TPU body in a per-module 3MF),
+// and the prototype's question is about the joint, not about feet. So a modular
+// column gets a bumper seat, and feet_mode only decides whether it gets one.
+module link_column_feet() {
+  fy = link_foot_y();
+  for (y = [fy, outer_d - fy])
+    feet_pocket_xy(s_cp / 2, y, link_foot_w, link_foot_w, link_foot_d);
+}
+
+/* ONE column module: its own complete channel with a full-thickness wall on both
+   sides, so capture never crosses a seam and the validated spool/track geometry
+   is untouched. Male on the right face, female on the left — every module the
+   same handedness, so they chain. */
+module link_column() {
+  difference() {
+    union() {
+      cube([s_cp, outer_d, s_fh]);
+      translate([s_cp, 0, 0])
+        link_male_face(s_fh, link_stations(), link_ramp, link_bump);
+    }
+    // the column's two channels, at the module's own centre
+    translate([0, s_bw, 0]) {
+      channel(s_cp / 2, s_elo, s_ehi);
+      channel(s_cp / 2, s_hlo, s_hhi);
+    }
+    link_female_face(s_fh, link_stations(), link_ramp, link_bump,
+                     link_slot_w, link_relief, link_fit);
+    // the flat-face relief: the chevron flanks are the only contact, so the rest
+    // of the seam is held clear. Cut from the female face only — one side of the
+    // pair carries the whole standoff.
+    translate([-0.01, -0.1, -0.01]) cube([link_relief + 0.01, outer_d + 0.2, s_fh + 0.02]);
+    if (feet) link_column_feet();
+  }
+}
+
+/* This module's own beads — free shells in its own channels, exactly as the
+   assembly emits them. The point of printing a PAIR is to confirm that halving
+   the web didn't disturb capture, and you cannot see that without the beads. */
+module link_column_beads() translate([0, s_bw, 0]) {
+  // coloured as the ones place (place_value 0), so a module previewed alone
+  // looks like the column it would actually be at the right-hand end.
+  for (j = [0 : earth - 1])
+    color(bead_color(cols - 1, false)) bead(s_cp / 2, earthy(j));
+  color(bead_color(cols - 1, true)) bead(s_cp / 2, s_hy);
+}
+
+/* The joint coupon: the same interface on two plain blocks of one pitch. No
+   channels, no beads — it exists to fail fast on the latch alone, in a quarter
+   of the time a column pair takes. Only the front station, since that is the one
+   with a release bore. */
+function link_coupon_stations() = [[0, 1, 0, strip_y]];
+module link_coupon_male() {
+  union() {
+    cube([s_cp, strip_y, s_fh]);
+    translate([s_cp, 0, 0])
+      link_male_face(s_fh, link_coupon_stations(), link_ramp, link_bump);
+  }
+}
+module link_coupon_female() {
+  difference() {
+    cube([s_cp, strip_y, s_fh]);
+    link_female_face(s_fh, link_coupon_stations(), link_ramp, link_bump,
+                     link_slot_w, link_relief, link_fit);
+    translate([-0.01, -0.1, -0.01]) cube([link_relief + 0.01, strip_y + 0.2, s_fh + 0.02]);
+  }
+}
+
+/* The two plates, in PRINT POSE: two pieces laid out flat and clear of each
+   other, ready to slice as they stand. The gap clears the male face's tongue,
+   which reaches link_beam_l − |link_beam_x0| past its module's right wall.
+
+   The guards run HERE — at the one moment somebody is about to spend filament —
+   rather than at file scope, where they would fire on every mono render too. */
+module link_plate_guard() {
+  link_assert(s_fh, s_cp, strip_y, link_ramp, link_fit, link_relief,
+              link_bump, link_slot_w);
+  // The foot's guards live in this file, not the library: the library is
+  // deliberately foot-agnostic (a specialty column may seat something else
+  // entirely), so where the bumper goes is the CONSUMER's business — and so is
+  // checking it still fits once the latch has taken its half of the strip.
+  assert(!feet || link_foot_y() + link_foot_w / 2 + 0.8 <= strip_y,
+         "per-module foot pocket runs off the end strip — raise link_border or use a smaller bumper");
+  assert(link_foot_w / 2 + 0.8 <= s_cp / 2,
+         "per-module foot wider than the module — smaller link_foot_w, or raise link_web");
+}
+function link_plate_gap() = s_cp + link_beam_l + link_beam_x0 + 5;
+
+module link_coupon_plate() {
+  link_plate_guard();
+  color(frame_color) link_coupon_male();
+  translate([link_plate_gap(), 0, 0]) color(frame_color) link_coupon_female();
+}
+
+// A PAIR, so the seam itself is what you test — and each module carries its own
+// beads, because whether halving the web disturbed capture is the other half of
+// the question and you cannot see it without them.
+module link_column_plate() {
+  link_plate_guard();
+  for (m = [0, 1]) translate([m * link_plate_gap(), 0, 0]) {
+    color(frame_color) link_column();
+    if (show_beads) link_column_beads();
+  }
+}
+
 module frame() {   // two children = implicit union (keeps the no-bar CSG tree
                    // EXACTLY the pre-#23 one — adhesive mode stays byte-stable)
   difference() {
@@ -827,6 +1036,18 @@ else if (only == "bead_exposed")
    on the origin rather than at its column, and one earth channel's travel. */
 else if (only == "channel")      color(frame_color) channel(0, -(s_ehi - s_elo) / 2, (s_ehi - s_elo) / 2);
 else if (only == "frame")        color(frame_color) frame();
+/* ---- the AbacusLink prototype slices, in PRINT POSE -----------------------
+   Both emit two pieces laid out flat and clear of each other, ready to slice as
+   they stand — the parts bench and the studio's download hand these straight to
+   a plate. The gap clears the male face's tongue, which reaches a full
+   link_beam_l − |link_beam_x0| past its module's right wall.
+
+   These render regardless of link_mode: asking for the coupon IS asking for the
+   modular geometry, and refusing unless a mode toggle happened to be on would be
+   a trap. link_assert() runs here, so a bad joint knob fails loudly at the one
+   moment somebody is about to spend filament on it. */
+else if (only == "link_coupon")  link_coupon_plate();
+else if (only == "link_column")  link_column_plate();
 else {
   if (show_frame) {
     color(frame_color) {

--- a/apps/web/src/components/create/abacus/AbacusStudioContext.tsx
+++ b/apps/web/src/components/create/abacus/AbacusStudioContext.tsx
@@ -48,7 +48,12 @@ import {
   type FabricationTarget,
 } from './abacus-fabrication'
 import { selectSourceIdentity } from './abacus-identity-source'
-import { type DisplayConfigInput, type Params, paramsFromDisplayConfig } from './abacus-model'
+import {
+  type DisplayConfigInput,
+  type Params,
+  paramsFromDisplayConfig,
+  type RenderPass,
+} from './abacus-model'
 import { materialize, planToFilamentMap } from './abacus-plan'
 import { DEFAULT_PROFILE_ID, profileById, solve } from './abacus-solver'
 
@@ -63,6 +68,13 @@ const PRINT_CONNECTION_STORAGE_KEY = 'abacus-studio-print-connection'
 export type AbacusExporter = {
   exportStl: () => Promise<ArrayBuffer>
   exportParts: () => Promise<AbacusExportParts>
+  /** One arbitrary `only=` slice. `exportStl` renders the whole abacus and
+   *  `exportParts` renders the fixed set the 3MF needs, so neither can reach an
+   *  inspection part — which is what the AbacusLink prototype's downloads are.
+   *  Kept general rather than adding a per-part method: the part vocabulary is
+   *  already a type (`RenderPass`), and it is pinned against the scad's dispatch
+   *  by export-defines.test.ts. */
+  exportPass: (pass: RenderPass) => Promise<ArrayBuffer>
 }
 
 // The identity slice of the current params, or null when a custom scheme/palette
@@ -345,6 +357,13 @@ function useStudioController(playerId: string | null, designId: string | null) {
         : Promise.reject(new Error('3D exporter not ready')),
     []
   )
+  const requestExportPass = useCallback(
+    (pass: RenderPass): Promise<ArrayBuffer> =>
+      exporterRef.current
+        ? exporterRef.current.exportPass(pass)
+        : Promise.reject(new Error('3D exporter not ready')),
+    []
+  )
 
   // The 3D model previews the REAL print (filament colors) by default; hovering a
   // tile's true-color fleck in the reconcile strip momentarily flips the whole
@@ -441,6 +460,7 @@ function useStudioController(playerId: string | null, designId: string | null) {
     registerExporter,
     requestExportStl,
     requestExportParts,
+    requestExportPass,
     registerRevealIntrinsic,
     setRevealIntrinsic,
     registerHighlightRole,

--- a/apps/web/src/components/create/abacus/AbacusStudioViewer.tsx
+++ b/apps/web/src/components/create/abacus/AbacusStudioViewer.tsx
@@ -752,6 +752,10 @@ export function AbacusStudioViewer() {
         const textPlugs = textStls.map((stl, g) => ({ group: g, stl: stl as ArrayBuffer }))
         return { stl, markerBlack, markerWhite, feet, textPlugs, params: p }
       },
+      // Same params snapshot rule as the other two — the slice has to be cut
+      // from the design that is on screen right now, not from whatever the rail
+      // happened to hold when its button was clicked.
+      exportPass: (pass) => scadRef.current.exportStl(paramsRef.current, pass),
     })
     return () => registerExporter(null)
   }, [registerExporter])

--- a/apps/web/src/components/create/abacus/FabricationRail.tsx
+++ b/apps/web/src/components/create/abacus/FabricationRail.tsx
@@ -16,10 +16,12 @@
 
 import { type CSSProperties, useState } from 'react'
 import { StudioSelect } from '@/components/studio/StudioSelect'
+import { useFeatureFlag } from '@/hooks/useFeatureFlag'
 import { useAbacusStudio } from './AbacusStudioContext'
 import { buildAbacusThreeMf } from './abacus-3mf'
 import { PRINTER_PROFILES } from './abacus-solver'
 import { FilamentPlanPanel } from './FilamentPlanPanel'
+import { MODULAR_COLUMNS_FLAG, ModularColumnsPanel } from './ModularColumnsPanel'
 import { PrintPanel } from './PrintPanel'
 
 const CYAN_GRADIENT = 'linear-gradient(135deg, #06b6d4 0%, #0891b2 100%)'
@@ -76,6 +78,10 @@ export function FabricationRail() {
   } = useAbacusStudio()
 
   const canExport = exporterReady && !exportBlocked
+
+  // Default-off: an unset flag reads as disabled, so the prototype is invisible
+  // until somebody turns it on for themselves.
+  const modularColumns = useFeatureFlag(MODULAR_COLUMNS_FLAG)
 
   // A failed export render (e.g. a marker part pass) now REJECTS instead of
   // hanging — surfaced inline under the button. Silently swallowing it would
@@ -315,6 +321,14 @@ export function FabricationRail() {
           dataAction="select-print-connection"
         />
       )}
+
+      {/* The AbacusLink prototype. Flag-gated and default-off: the toggle moves
+          real geometry (a wider web and border), so it stays invisible until
+          somebody deliberately turns it on at /admin/feature-flags. It sits
+          BELOW the ordinary exports and above the print service — it is a
+          fabrication strategy, but an experimental one, and the shipped path
+          should stay the one you meet first. */}
+      {modularColumns.enabled ? <ModularColumnsPanel /> : null}
 
       {/* print-service panel (Gitea #9) — embedded (normal flow) in the rail */}
       <PrintPanel

--- a/apps/web/src/components/create/abacus/ModularColumnsPanel.tsx
+++ b/apps/web/src/components/create/abacus/ModularColumnsPanel.tsx
@@ -1,0 +1,251 @@
+'use client'
+
+// ModularColumnsPanel — the AbacusLink prototype's surface in the studio.
+//
+// SPEC: apps/web/docs/abacus-studio/modular-columns-spec.md
+//
+// WHY THE RIGHT RAIL. Mono-vs-modular is a FABRICATION strategy — a sub-axis of
+// the paper/FDM `FabricationKind` — not a design property. The abacus reads the
+// same either way; what changes is whether it comes off the plate in one piece
+// or thirteen. It also has to sit beside the download buttons, which is where
+// the two plates actually get to a printer.
+//
+// WHAT THE TOGGLE ACTUALLY DOES, in this revision: it raises two dimension
+// floors (a wider web, because the seam halves it; a wider border, because the
+// end strips now carry a latch AND a foot) and nothing else. The assembled
+// abacus still renders as ONE solid. The topology change waits on analyzeShells,
+// which identifies the frame as "the one shell wider than a column pitch" —
+// a test every column module fails, taking the viewer's whole recolor pass with
+// it. The two plate downloads are what you print in the meantime, and they force
+// the modular floors on regardless of the toggle, so a coupon is always cut to
+// the pitch a modular abacus would actually have.
+
+import { useState } from 'react'
+import { Disclosure } from '@/components/studio/Disclosure'
+import { DebugCheckbox, DebugSlider } from '@/components/toys/ToyDebugPanel'
+import { useAbacusStudio } from './AbacusStudioContext'
+import { linkDerived, linkFit, linkMechanics, linkParamsOf } from './abacus-link'
+import { derived, isModular, type Params, type RenderPass } from './abacus-model'
+
+/** Default-off, admin-managed at /admin/feature-flags. The toggle underneath it
+ *  moves real geometry, so the prototype stays invisible until somebody asks
+ *  for it — an unset flag reads as disabled. */
+export const MODULAR_COLUMNS_FLAG = 'abacus.modular_columns'
+
+/** The two plates, and what each one is for. Both emit TWO pieces in print pose,
+ *  because in both cases the thing under test is the seam between them. */
+const PLATES: ReadonlyArray<{
+  pass: RenderPass
+  label: string
+  file: string
+  hint: string
+}> = [
+  {
+    pass: { only: 'link_coupon' },
+    label: '⬇ Joint coupon',
+    file: 'abacus-link-coupon',
+    hint: 'Two half-blocks, one full interface, ~15 min. Does the cam actually cam, hold, and release? Print this first, and print it at three ramp angles.',
+  },
+  {
+    pass: { only: 'link_column' },
+    label: '⬇ Column pair',
+    file: 'abacus-link-column-pair',
+    hint: 'Two real column modules with their captive beads. Does halving the web disturb capture, and do two columns click up flush?',
+  },
+]
+
+const mm = (v: number) => v.toFixed(1)
+
+export function ModularColumnsPanel() {
+  const { params, set, requestExportPass, exporterReady } = useAbacusStudio()
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Both sizes come from the ONE derived chain the geometry uses, evaluated at
+  // each mode — a second copy of the arithmetic here is exactly how a readout
+  // and the thing it describes drift apart.
+  const monoSize = derived({ ...params, link_mode: 'mono' })
+  const modSize = derived({ ...params, link_mode: 'modular' })
+  const on = isModular(params)
+
+  // The joint's own guards, run against THIS design rather than against the
+  // coupon defaults — so shrinking the abacus past the joint's size floor is
+  // reported here instead of failing inside a render the user already paid for.
+  const link = linkParamsOf(params)
+  const fit = linkFit(link)
+  const mech = linkMechanics(link)
+  const geom = linkDerived(link)
+
+  const download = async (plate: (typeof PLATES)[number]) => {
+    setError(null)
+    setBusy(plate.file)
+    try {
+      const stl = await requestExportPass(plate.pass)
+      const a = document.createElement('a')
+      a.href = URL.createObjectURL(new Blob([stl], { type: 'model/stl' }))
+      a.download = `${plate.file}-ramp${params.link_ramp}-x${params.scale_factor}.stl`
+      a.click()
+      URL.revokeObjectURL(a.href)
+    } catch (err) {
+      setError(String((err as Error)?.message ?? err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const knob = (
+    label: string,
+    key: 'link_ramp' | 'link_fit' | 'link_relief' | 'link_bump',
+    min: number,
+    max: number,
+    step: number,
+    fmt: (v: number) => string
+  ) => (
+    <DebugSlider
+      label={label}
+      value={params[key]}
+      min={min}
+      max={max}
+      step={step}
+      formatValue={fmt}
+      onChange={(v) => set(key, v)}
+    />
+  )
+
+  return (
+    <Disclosure
+      label="Modular columns (prototype)"
+      dataElement="abacus-modular-columns"
+      dataAction="toggle-modular-columns"
+    >
+      <div
+        data-element="modular-columns-body"
+        style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
+      >
+        <DebugCheckbox
+          label="Modular column dimensions"
+          checked={on}
+          onChange={(v) => set('link_mode', v ? 'modular' : 'mono')}
+        />
+
+        <div
+          data-element="modular-size-delta"
+          style={{ fontSize: 11, lineHeight: 1.5, color: 'rgba(226,232,240,0.75)' }}
+        >
+          {params.cols} columns:{' '}
+          <strong style={{ color: on ? 'rgba(148,163,184,0.9)' : 'rgba(243,244,246,1)' }}>
+            {mm(monoSize.frameW)} × {mm(monoSize.outerD)} mm
+          </strong>
+          {' → '}
+          <strong style={{ color: on ? 'rgba(243,244,246,1)' : 'rgba(148,163,184,0.9)' }}>
+            {mm(modSize.frameW)} × {mm(modSize.outerD)} mm
+          </strong>
+          <div style={{ marginTop: 3, color: 'rgba(148,163,184,0.85)' }}>
+            The seam splits the wall between channels, so each module keeps half — too thin at
+            stock, hence a wider web. And an end strip now carries a latch tongue <em>and</em> a
+            foot pocket, hence a wider border.
+          </div>
+        </div>
+
+        {/* The joint's verdict. `linkFit` names the knob that fixes each problem,
+            which is the whole reason it returns structured reasons instead of a
+            boolean — same contract feetFit has with the feet notes. */}
+        {fit.fits ? (
+          <div
+            data-element="modular-verdict-ok"
+            style={{ fontSize: 11, color: 'rgba(134,239,172,0.9)', lineHeight: 1.5 }}
+          >
+            Joint holds ≈{mech.clampPerSeam.toFixed(0)} N per seam, camming {geom.takeUp.toFixed(3)}{' '}
+            mm shut. {mech.selfLocking ? 'Self-locking.' : ''}
+          </div>
+        ) : (
+          <div
+            data-element="modular-verdict-bad"
+            style={{
+              fontSize: 11,
+              lineHeight: 1.5,
+              color: 'rgba(254,226,226,0.95)',
+              background: 'rgba(127,29,29,0.35)',
+              border: '1px solid rgba(248,113,113,0.5)',
+              borderRadius: 6,
+              padding: '7px 9px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 5,
+            }}
+          >
+            {fit.problems.map((p) => (
+              <div key={p.code}>
+                {p.message} <em style={{ opacity: 0.8 }}>({p.knob})</em>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* The sweep. §9 of the spec prints the ramp at 8/12/16 on one plate:
+            shallower cams harder and holds more, steeper swallows more of what
+            the printer got wrong. Which end is right is a question about real
+            printers, so it ships as a knob rather than a decision. */}
+        {knob('cam ramp (°)', 'link_ramp', 4, 16, 1, (v) => `${v}°`)}
+        {knob('barb travel (mm)', 'link_bump', 0.6, 1.8, 0.1, mm)}
+        {knob('groove fit (mm)', 'link_fit', 0.05, 0.25, 0.01, (v) => v.toFixed(2))}
+        {knob('flat relief (mm)', 'link_relief', 0.15, 0.6, 0.05, (v) => v.toFixed(2))}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+          {PLATES.map((plate) => (
+            <div key={plate.file} style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+              <button
+                type="button"
+                data-action={`download-${plate.file}`}
+                disabled={!exporterReady || !fit.fits || busy !== null}
+                onClick={() => download(plate)}
+                style={{
+                  padding: '8px 10px',
+                  borderRadius: 7,
+                  border: '1px solid rgba(148,163,184,0.4)',
+                  background: 'rgba(30,41,59,0.85)',
+                  color: 'rgba(243,244,246,1)',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: !exporterReady || !fit.fits || busy !== null ? 'default' : 'pointer',
+                  opacity: !exporterReady || !fit.fits || busy !== null ? 0.5 : 1,
+                }}
+              >
+                {busy === plate.file ? 'Rendering…' : plate.label}
+              </button>
+              <div style={{ fontSize: 10, lineHeight: 1.45, color: 'rgba(148,163,184,0.85)' }}>
+                {plate.hint}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {error ? (
+          <div
+            data-element="modular-export-error"
+            style={{ fontSize: 11, color: 'rgba(254,202,202,0.95)', lineHeight: 1.5 }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <div style={{ fontSize: 10, lineHeight: 1.5, color: 'rgba(148,163,184,0.7)' }}>
+          Unproven geometry — no headless OpenSCAD exists here, so nothing below the arithmetic has
+          been checked by a machine. Measure the coupon before trusting it: seam gap at the flanks,
+          step across the top faces, insertion and release force.
+        </div>
+      </div>
+    </Disclosure>
+  )
+}
+
+/** Exported for the story/test seam: the panel is pure in `params`, so the two
+ *  things worth asserting about it — the size delta it quotes and whether the
+ *  downloads are reachable — are derivable without mounting it. */
+export const modularSizeDelta = (
+  p: Params
+): { mono: [number, number]; modular: [number, number] } => {
+  const a = derived({ ...p, link_mode: 'mono' })
+  const b = derived({ ...p, link_mode: 'modular' })
+  return { mono: [a.frameW, a.outerD], modular: [b.frameW, b.outerD] }
+}

--- a/apps/web/src/components/create/abacus/__tests__/abacus-link.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-link.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
+import { DEFAULT_PROFILE, solve } from '../abacus-solver'
+import { borderEff, defaultParams, derived, type Params, webEff } from '../abacus-model'
 import {
+  BOX_CLEAR,
   defaultLinkParams,
   type LinkParams,
   linkDerived,
   linkFit,
   linkHingeDroop,
   linkMechanics,
+  linkParamsOf,
   MIN_TAKEUP,
   SELF_LOCK_MAX_DEG,
 } from '../abacus-link'
@@ -154,5 +158,85 @@ describe('linkHingeDroop', () => {
       6
     )
     expect(linkHingeDroop(defaultLinkParams, 0, 12)).toBe(0)
+  })
+})
+
+describe('linkParamsOf — the bridge onto a real design', () => {
+  it('takes its envelope from the design, not from the coupon defaults', () => {
+    const modular: Params = { ...defaultParams, link_mode: 'modular' }
+    const lp = linkParamsOf(modular)
+    // pitch and station come off derived(), so they track the modular floors:
+    // web 2.5 → 4.5 gives a 15 mm pitch, border 5.25 → 7.0 a 14.75 mm strip.
+    expect(lp.pitch).toBeCloseTo(15, 6)
+    expect(lp.station).toBeCloseTo(14.75, 6)
+    expect(lp.h).toBeCloseTo(8, 6)
+    expect(linkFit(lp).fits).toBe(true)
+  })
+
+  it('follows scale_factor, because the joint envelope scales but the joint does not', () => {
+    const big = linkParamsOf({ ...defaultParams, link_mode: 'modular', scale_factor: 1.5 })
+    expect(big.h).toBeCloseTo(12, 6)
+    expect(big.pitch).toBeGreaterThan(20)
+    // the tongue and barb are absolute hardware and must NOT have scaled
+    expect(big.beamL).toBe(defaultLinkParams.beamL)
+    expect(big.bump).toBe(defaultParams.link_bump)
+  })
+
+  it('seats the foot clear of the latch slot, measured off the slot far edge', () => {
+    // The scad's link_foot_y() and this have to agree, or the pocket is punched
+    // through the shoulder. Measuring off the barb (the slot's NEAR edge) is the
+    // mistake this pins against.
+    const lp = linkParamsOf({ ...defaultParams, link_mode: 'modular' })
+    const d = linkDerived(lp)
+    expect(lp.footY - lp.footW / 2).toBeCloseTo(d.slotBox[3] + BOX_CLEAR, 6)
+    expect(linkFit(lp).problems.map((p) => p.code)).not.toContain('foot-hits-slot')
+  })
+
+  it('refuses a design whose modular pitch is too narrow for the tongue', () => {
+    // The tongue is absolute, so shrinking the abacus is what eventually breaks
+    // the joint — the size floor modular mode has and the monolith does not.
+    const tiny = linkParamsOf({ ...defaultParams, link_mode: 'modular', scale_factor: 0.5 })
+    expect(linkFit(tiny).problems.map((p) => p.code)).toContain('slot-past-pitch')
+  })
+})
+
+describe('the modular dimension floors', () => {
+  it('raise web and border only in modular mode, and never lower them', () => {
+    expect(webEff(defaultParams)).toBe(defaultParams.web)
+    expect(borderEff(defaultParams)).toBe(defaultParams.border_w)
+    const m: Params = { ...defaultParams, link_mode: 'modular' }
+    expect(webEff(m)).toBe(4.5)
+    expect(borderEff(m)).toBe(7.0)
+    // a design that already asked for more keeps it
+    expect(webEff({ ...m, web: 6 })).toBe(6)
+    expect(borderEff({ ...m, border_w: 9 })).toBe(9)
+  })
+
+  it('grows the abacus by the amount the spec quotes', () => {
+    const mono = derived(defaultParams)
+    const mod = derived({ ...defaultParams, link_mode: 'modular' })
+    expect(mono.frameW).toBeCloseTo(192.5, 4)
+    expect(mono.outerD).toBeCloseTo(100.5, 4)
+    expect(mod.frameW).toBeCloseTo(220.0, 4)
+    expect(mod.outerD).toBeCloseTo(104.0, 4)
+  })
+
+  it('makes the solver judge the HALF-web, which is the wall that has to print', () => {
+    // The two modes diverge in a narrow band, and 0.5× sits in it: the mono web
+    // is 2.5 · 0.5 = 1.25 and clears the 1.2 floor, while the modular half-web is
+    // 2.25 · 0.5 = 1.125 and does not. Same design, same scale — the only
+    // difference is that the seam splits the wall in half.
+    const at = (s: number, link_mode: string): string[] =>
+      solve({ ...defaultParams, scale_factor: s, link_mode }, DEFAULT_PROFILE).reasons.map(
+        (r) => r.dim
+      )
+    expect(at(0.5, 'mono')).not.toContain('wall')
+    expect(at(0.5, 'modular')).toContain('wall')
+    // and the modular message names the half-web, so the fix is discoverable
+    const r = solve(
+      { ...defaultParams, scale_factor: 0.5, link_mode: 'modular' },
+      DEFAULT_PROFILE
+    ).reasons.find((x) => x.dim === 'wall')
+    expect(r?.label).toBe('channel wall (half-web)')
   })
 })

--- a/apps/web/src/components/create/abacus/__tests__/abacus-link.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-link.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultLinkParams,
+  type LinkParams,
+  linkDerived,
+  linkFit,
+  linkHingeDroop,
+  linkMechanics,
+  MIN_TAKEUP,
+  SELF_LOCK_MAX_DEG,
+} from '../abacus-link'
+
+// The AbacusLink joint's arithmetic. There is no headless OpenSCAD in this repo
+// (see export-defines.test.ts), so abacus-link.scad's asserts only ever fire
+// inside a user's render — these are the copy that runs in CI.
+//
+// Two of the guards below exist because their failure is SILENT: the part still
+// renders, still slices, still prints, and still clicks together. Those two get
+// dedicated cases rather than riding along in a table.
+
+const withP = (over: Partial<LinkParams>): LinkParams => ({ ...defaultLinkParams, ...over })
+const codes = (p: LinkParams) => linkFit(p).problems.map((x) => x.code)
+
+describe('linkDerived', () => {
+  it('puts the chevron flank inside the self-support limit at defaults', () => {
+    // atan(1.6 / 2) — the flank off VERTICAL. 45° is where the groove's roof
+    // stops being printable, so this is the margin that matters.
+    expect(linkDerived(defaultLinkParams).flankDeg).toBeCloseTo(38.66, 2)
+    expect(linkDerived(defaultLinkParams).flankDeg).toBeLessThan(45)
+  })
+
+  it('derives the seating travel from the flank, not from the ramp', () => {
+    // The two angles are unrelated and the early draft of the scad conflated
+    // them, which made the relief guard demand 0.53 mm instead of 0.18 and
+    // refused a geometry that is fine. Pinned so it cannot come back.
+    const d = linkDerived(defaultLinkParams)
+    expect(d.seatTravel).toBeCloseTo(0.1 / Math.cos((38.66 * Math.PI) / 180), 3)
+    expect(d.seatTravel).toBeLessThan(defaultLinkParams.relief)
+  })
+
+  it('take-up is the cam face x-run, and clears the print-spread floor', () => {
+    const p = defaultLinkParams
+    const d = linkDerived(p)
+    expect(d.takeUp).toBeCloseTo(p.bump * Math.tan((p.rampDeg * Math.PI) / 180), 4)
+    expect(d.takeUp).toBeGreaterThanOrEqual(MIN_TAKEUP)
+  })
+})
+
+describe('linkFit — the defaults are buildable', () => {
+  it('accepts the shipped coupon geometry', () => {
+    expect(linkFit(defaultLinkParams)).toEqual({ fits: true, problems: [] })
+  })
+})
+
+describe('linkFit — the two silent failures', () => {
+  it('refuses relief that lets the seam faces bottom out before the chevron seats', () => {
+    // Silent because everything downstream still works: it renders, prints, and
+    // clicks. What is lost is the chevron's Z registration — which is the only
+    // thing keeping the four ArUco markers coplanar across a stack, and the CV
+    // homography assumes coplanar and will not complain when they aren't.
+    const p = withP({ relief: 0.12 })
+    expect(codes(p)).toContain('relief-too-small')
+    expect(linkFit(p).problems[0].knob).toBe('relief')
+  })
+
+  it('refuses a foot pocket that overlaps the latch slot', () => {
+    // Silent in the other direction: OpenSCAD unions the two voids without
+    // comment, and the result is a latch shoulder with a hole through it.
+    expect(codes(withP({ footY: 6.5 }))).toContain('foot-hits-slot')
+    // and the shipped 5/16" bumper is exactly what does NOT fit — the finding
+    // that set the 1/4" preset and the widened strip.
+    expect(codes(withP({ footW: 7.94, footY: 6.5 }))).toContain('foot-hits-slot')
+  })
+})
+
+describe('linkFit — the loud ones', () => {
+  it.each([
+    ['toothD', { toothD: 2.4 }, 'flank-overhang'],
+    ['rampDeg above the friction angle', { rampDeg: 20 }, 'ramp-not-self-locking'],
+    ['bump too small to cam', { bump: 0.2, slot: 0.5 }, 'takeup-too-small'],
+    ['slot narrower than the barb', { slot: 0.9 }, 'slot-binds'],
+    ['tongue too close to the outer wall', { beamY0: 1.9 }, 'wall-too-thin'],
+    ['station too shallow for the slot', { station: 5.0 }, 'slot-past-station'],
+    ['foot wider than the strip', { footW: 12.7 }, 'foot-off-strip'],
+  ])('refuses %s', (_label, over, code) => {
+    expect(codes(withP(over))).toContain(code)
+  })
+
+  it('names a knob that actually moves the failing quantity', () => {
+    for (const problem of linkFit(withP({ toothD: 2.4, rampDeg: 20, slot: 0.5 })).problems) {
+      expect(Object.keys(defaultLinkParams)).toContain(problem.knob)
+    }
+  })
+})
+
+describe('linkMechanics', () => {
+  it('self-locks at the default ramp and stops doing so past the friction angle', () => {
+    expect(linkMechanics(defaultLinkParams).selfLocking).toBe(true)
+    expect(linkMechanics(withP({ rampDeg: SELF_LOCK_MAX_DEG + 1 })).selfLocking).toBe(false)
+  })
+
+  it('keeps the tongue under PLA yield while still developing useful clamp', () => {
+    const m = linkMechanics(defaultLinkParams)
+    expect(m.beamStressMPa).toBeLessThan(50) // PLA yields ~55 MPa; peak is transient
+    // 25 N hand press with a foot under every column wants 70 N; being carried
+    // by one end wants ~105 N. Both inside the seated preload.
+    expect(m.clampPerSeam).toBeGreaterThan(100)
+  })
+
+  it('quotes the preload at the SEATED position, not at full travel', () => {
+    // Full travel is the insertion peak. Reporting it as the preload would
+    // overstate what the seam actually holds by exactly 2×, which is the kind of
+    // error that survives all the way to a physical part that feels loose.
+    const m = linkMechanics(defaultLinkParams)
+    expect(m.springForceFull).toBeCloseTo(2 * m.springForceSeated, 6)
+    expect(m.clampPerStation).toBeCloseTo(
+      m.springForceSeated / Math.tan((defaultLinkParams.rampDeg * Math.PI) / 180),
+      6
+    )
+  })
+
+  it('trades clamp against stress as the tongue shortens — the reason L is 12', () => {
+    const short = linkMechanics(withP({ beamL: 8 }))
+    const long = linkMechanics(defaultLinkParams)
+    expect(short.clampPerSeam).toBeGreaterThan(long.clampPerSeam) // ∝ 1/L³
+    expect(short.beamStressMPa).toBeGreaterThan(long.beamStressMPa) // ∝ 1/L²
+    expect(short.beamStressMPa).toBeGreaterThan(50) // and that is what rules it out
+  })
+
+  it('trades clamp against take-up as the ramp steepens — the coupon sweep', () => {
+    const steep = linkMechanics(withP({ rampDeg: 16 }))
+    expect(steep.clampPerSeam).toBeLessThan(linkMechanics(defaultLinkParams).clampPerSeam)
+    expect(linkDerived(withP({ rampDeg: 16 })).takeUp).toBeGreaterThan(
+      linkDerived(defaultLinkParams).takeUp
+    )
+    // …and every rung of the sweep is still a legal geometry, so §9 can print
+    // all three on one plate without hand-editing anything else.
+    for (const rampDeg of [8, 12, 16]) expect(linkFit(withP({ rampDeg })).fits).toBe(true)
+  })
+})
+
+describe('linkHingeDroop', () => {
+  it('turns a twentieth of a millimetre of latch play into centimetres of droop', () => {
+    // The number the whole cam mechanism exists to avoid: 0.05 mm of residual
+    // clearance per joint, twelve joints in series, cantilevered from one end.
+    const droop = linkHingeDroop(defaultLinkParams, 0.05, 12)
+    expect(droop).toBeGreaterThan(6)
+    expect(droop).toBeLessThan(11)
+  })
+
+  it('is linear in the residual clearance — which is why zero is the target', () => {
+    expect(linkHingeDroop(defaultLinkParams, 0.1, 12)).toBeCloseTo(
+      2 * linkHingeDroop(defaultLinkParams, 0.05, 12),
+      6
+    )
+    expect(linkHingeDroop(defaultLinkParams, 0, 12)).toBe(0)
+  })
+})

--- a/apps/web/src/components/create/abacus/abacus-link.ts
+++ b/apps/web/src/components/create/abacus/abacus-link.ts
@@ -1,0 +1,314 @@
+// Abacus Studio — the AbacusLink modular-column joint, TS mirror.
+//
+// SPEC: apps/web/docs/abacus-studio/modular-columns-spec.md
+// GEOMETRY: public/scad/abacus-link.scad — that file stays the source of truth
+// for the printed shape. This one mirrors its derived chain and its asserts,
+// exactly as `derived()` mirrors abacus.scad's intent-knob chain and
+// `feetEffective()` / `feetFit()` mirror the foot-pocket asserts.
+//
+// WHY THE MIRROR EARNS ITS KEEP HERE MORE THAN ANYWHERE ELSE. There is no
+// headless OpenSCAD in this repo, so a scad `assert()` only ever fires inside a
+// user's render — mid-export, in a message written for whoever edits the scad.
+// The joint has two failure modes that are *silent* rather than loud, and both
+// are caught below instead:
+//
+//   1. A release bore drilled at or before the latch shoulder removes the very
+//      material the barb bears on. The part renders, slices, prints, and clicks
+//      — and holds nothing.
+//   2. Flat relief under the chevron's seating travel lets the seam faces bottom
+//      out before the chevron flanks touch. Also renders, also prints, also
+//      clicks — and quietly gives up the Z registration the ArUco markers'
+//      coplanarity depends on.
+//
+// Neither shows up in a preview. Both are one arithmetic comparison.
+//
+// Framework-free: no React, no three, no geometry kernel. Pure numbers.
+
+/** PLA's effective modulus for printed parts at 3–4 walls + ~40% infill. The
+ *  same 2 GPa abacus.scad's anti-bend feet napkin uses — kept identical so the
+ *  two structural arguments in this project can be compared without conversion. */
+export const E_PLA = 2000 // MPa
+
+/** PLA-on-PLA sliding friction. Sets the self-locking bound on the cam ramp:
+ *  below atan(MU_PLA) a wedge cannot be driven back out by load, only released
+ *  by pushing the spring. Conservative — printed surfaces usually run higher. */
+export const MU_PLA = 0.3
+export const SELF_LOCK_MAX_DEG = (Math.atan(MU_PLA) * 180) / Math.PI // ≈ 16.7°
+
+const rad = (deg: number): number => (deg * Math.PI) / 180
+
+/** The joint's knob surface. Mirrors the `link_*` variables in abacus-link.scad
+ *  one for one; anything derived from these lives in {@link linkDerived}. */
+export type LinkParams = {
+  h: number // seam height = frame_h · S
+  pitch: number // modular col_pitch
+  station: number // Y depth of a joint station (the solid border strip)
+  // chevron
+  teeth: number
+  toothD: number
+  fit: number
+  relief: number
+  // cam latch
+  rampDeg: number
+  leadDeg: number
+  beamT: number
+  beamL: number
+  beamX0: number
+  beamY0: number
+  bump: number
+  slot: number
+  release: number
+  // foot
+  footW: number
+  footX: number
+  footY: number
+}
+
+/** The values the scad and this module both derive, and the coupon's defaults.
+ *  Kept in one place so a sweep (§9 of the spec) is a spread, not a rewrite. */
+export const defaultLinkParams: LinkParams = {
+  h: 8,
+  pitch: 15,
+  station: 14.75,
+  teeth: 2,
+  toothD: 1.6,
+  fit: 0.1,
+  relief: 0.25,
+  rampDeg: 8,
+  leadDeg: 40,
+  beamT: 1.8,
+  beamL: 12,
+  beamX0: -5,
+  beamY0: 2.6,
+  bump: 1.1,
+  slot: 1.4,
+  release: 2.6,
+  footW: 6.35, // 1/4" — the largest BUMPER_PRESETS entry that clears the slot
+  footX: 7.5,
+  footY: 10.0,
+}
+
+/** An axis-aligned footprint on the module's solid strip, `[x0, y0, x1, y1]`. */
+export type LinkBox = readonly [number, number, number, number]
+
+export type LinkDerived = {
+  /** one tooth's height */
+  toothH: number
+  /** chevron flank angle off VERTICAL, degrees. ≤ 45 is the self-support limit
+   *  — the number that decides whether the groove's roof needs support. */
+  flankDeg: number
+  /** X travel needed to close a `fit` normal gap on the flank; the relief has to
+   *  exceed this or the flats seat before the chevron does. */
+  seatTravel: number
+  /** the cam face's x-run — how much X the latch draws per full barb travel */
+  takeUp: number
+  /** the insertion lead-in's x-run */
+  leadRun: number
+  beamX1: number
+  barbX: number
+  slotEnd: number
+  boreX: number
+  slotBox: LinkBox
+  footBox: LinkBox
+}
+
+export const linkDerived = (p: LinkParams): LinkDerived => {
+  const toothH = p.h / p.teeth
+  const flankDeg = (Math.atan(p.toothD / (toothH / 2)) * 180) / Math.PI
+  const beamX1 = p.beamX0 + p.beamL
+  const barbX = beamX1 - 3.4
+  const takeUp = p.bump * Math.tan(rad(p.rampDeg))
+  const leadRun = p.bump / Math.tan(rad(p.leadDeg))
+  const slotEnd = beamX1 + 1.2
+  return {
+    toothH,
+    flankDeg,
+    seatTravel: p.fit / Math.cos(rad(flankDeg)),
+    takeUp,
+    leadRun,
+    beamX1,
+    barbX,
+    slotEnd,
+    boreX: beamX1 - 0.5,
+    slotBox: [p.relief - 0.1, p.beamY0 - p.bump - 0.15, slotEnd, p.beamY0 + p.beamT + p.slot],
+    footBox: [
+      p.footX - p.footW / 2,
+      p.footY - p.footW / 2,
+      p.footX + p.footW / 2,
+      p.footY + p.footW / 2,
+    ],
+  }
+}
+
+// ---- what the latch is actually worth ---------------------------------------
+// The cantilever is `h` tall in Z and `beamT` thick in Y, so it springs in Y
+// while staying stiff about the axis a sagging abacus loads. Everything below is
+// straight Euler-Bernoulli on that beam — the point is not precision, it is that
+// the three quantities trade against each other and you cannot improve one
+// without paying in another:
+//
+//   clamp     ∝ 1/L³   (short beam → strong)
+//   stress    ∝ 1/L²   (short beam → cracks)
+//   take-up   ∝ tan(ramp)   while   clamp ∝ 1/tan(ramp)
+//
+// SEATED, NOT FULL, DEFLECTION. The clamp a seam actually holds is set by how
+// far the barb still HAD to travel when the chevron flanks bottomed out — not by
+// the barb's full height. Quoting the full-travel force would overstate the
+// preload by 2×. Nominal design point is the barb seating at mid-travel, so
+// `clampPerSeam` is taken at bump/2 and the full-travel figure is reported
+// separately as what it really is: the peak the tongue sees while you push two
+// modules together, and the deflection its fibre stress must be checked at.
+export type LinkMechanics = {
+  /** tip stiffness of one tongue, N/mm */
+  beamK: number
+  /** spring force at the nominal seated position (barb at mid-travel), N */
+  springForceSeated: number
+  /** spring force at full barb deflection — the INSERTION peak, not the preload */
+  springForceFull: number
+  /** X clamp one station holds when seated, N — the spring through the ramp's 1/tan */
+  clampPerStation: number
+  /** two stations (front strip + back strip) per seam */
+  clampPerSeam: number
+  /** peak bending stress at the tongue's root during insertion, MPa. The stress
+   *  it lives at is roughly half this; the peak is what has to clear yield. */
+  beamStressMPa: number
+  /** ramp below the friction angle: load cannot back the joint out */
+  selfLocking: boolean
+  /** bending moment a seam carries before its tension side opens, N·mm.
+   *  M_gap = P·h/6 for an axially preloaded rectangular joint face. Past this
+   *  the joint does not fail — it opens onto the self-locking wedge and carries
+   *  the rest in bearing — but it stops being as stiff as the slab it replaced. */
+  gapMomentNmm: number
+}
+
+export const linkMechanics = (p: LinkParams): LinkMechanics => {
+  const I = (p.h * p.beamT ** 3) / 12
+  const beamK = (3 * E_PLA * I) / p.beamL ** 3
+  const springForceSeated = beamK * (p.bump / 2)
+  const clampPerStation = springForceSeated / Math.tan(rad(p.rampDeg))
+  const clampPerSeam = 2 * clampPerStation
+  return {
+    beamK,
+    springForceSeated,
+    springForceFull: beamK * p.bump,
+    clampPerStation,
+    clampPerSeam,
+    beamStressMPa: (3 * E_PLA * p.bump * p.beamT) / (2 * p.beamL ** 2),
+    selfLocking: Math.tan(rad(p.rampDeg)) < MU_PLA,
+    gapMomentNmm: (clampPerSeam * p.h) / 6,
+  }
+}
+
+/** How far the far end of an `n`-seam stack falls out of plane if every joint
+ *  hinges on `clearance` of residual latch play — the calculation in §3 of the
+ *  spec, and the reason the latch has to cam the seam shut rather than merely
+ *  hook it. Cantilevered from one end; each joint contributes clearance/h of
+ *  rotation acting over its distance to the free end. */
+export const linkHingeDroop = (p: LinkParams, clearance: number, seams: number): number => {
+  const theta = clearance / p.h
+  const span = (seams + 1) * p.pitch
+  let droop = 0
+  for (let i = 1; i <= seams; i++) droop += theta * (span - i * p.pitch)
+  return droop
+}
+
+// ---- the fit guards — one per scad assert ------------------------------------
+/** Why a link geometry is refused. One code per `assert()` in abacus-link.scad,
+ *  same order, so the two can be read side by side. */
+export type LinkProblemCode =
+  | 'flank-overhang'
+  | 'ramp-not-self-locking'
+  | 'relief-too-small'
+  | 'takeup-too-small'
+  | 'slot-binds'
+  | 'wall-too-thin'
+  | 'slot-past-station'
+  | 'foot-hits-slot'
+  | 'foot-off-strip'
+
+export type LinkProblem = {
+  code: LinkProblemCode
+  /** written for whoever is turning the knob, not for whoever wrote the scad */
+  message: string
+  /** the LinkParams key that actually fixes it */
+  knob: keyof LinkParams
+}
+
+export type LinkFit = { fits: boolean; problems: LinkProblem[] }
+
+/** Smallest cam take-up worth shipping: under this the joint cannot swallow the
+ *  ±0.1 mm a well-tuned FDM printer varies by, and the seam gap goes back to
+ *  being whatever the printer felt like that day. */
+export const MIN_TAKEUP = 0.12
+/** Clear space demanded between two footprints on the same solid strip. */
+export const BOX_CLEAR = 0.8
+
+const disjoint = (a: LinkBox, b: LinkBox, clear: number): boolean =>
+  a[0] > b[2] + clear || a[2] < b[0] - clear || a[1] > b[3] + clear || a[3] < b[1] - clear
+
+export function linkFit(p: LinkParams): LinkFit {
+  const d = linkDerived(p)
+  const problems: LinkProblem[] = []
+  const bad = (code: LinkProblemCode, message: string, knob: keyof LinkParams) =>
+    problems.push({ code, message, knob })
+
+  if (d.flankDeg > 45.001)
+    bad(
+      'flank-overhang',
+      `chevron flank is ${d.flankDeg.toFixed(1)}° off vertical; past 45° the groove's roof needs support, and support inside a snap fit is not a thing`,
+      'toothD'
+    )
+  if (!(p.rampDeg > 0 && p.rampDeg < SELF_LOCK_MAX_DEG))
+    bad(
+      'ramp-not-self-locking',
+      `cam ramp must sit in (0°, ${SELF_LOCK_MAX_DEG.toFixed(1)}°) to self-lock; above it, load can drive the joint open`,
+      'rampDeg'
+    )
+  if (p.relief <= d.seatTravel + 0.05)
+    bad(
+      'relief-too-small',
+      `flat relief ${p.relief} mm is under the ${d.seatTravel.toFixed(3)} mm of travel the chevron needs to seat — the seam faces would bottom out first and the joint would lose its Z registration silently`,
+      'relief'
+    )
+  if (d.takeUp < MIN_TAKEUP)
+    bad(
+      'takeup-too-small',
+      `cam take-up ${d.takeUp.toFixed(3)} mm cannot swallow a normal print's spread (${MIN_TAKEUP} mm)`,
+      'bump'
+    )
+  if (p.slot <= p.bump + 0.2)
+    bad(
+      'slot-binds',
+      "slot is narrower than the barb's travel — the tongue would bind on insertion",
+      'slot'
+    )
+  if (p.beamY0 - p.bump <= 1.2)
+    bad(
+      'wall-too-thin',
+      'outer wall left in front of the barb is thinner than a printable wall',
+      'beamY0'
+    )
+  if (d.slotBox[3] >= p.station)
+    bad(
+      'slot-past-station',
+      'latch slot runs past the solid strip into the bead channel',
+      'station'
+    )
+  if (!disjoint(d.footBox, d.slotBox, BOX_CLEAR))
+    bad(
+      'foot-hits-slot',
+      'foot pocket overlaps the latch slot — they compete for the same strip, and the slot wins on X, so the foot has to clear it in Y',
+      'footY'
+    )
+  if (
+    !(
+      d.footBox[0] > p.relief + 0.8 &&
+      d.footBox[2] < p.relief + p.pitch - 0.8 &&
+      d.footBox[1] > 0.8 &&
+      d.footBox[3] < p.station - 0.8
+    )
+  )
+    bad('foot-off-strip', "foot pocket runs off the module's solid strip", 'footW')
+
+  return { fits: problems.length === 0, problems }
+}

--- a/apps/web/src/components/create/abacus/abacus-link.ts
+++ b/apps/web/src/components/create/abacus/abacus-link.ts
@@ -24,6 +24,8 @@
 //
 // Framework-free: no React, no three, no geometry kernel. Pure numbers.
 
+import { borderEff, derived, type Params } from './abacus-model'
+
 /** PLA's effective modulus for printed parts at 3–4 walls + ~40% infill. The
  *  same 2 GPa abacus.scad's anti-bend feet napkin uses — kept identical so the
  *  two structural arguments in this project can be compared without conversion. */
@@ -223,6 +225,11 @@ export type LinkProblemCode =
   | 'slot-binds'
   | 'wall-too-thin'
   | 'slot-past-station'
+  | 'slot-past-pitch'
+  // The last two have no counterpart in `link_assert()`. The library is
+  // deliberately foot-agnostic — a specialty column may seat something else
+  // entirely — so where the bumper goes is the CONSUMER's business, and
+  // abacus.scad asserts these two beside its own foot placement.
   | 'foot-hits-slot'
   | 'foot-off-strip'
 
@@ -243,8 +250,17 @@ export const MIN_TAKEUP = 0.12
 /** Clear space demanded between two footprints on the same solid strip. */
 export const BOX_CLEAR = 0.8
 
+/** At least `clear` apart on some axis. The comparison is `>=`, not `>`: `clear`
+ *  is the REQUIRED gap, so a placement that delivers exactly that much has met
+ *  it. Strict `>` rejected the scad's own foot position, which is derived to sit
+ *  exactly BOX_CLEAR past the slot — a guard that refuses the geometry it was
+ *  written to describe. EPS absorbs the float drift of that derivation. */
+const BOX_EPS = 1e-9
 const disjoint = (a: LinkBox, b: LinkBox, clear: number): boolean =>
-  a[0] > b[2] + clear || a[2] < b[0] - clear || a[1] > b[3] + clear || a[3] < b[1] - clear
+  a[0] + BOX_EPS >= b[2] + clear ||
+  a[2] - BOX_EPS <= b[0] - clear ||
+  a[1] + BOX_EPS >= b[3] + clear ||
+  a[3] - BOX_EPS <= b[1] - clear
 
 export function linkFit(p: LinkParams): LinkFit {
   const d = linkDerived(p)
@@ -294,6 +310,12 @@ export function linkFit(p: LinkParams): LinkFit {
       'latch slot runs past the solid strip into the bead channel',
       'station'
     )
+  if (d.slotEnd + 1.0 >= p.pitch)
+    bad(
+      'slot-past-pitch',
+      "latch slot runs past the module's far wall — the tongue is longer than a column is wide",
+      'pitch'
+    )
   if (!disjoint(d.footBox, d.slotBox, BOX_CLEAR))
     bad(
       'foot-hits-slot',
@@ -311,4 +333,38 @@ export function linkFit(p: LinkParams): LinkFit {
     bad('foot-off-strip', "foot pocket runs off the module's solid strip", 'footW')
 
   return { fits: problems.length === 0, problems }
+}
+
+/** Project a studio design onto the joint's parameter surface — the bridge that
+ *  makes `linkFit` a guard on the ACTUAL abacus rather than on a fixture with
+ *  its own numbers.
+ *
+ *  The envelope (height, pitch, station depth) comes from the design's derived
+ *  chain, so it tracks size and the modular floors; the joint's own proportions
+ *  come from the `link_*` params. Foot placement mirrors the scad's
+ *  `link_foot_y()` — measured off the slot's FAR edge, which is `slot` past the
+ *  tongue, and NOT off the barb on its near side, which would put the pocket
+ *  through the slot it is supposed to clear. */
+export const linkParamsOf = (p: Params): LinkParams => {
+  const d = derived(p)
+  return {
+    ...defaultLinkParams,
+    h: p.frame_h * p.scale_factor,
+    pitch: d.sCp,
+    // the solid end strip: border band + shelf — the scad's strip_y
+    station: borderEff(p) * p.scale_factor + d.sShelf,
+    fit: p.link_fit,
+    relief: p.link_relief,
+    rampDeg: p.link_ramp,
+    bump: p.link_bump,
+    slot: p.link_slot_w,
+    footW: p.link_foot_w,
+    footX: d.sCp / 2,
+    footY:
+      defaultLinkParams.beamY0 +
+      defaultLinkParams.beamT +
+      p.link_slot_w +
+      BOX_CLEAR +
+      p.link_foot_w / 2,
+  }
 }

--- a/apps/web/src/components/create/abacus/abacus-model.ts
+++ b/apps/web/src/components/create/abacus/abacus-model.ts
@@ -110,6 +110,27 @@ export const defaultParams = {
   feet_span: 110, // max unsupported bottom run (mm @ scale 1) before mid feet
   feet_proud: 1.6, // printed: stand-off below the bottom face (absolute mm)
   feet_retention: 'crossbar',
+  // modular columns — the AbacusLink prototype (docs/abacus-studio/
+  // modular-columns-spec.md). 'mono' is the shipped one-piece abacus and every
+  // derivation below reduces to its pre-modular form under it.
+  //
+  // 'modular' raises TWO DIMENSION FLOORS and nothing else in this revision: the
+  // seam splits the inter-channel web down its middle (so each module keeps half
+  // of it, and half of 2.5 is thinner than a printable wall), and the end strips
+  // have to hold a latch tongue AND a foot pocket, which don't fit in the mono
+  // border's 13 mm strip. The assembled abacus is still ONE solid — only the
+  // link_coupon / link_column part passes emit modular geometry. See the scad's
+  // note on analyzeShells for why the topology change waits.
+  link_mode: 'mono',
+  link_web: 4.5, // modular floor on `web` — 2.25 mm of wall per module
+  link_border: 7.0, // modular floor on `border_w` — a 14.75 mm strip
+  link_ramp: 8, // cam ramp °, off the tongue's travel; self-locking under ~16.7
+  link_fit: 0.1, // per-face chevron groove clearance
+  link_relief: 0.25, // flat-face standoff — the chevron flanks are the only contact
+  link_bump: 1.1, // barb height = cam travel = the spread the joint can swallow
+  link_slot_w: 1.4, // spring room past the tongue; must exceed link_bump
+  link_foot_w: 6.35, // 1/4" bumper — the largest that clears the latch slot
+  link_foot_d: 1.2,
   // toggles / quality
   show_frame: true,
   show_beads: true,
@@ -251,18 +272,28 @@ export type Derived = {
   frameW: number
   outerD: number
 }
+/** The modular dimension floors, mirroring the scad's `web_eff`/`border_w_eff`.
+ *  `max` not assignment: a design that already asked for a fatter web or a wider
+ *  brim keeps it — the floor raises, never lowers. Exported because the studio
+ *  rail quotes the before/after size, and computing that a second time in the UI
+ *  is how the readout and the geometry drift apart. */
+export const isModular = (p: Params): boolean => p.link_mode === 'modular'
+export const webEff = (p: Params): number => (isModular(p) ? Math.max(p.web, p.link_web) : p.web)
+export const borderEff = (p: Params): number =>
+  isModular(p) ? Math.max(p.border_w, p.link_border) : p.border_w
+
 export const derived = (p: Params): Derived => {
   const S = p.scale_factor
   const cl = p.clearance
   const sBd = p.bead_dia * S
   const sBl = p.bead_len * S
-  const sBw = p.border_w * S
+  const sBw = borderEff(p) * S
   const sFh = p.frame_h * S
   const sCr = p.corner_r * S
   const chamf = Math.min(p.top_chamfer, sFh * 0.4)
   const mkI = Math.max(0, chamf, sCr <= 0 ? 0 : sCr - (sCr - chamf) / Math.SQRT2 - p.marker_mm / 9)
   const sShelf = Math.max(p.shelf * S, mkI + p.marker_mm - sBw)
-  const sCp = sBd + 2 * cl + p.web * S
+  const sCp = sBd + 2 * cl + webEff(p) * S
   const sEm = sShelf + cl + sBd / 2
   const sEp = sBl + p.print_gap
   const sElo = sShelf + cl + sBl / 2
@@ -331,6 +362,21 @@ export const DEFINE_KEYS: (keyof Params)[] = [
   'feet_span',
   'feet_proud',
   'feet_retention',
+  // The scad owns the modular floors and the joint's envelope; the joint's own
+  // proportions (tooth depth, tongue length, barb setback) live in
+  // abacus-link.scad as library constants and are deliberately NOT defines —
+  // they are the interface, and an interface a caller can vary per render is not
+  // one anybody can print a matching column against.
+  'link_mode',
+  'link_web',
+  'link_border',
+  'link_ramp',
+  'link_fit',
+  'link_relief',
+  'link_bump',
+  'link_slot_w',
+  'link_foot_w',
+  'link_foot_d',
   'show_frame',
   'show_beads',
   'show_markers',
@@ -357,6 +403,37 @@ export const definesFrom = (p: Params): string[] => [
   // with nothing to catch it (see textSlots).
   ...textSlots(p).map((toks, i) => `-D${TEXT_SLOT_DEFINES[i]}=${JSON.stringify(toks)}`),
 ]
+
+/** Defines that can only ever change a PART PASS, never the assembled abacus.
+ *  They still ride every render — the part passes need them, and a define the
+ *  worker never sees is one the scad silently defaults — but they are excluded
+ *  from the preview's dedup key below.
+ *
+ *  Without this, dragging the joint's cam-ramp slider re-solves the whole abacus
+ *  on every step, for a model the knob provably cannot touch. The joint's
+ *  ENVELOPE knobs (`link_mode`, `link_web`, `link_border`) are deliberately NOT
+ *  in this list — those move the assembled abacus's own width and depth. */
+export const PART_ONLY_DEFINE_KEYS: readonly (keyof Params)[] = [
+  'link_ramp',
+  'link_fit',
+  'link_relief',
+  'link_bump',
+  'link_slot_w',
+  'link_foot_w',
+  'link_foot_d',
+]
+
+/** The dedup key the preview pump compares renders on. Same rule the color and
+ *  filament knobs already follow (JS-only, never reach the scad, never re-solve):
+ *  a knob that cannot change THIS render shouldn't force it. Lives here rather
+ *  than in the hook so the "what actually moves the assembled geometry"
+ *  judgement sits next to the params it is about. */
+export const previewDedupKey = (p: Params): string => {
+  const skip = new Set<string>(PART_ONLY_DEFINE_KEYS.map((k) => `-D${k}`))
+  return definesFrom(p)
+    .filter((d) => !skip.has(d.slice(0, d.indexOf('='))))
+    .join('')
+}
 
 /** One export render request: the whole abacus (no pass) or a single `only=`
  *  part pass. The marker passes render JUST the four corner plugs, and
@@ -388,6 +465,17 @@ export const INSPECT_PARTS = [
   'bead_exposed',
   'channel',
   'frame',
+  // The AbacusLink prototype slices. Inspection parts, but print-READY ones:
+  // each emits two pieces in print pose, because what they test is the seam
+  // between them. `link_coupon` is the joint alone (fast, fails fast on the cam
+  // latch); `link_column` is two real column modules with their captive beads,
+  // which is what answers whether halving the web disturbed capture.
+  //
+  // Both force the modular dimension floors on regardless of `link_mode` — a
+  // coupon cut to the mono pitch would pass its own test and tell you nothing
+  // about the abacus you'd actually print.
+  'link_coupon',
+  'link_column',
 ] as const
 export type InspectPart = (typeof INSPECT_PARTS)[number]
 
@@ -677,9 +765,9 @@ export function analyzeShells(positions: ArrayLike<number>, p: Params): ShellAna
 
   // border offset: the bead field sits at (border_w, border_w) inside the outer rect
   const d = derived(p)
-  const s_em = p.border_w * p.scale_factor + d.sEm
+  const s_em = borderEff(p) * p.scale_factor + d.sEm
   const s_cp = d.sCp
-  const s_hy = p.border_w * p.scale_factor + d.sHy
+  const s_hy = borderEff(p) * p.scale_factor + d.sHy
   const s_ep = d.sEp
   let frameSi = -1
   let frameSpan = 2 * s_cp // a shell must beat >1 column pitch to be the frame
@@ -1224,7 +1312,7 @@ export function feetEffective(p: Params): FeetEffective {
  *  it open. Only the first branch answers to the brim. */
 export const borderStrip = (p: Params): number => {
   const d = derived(p)
-  return Math.max((p.border_w + p.shelf) * p.scale_factor, d.mkI + p.marker_mm)
+  return Math.max((borderEff(p) + p.shelf) * p.scale_factor, d.mkI + p.marker_mm)
 }
 
 export type FeetFit = {

--- a/apps/web/src/components/create/abacus/abacus-parts.stories.tsx
+++ b/apps/web/src/components/create/abacus/abacus-parts.stories.tsx
@@ -96,3 +96,37 @@ export const TextPlugs: Story = part({
 /** No `only=` at all: the full assembly the studio previews, for scale. Low $fn —
  *  this is the one render here that's genuinely expensive. */
 export const WholeAbacus: Story = part({ fn: 24 })
+
+// ── the AbacusLink prototype (docs/abacus-studio/modular-columns-spec.md) ────
+// Two slices that are inspection parts and PRINT-READY plates at once: each
+// emits two pieces in print pose, because in both cases the thing under test is
+// the seam between them. Their Download STL is the same file the studio's
+// "Modular columns (prototype)" panel hands you.
+//
+// These are also the FIRST time this geometry goes through an evaluator at all —
+// there is no headless OpenSCAD in this repo, so until one of these stories
+// renders, the joint has never been solved by a machine. Look before printing:
+// the chevron teeth should mesh, the latch tongue should stand clear of its
+// slot, and the release bore should miss the shoulder it is meant to reach past.
+//
+// Both force the modular dimension floors on regardless of `link_mode`, so what
+// you see is cut to the pitch a modular abacus would actually have.
+
+/** The joint alone, on two plain blocks of one column pitch. Fails fast — a
+ *  quarter of the column pair's print time — on the only question that has to be
+ *  answered first: does the cam actually cam, hold, and release? */
+export const LinkCoupon: Story = part({ pass: { only: 'link_coupon' } })
+
+/** …and at the far end of the sweep. Shallower cams harder and holds more,
+ *  steeper swallows more of whatever the printer got wrong; §9 of the spec puts
+ *  8°/12°/16° on one plate. Every rung is a legal geometry, so the sweep is a
+ *  define change and nothing else. */
+export const LinkCouponSteepRamp: Story = part({
+  pass: { only: 'link_coupon' },
+  params: { link_ramp: 16 } satisfies Partial<Params>,
+})
+
+/** Two REAL column modules, each with its own captive beads. This is the one
+ *  that answers whether halving the web disturbed capture — which you cannot see
+ *  without the beads, and cannot see on the coupon at all. */
+export const LinkColumnPair: Story = part({ pass: { only: 'link_column' }, fn: 32 })

--- a/apps/web/src/components/create/abacus/abacus-solver.ts
+++ b/apps/web/src/components/create/abacus/abacus-solver.ts
@@ -28,7 +28,7 @@
 // a verdict + reasons, never mutated params — size stays a deliberate fabrication
 // choice; the UI (S3) turns each reason's `fix` into a one-click action.
 
-import { anyTokens, type Params } from './abacus-model'
+import { anyTokens, isModular, type Params, webEff } from './abacus-model'
 
 // ---- printer profile --------------------------------------------------------
 // A small static tolerance table. `nozzleMm`/`layerMm` are informational (shown
@@ -83,8 +83,9 @@ export const PRINTER_PROFILES: readonly PrinterProfile[] = [
 ]
 
 export const DEFAULT_PROFILE_ID = 'fdm-0.4'
-export const DEFAULT_PROFILE: PrinterProfile =
-  PRINTER_PROFILES.find((p) => p.id === DEFAULT_PROFILE_ID) as PrinterProfile
+export const DEFAULT_PROFILE: PrinterProfile = PRINTER_PROFILES.find(
+  (p) => p.id === DEFAULT_PROFILE_ID
+) as PrinterProfile
 
 // Resolve a profile id to its profile, falling back to the default for an
 // unknown id (e.g. a stale `profileId` deserialized from an old saved design).
@@ -138,8 +139,7 @@ const EPS = 1e-9
 
 // Smallest scale_factor at which `knob * S >= floor`, rounded UP to 4 decimals so
 // the returned value comfortably clears the floor (never lands just under it).
-const clearsAtScale = (knob: number, floor: number): number =>
-  Math.ceil((floor / knob) * 1e4) / 1e4
+const clearsAtScale = (knob: number, floor: number): number => Math.ceil((floor / knob) * 1e4) / 1e4
 
 /**
  * Check a design against a printer profile. Pure: no I/O, no mutation. Returns a
@@ -166,17 +166,28 @@ export function solve(p: Params, profile: PrinterProfile): SolveResult {
   }
 
   // 2. channel wall (`web`) — proportional.
-  const wall = p.web * S
+  //
+  // In MODULAR mode the seam runs down the middle of the web, so each module
+  // keeps only half of it and the wall that has to survive the printer is that
+  // half — never the nominal web. This is what gives modular mode a size floor
+  // the monolith doesn't have (the joint's own proportions are absolute, the
+  // frame around them scales), and it is the same shape as the feet_crossbar
+  // degrade. Mirrors the scad's `web_eff * S / (modular ? 2 : 1)` assert.
+  const halves = isModular(p) ? 2 : 1
+  const wallKnob = webEff(p) / halves
+  const wall = wallKnob * S
   if (wall < profile.minWallMm - EPS) {
     reasons.push({
       dim: 'wall',
       severity: 'error',
-      label: 'channel wall',
+      label: isModular(p) ? 'channel wall (half-web)' : 'channel wall',
       measuredMm: wall,
       floorMm: profile.minWallMm,
-      message: `Channel wall ${wall.toFixed(2)} mm is below the ${profile.label} floor of ${profile.minWallMm.toFixed(2)} mm — walls between columns would be too thin to print.`,
-      fix: `Print larger (≈${clearsAtScale(p.web, profile.minWallMm)}× or more), or raise the wall knob.`,
-      suggestedScale: clearsAtScale(p.web, profile.minWallMm),
+      message: isModular(p)
+        ? `Each module's channel wall is ${wall.toFixed(2)} mm — half the ${(webEff(p) * S).toFixed(2)} mm web, because the seam splits it — and that is below the ${profile.label} floor of ${profile.minWallMm.toFixed(2)} mm.`
+        : `Channel wall ${wall.toFixed(2)} mm is below the ${profile.label} floor of ${profile.minWallMm.toFixed(2)} mm — walls between columns would be too thin to print.`,
+      fix: `Print larger (≈${clearsAtScale(wallKnob, profile.minWallMm)}× or more), or raise the wall knob.`,
+      suggestedScale: clearsAtScale(wallKnob, profile.minWallMm),
     })
   }
 

--- a/apps/web/src/components/create/abacus/useAbacusScad.ts
+++ b/apps/web/src/components/create/abacus/useAbacusScad.ts
@@ -22,13 +22,29 @@
 // OpenSCAD (that was the dead feature's fatal flaw); this is client WASM only.
 
 import { useEffect, useRef } from 'react'
-import { anyTokens, definesFrom, exportDefines, type Params, type RenderPass } from './abacus-model'
+import {
+  anyTokens,
+  definesFrom,
+  exportDefines,
+  type Params,
+  previewDedupKey,
+  type RenderPass,
+} from './abacus-model'
 
 const WORKER_URL = '/openscad/scad-worker.js'
-const SCAD_URL = '/scad/abacus.scad'
+// The entry, then its library. `abacus.scad` does `include <abacus-link.scad>`
+// for the modular-column joint, and `include` resolves against the entry's
+// directory — so both have to be in MEMFS, at these exact paths, or a modular
+// render dies with a file-not-found from inside the WASM engine. The public URLs
+// double as the absolute MEMFS paths (same trick the fonts use).
+const SCAD_URLS = ['/scad/abacus.scad', '/scad/abacus-link.scad'] as const
+const SCAD_ENTRY = '/abacus.scad'
 const FONT_URLS = ['/fonts/DejaVuSans-Bold.ttf', '/fonts/NotoEmoji-Regular.ttf'] as const
 
-const mainKeyOf = (p: Params): string => `${definesFrom(p).join('')}${p.fn}`
+// Part-pass-only defines are excluded (see previewDedupKey) — they ride every
+// render but cannot change THIS one, so keying on them would re-solve the whole
+// abacus every time somebody nudged a joint knob.
+const mainKeyOf = (p: Params): string => `${previewDedupKey(p)}${p.fn}`
 
 export type MainResult = { stl: ArrayBuffer; ms: number; id: number }
 export type StatusUpdate = { text: string; error?: boolean }
@@ -65,6 +81,30 @@ type Pump = {
   reqId: number // positive, pump-owned; export one-shots use negative ids
   pending: { id: number; key: string } | null
 }
+type ScadState = {
+  /** MEMFS path → source, for every .scad the entry needs (entry + libraries) */
+  scads: Record<string, string>
+  fonts: Record<string, Uint8Array>
+  loaded: boolean
+  worker: Worker | null
+  plugWorker: Worker | null
+  main: Pump
+  plug: Pump
+  nextExportId: number
+  pumpMain?: () => void
+  pumpPlug?: () => void
+}
+
+/** The MEMFS image every render is handed: every .scad source plus the fonts.
+ *  Module-scope and shared by all four post sites (two pumps, two export paths)
+ *  because it used to be inlined twice — and the day a second .scad appeared,
+ *  the copy inside `exportStl` would have silently kept shipping only the entry,
+ *  so previews would render a modular design and exports would fail on it. */
+const renderFiles = (st: ScadState): Record<string, string | Uint8Array> => ({
+  ...st.scads,
+  ...st.fonts,
+})
+
 const newPump = (): Pump => ({
   latest: null,
   latestKey: '',
@@ -79,19 +119,8 @@ export function useAbacusScad(args: UseAbacusScadArgs): UseAbacusScad {
   const cbRef = useRef(args)
   cbRef.current = args
 
-  const stateRef = useRef<{
-    scad: string
-    fonts: Record<string, Uint8Array>
-    loaded: boolean
-    worker: Worker | null
-    plugWorker: Worker | null
-    main: Pump
-    plug: Pump
-    nextExportId: number
-    pumpMain?: () => void
-    pumpPlug?: () => void
-  }>({
-    scad: '',
+  const stateRef = useRef<ScadState>({
+    scads: {},
     fonts: {},
     loaded: false,
     worker: null,
@@ -107,7 +136,6 @@ export function useAbacusScad(args: UseAbacusScadArgs): UseAbacusScad {
   useEffect(() => {
     const st = stateRef.current
     let disposed = false
-    const renderFiles = () => ({ '/abacus.scad': st.scad, ...st.fonts })
 
     // ---- main geometry pump --------------------------------------------------
     function pumpMain() {
@@ -119,8 +147,8 @@ export function useAbacusScad(args: UseAbacusScadArgs): UseAbacusScad {
       cbRef.current.onStatus?.({ text: `rendering #${id}…` })
       st.worker?.postMessage({
         id,
-        entry: '/abacus.scad',
-        files: renderFiles(),
+        entry: SCAD_ENTRY,
+        files: renderFiles(st),
         defines: definesFrom(m.latest),
         fn: m.latest.fn,
       })
@@ -135,8 +163,8 @@ export function useAbacusScad(args: UseAbacusScadArgs): UseAbacusScad {
       pl.pending = { id, key: pl.latestKey }
       st.plugWorker?.postMessage({
         id,
-        entry: '/abacus.scad',
-        files: renderFiles(),
+        entry: SCAD_ENTRY,
+        files: renderFiles(st),
         // No -Dplug_group here on purpose: the preview wants ONE mesh carrying
         // every token (it tints per-triangle in JS), which is exactly the scad's
         // plug_group = −1 default. Only the export splits the soup per color
@@ -184,17 +212,21 @@ export function useAbacusScad(args: UseAbacusScadArgs): UseAbacusScad {
       pumpPlug()
     }
 
-    // ---- one-time load of the scad source + fonts ----------------------------
+    // ---- one-time load of the scad sources + fonts ---------------------------
     ;(async () => {
       cbRef.current.onStatus?.({ text: 'loading abacus.scad + fonts…' })
       try {
-        const [scad, ...fontBufs] = await Promise.all([
-          fetch(SCAD_URL).then((r) => r.text()),
-          ...FONT_URLS.map((u) => fetch(u).then((r) => r.arrayBuffer())),
+        const [scadTexts, fontBufs] = await Promise.all([
+          Promise.all(SCAD_URLS.map((u) => fetch(u).then((r) => r.text()))),
+          Promise.all(FONT_URLS.map((u) => fetch(u).then((r) => r.arrayBuffer()))),
         ])
         if (disposed) return
-        st.scad = scad
-        // the public URLs (/fonts/…) double as the absolute MEMFS paths
+        // the public URLs (/scad/…, /fonts/…) double as the absolute MEMFS paths
+        // — except the .scad basenames, which have to sit at the FS ROOT so the
+        // entry's `include <abacus-link.scad>` resolves beside it.
+        SCAD_URLS.forEach((u, i) => {
+          st.scads[`/${u.split('/').pop()}`] = scadTexts[i]
+        })
         FONT_URLS.forEach((u, i) => {
           st.fonts[u] = new Uint8Array(fontBufs[i])
         })
@@ -265,8 +297,8 @@ export function useAbacusScad(args: UseAbacusScadArgs): UseAbacusScad {
       // never settles — callers that outlive the viewer must race a timeout.
       worker.postMessage({
         id,
-        entry: '/abacus.scad',
-        files: { '/abacus.scad': st.scad, ...st.fonts },
+        entry: SCAD_ENTRY,
+        files: renderFiles(st),
         defines: exportDefines(params, pass),
         fn,
       })


### PR DESCRIPTION
## Summary

Introduces the AbacusLink modular-column joint system as a design prototype. This allows an abacus to be assembled from individual column modules that snap together via a chevron-and-cam-latch interface, rather than as a single monolithic piece. The prototype is feature-flagged (`abacus.modular_columns`) and disabled by default.

## Key Changes

- **Specification document** (`modular-columns-spec.md`): Comprehensive 565-line design spec covering the joint's structural analysis, load cases, geometry, and manufacturing constraints. Documents why the joint must be a closed, preloaded butt joint with a chevron for Z-registration and a cam latch for X-preload.

- **OpenSCAD geometry** (`abacus-link.scad`): Library file (included by `abacus.scad`) that defines the joint geometry—chevron ridges/grooves and cantilever cam latches—all printable flat with no supports. Includes parametric modules and assertion guards for silent-failure modes (relief too small, foot pocket overlap).

- **TypeScript mirror** (`abacus-link.ts`): Mirrors the joint's derived chain and fit guards from the scad, running them against actual designs rather than coupon defaults. Includes mechanics calculations (beam stiffness, clamp force, self-locking verification) and hinge-droop analysis showing why latch slop must be zero.

- **Studio UI** (`ModularColumnsPanel.tsx`): New right-rail panel behind the feature flag. Toggles modular mode, displays size delta (192.5 × 100.5 mm → 220.0 × 104.0 mm at 13 columns), shows fit verdict, and provides two print-ready plate downloads (joint coupon and column pair).

- **Test suite** (`abacus-link.test.ts`): 242 lines covering the two silent-failure guards (relief seating, foot-slot overlap), loud validation failures, mechanics calculations, and hinge-droop predictions.

- **Model integration** (`abacus-model.ts`): Adds 11 new knobs for the joint (ramp angle, fit clearance, relief, bump height, slot width, foot dimensions) and two dimension floors (`link_web`, `link_border`) that raise when modular mode is active.

- **Scad integration** (`abacus.scad`): Adds `link_mode` knob and modular dimension floors. Introduces `link_coupon` and `link_column` part passes for inspection/print-ready plates. Geometry remains byte-stable in mono mode.

- **Worker/viewer updates**: Loads both `abacus.scad` and `abacus-link.scad` into MEMFS so the `include` directive resolves correctly. Adds dedup key logic to exclude part-pass-only defines from preview caching.

- **Storybook** (`abacus-parts.stories.tsx`): Adds stories for the two modular inspection plates.

## Notable Implementation Details

- **Silent-failure guards**: Two failure modes (relief too small, foot overlap) render and print successfully but break functionality silently. Both are caught by arithmetic comparisons in the TS mirror, not by scad asserts.

- **Dimension floors, not assignments**: Modular mode raises `web` and `border_w` via `max()`, so designs that already requested fatter geometry keep it. The floor only applies when needed.

- **Part-pass dedup**: Joint knobs are excluded from the preview cache key (`previewDedupKey`) because they only affect part passes, not the main assembly render. This prevents unnecessary re-solves when sweeping joint parameters.

- **Chevron self-centering**: The two-tooth chevron is self-centering in Z by construction—modules cannot assemble out of step. This guarantees ArUco marker coplanarity without tolerance.

- **Cam ramp self-locking**: The 8° ramp angle is below the friction angle (~16.7°), so the joint cannot be backed out by load—only released by pushing the spring. Prevents accidental disassembly.

- **Assembled clearance is zero**: The cam latch drives the seam shut via flexure travel, consuming manufacturing spread

https://claude.ai/code/session_0133ftDCkp8vyuaGfFqJYL9M