### PR TITLE
One-click print for the modular column kit

### DIFF
--- a/apps/web/src/components/create/abacus/FabricationRail.tsx
+++ b/apps/web/src/components/create/abacus/FabricationRail.tsx
@@ -14,7 +14,7 @@
 // the store's live filamentMap/catalog. `exporterReady` gates the buttons while
 // the viewer chunk is still loading.
 
-import { type CSSProperties, useState } from 'react'
+import { type CSSProperties, useMemo, useState } from 'react'
 import { StudioSelect } from '@/components/studio/StudioSelect'
 import { useFeatureFlag } from '@/hooks/useFeatureFlag'
 import { useAbacusStudio } from './AbacusStudioContext'
@@ -64,6 +64,7 @@ export function FabricationRail() {
     clearanceFix,
     requestExportStl,
     requestExportParts,
+    requestExportModuleParts,
     exporterReady,
     setRevealIntrinsic,
     setHighlightRole,
@@ -75,11 +76,17 @@ export function FabricationRail() {
 
   // Modular columns (Gitea #30): the whole-abacus exports are a footgun in
   // modular mode — they'd print a fused-seam monolith with dead sockets — so
-  // they lock with a pointer at the kit, and the print-service panel yields to
-  // a note (module tickets are deferred; the kit download is the export).
+  // they lock with a pointer at the kit. The print-service panel does NOT lock:
+  // it switches to the kit (Gitea #32), packing every module onto one bed and
+  // submitting that plate, and refuses to the kit-zip download only when the
+  // modules genuinely don't fit one plate.
   const modularFlag = useFeatureFlag(MODULAR_COLUMNS_FLAG)
   const modular = isModular(params)
   const canExportMono = canExport && !modular
+
+  // Rebuilt only when the requestor identity changes, so the panel's submit
+  // mutation isn't handed a fresh object every render.
+  const kitPrint = useMemo(() => ({ requestExportModuleParts }), [requestExportModuleParts])
 
   // A failed export render (e.g. a marker part pass) now REJECTS instead of
   // hanging — surfaced inline under the button. Silently swallowing it would
@@ -333,50 +340,35 @@ export function FabricationRail() {
       )}
 
       {/* print-service panel (Gitea #9) — embedded (normal flow) in the rail.
-          In modular mode it yields to a note: a service ticket sends the
-          one-piece abacus, and per-module tickets are deferred (phase 1 —
-          the kit download is the modular export). */}
-      {modular ? (
-        <div
-          data-element="abacus-studio-print-modular-note"
-          style={{
-            padding: '8px 10px',
-            borderRadius: 8,
-            background: 'rgba(30,41,59,0.6)',
-            border: '1px solid rgba(148,163,184,0.25)',
-            color: 'rgba(148,163,184,0.9)',
-            fontSize: 11,
-            lineHeight: 1.5,
-          }}
-        >
-          Print-service tickets for module kits aren&apos;t wired yet — download the kit above and
-          slice it yourself.
-        </div>
-      ) : (
-        <PrintPanel
-          embedded
-          visible={true}
-          params={params}
-          filamentMap={filamentMap}
-          catalog={catalog}
-          overrides={overrides}
-          profileId={profileId}
-          printerId={thhFilaments.printerId}
-          printerMultiMaterial={thhFilaments.printerMultiMaterial}
-          printerBed={thhFilaments.printerBed}
-          wipeTower={thhFilaments.wipeTower}
-          amsPresent={thhFilaments.amsPresent}
-          externalUnprintable={thhFilaments.externalUnprintable}
-          rosterEmpty={thhFilaments.rosterEmpty}
-          isLoading={thhFilaments.isLoading}
-          isFetching={thhFilaments.isFetching}
-          connectionId={selectedConnectionId}
-          unavailable={thhFilaments.unavailable}
-          exportBlocked={exportBlocked}
-          requestExportParts={requestExportParts}
-          playerId={playerId}
-        />
-      )}
+          One panel, two shapes of print: in modular mode `kit` switches the
+          submit onto the packed module plate (Gitea #32) instead of the
+          one-piece abacus, which in modular mode would be the same footgun the
+          whole-abacus download buttons are. Everything else — settings, jobs,
+          filament roster — is the same abacus and is shared verbatim. */}
+      <PrintPanel
+        embedded
+        visible={true}
+        params={params}
+        filamentMap={filamentMap}
+        catalog={catalog}
+        overrides={overrides}
+        profileId={profileId}
+        printerId={thhFilaments.printerId}
+        printerMultiMaterial={thhFilaments.printerMultiMaterial}
+        printerBed={thhFilaments.printerBed}
+        wipeTower={thhFilaments.wipeTower}
+        amsPresent={thhFilaments.amsPresent}
+        externalUnprintable={thhFilaments.externalUnprintable}
+        rosterEmpty={thhFilaments.rosterEmpty}
+        isLoading={thhFilaments.isLoading}
+        isFetching={thhFilaments.isFetching}
+        connectionId={selectedConnectionId}
+        unavailable={thhFilaments.unavailable}
+        exportBlocked={exportBlocked}
+        requestExportParts={requestExportParts}
+        playerId={playerId}
+        kit={modular ? kitPrint : undefined}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/create/abacus/PrintPanel.tsx
+++ b/apps/web/src/components/create/abacus/PrintPanel.tsx
@@ -45,9 +45,11 @@ import type {
 } from '@/lib/abacus/print/filament-wire'
 import { api } from '@/lib/queryClient'
 import { abacusPrintKeys } from '@/lib/queryKeys'
-import { type AbacusExportParts, buildAbacusThreeMf } from './abacus-3mf'
+import { type AbacusExportParts, bedSizeFromThh, buildAbacusThreeMf } from './abacus-3mf'
 import { type FilamentCatalog, spoolSupportKind } from './abacus-catalog'
+import { buildKitPlateThreeMf, KitPlateFitError, kitPlateSignature } from './abacus-kit-plate'
 import type { FilamentMap, Params } from './abacus-model'
+import type { ModuleExportParts } from './abacus-module-kit'
 import {
   abacusPrintPanelState,
   designSlotIds,
@@ -129,6 +131,18 @@ export interface PrintPanelProps {
    *  rides the authoring hand-off so the job's edit link reopens the studio on
    *  the same student (things-haunt-house#408). */
   playerId?: string | null
+  /** Present in modular mode (Gitea #30/#32): the design prints as a KIT — every
+   *  column module packed onto one bed — instead of the one-piece abacus, so the
+   *  submit renders the module bundle and packs it. Absent = the mono print.
+   *  Everything downstream (ticket, idempotency, jobs, settings) is shared: a
+   *  kit's filament slots are the same abacus's slots. */
+  kit?: AbacusKitPrint
+}
+
+export interface AbacusKitPrint {
+  /** The modular counterpart to `requestExportParts` — one snapshot, every
+   *  module pass (the same bundle the kit zip download builds from). */
+  requestExportModuleParts: () => Promise<ModuleExportParts>
 }
 
 /** How long the export render may take before the submit gives up. */
@@ -196,6 +210,7 @@ export function PrintPanel(props: PrintPanelProps) {
     exportBlocked,
     requestExportParts,
     playerId = null,
+    kit,
   } = props
 
   // Which body state to render — the pure decision lives in `abacusPrintPanelState`
@@ -405,52 +420,67 @@ export function PrintPanel(props: PrintPanelProps) {
       // restorable intent (params + pins + profile); the AMS projection
       // (filamentMap/slotLabels) rides as provenance only.
       const slotLabels = catalog.spools.map((s) => s.name)
-      const [parts, designId] = await Promise.all([
+      const bed = bedSizeFromThh(printerBed)
+      // Started here, awaited below, so it overlaps the render. It's bounded and
+      // TOTAL — null on any failure — so a dead snapshot API costs the job its
+      // deep edit link, never the print. The envelope is the restorable intent
+      // (params + pins + profile); the AMS projection (filamentMap/slotLabels)
+      // rides as provenance only.
+      const snapshot = persistAbacusDesign(
+        { v: 1, params, overrides, profileId },
+        { filamentMap, slotLabels }
+      )
+      // The race covers the whole bundle (every part pass) — the bundle promise
+      // resolves only after all renders land. The 3MF builds from the bundle's own
+      // params snapshot; the ticket/idempotency below keep using the live `params`
+      // prop (they describe submit intent, and any divergence requires editing the
+      // design inside the render window).
+      const raceRender = <T,>(bundle: Promise<T>): Promise<T> =>
         Promise.race([
-          requestExportParts(),
+          bundle,
           new Promise<never>((_, reject) =>
             setTimeout(
               () => reject(new Error("The 3D render didn't finish — try again")),
               EXPORT_TIMEOUT_MS
             )
           ),
-        ]),
-        persistAbacusDesign({ v: 1, params, overrides, profileId }, { filamentMap, slotLabels }),
-      ])
+        ])
+
       // Supports push the first layer past the model outline, eating into the 6 mm the
       // tower was pinned at — the best available reading of prod's exit 155 on
       // 2026-07-29 (a later A/B slices 6 mm clean, so treat the wider gap as margin,
       // not a proven cure). The style's `enable_support`, not the design's feet
       // setting, is the print's real source of truth, so the gap keys off the style.
-      const model = buildAbacusThreeMf({
-        ...parts,
-        filamentMap,
-        slotLabels,
-        supportsAtSlice: supportsWanted,
-        bed: printerBed
-          ? {
-              wMm: printerBed.sizeMm.x,
-              dMm: printerBed.sizeMm.y,
-              exclude: (printerBed.exclusionsMm ?? []).flatMap((zone) => {
-                if (zone.pointsMm.length === 0) return []
-                const xs = zone.pointsMm.map((point) => point[0])
-                const ys = zone.pointsMm.map((point) => point[1])
-                const x0 = Math.min(...xs)
-                const y0 = Math.min(...ys)
-                return [
-                  {
-                    xMm: x0,
-                    yMm: y0,
-                    wMm: Math.max(...xs) - x0,
-                    dMm: Math.max(...ys) - y0,
-                  },
-                ]
-              }),
-            }
-          : undefined,
-        wipeTower: wipeTower ?? undefined,
-      })
+      //
+      // Two shapes of print, one tail: a KIT packs every column module onto a
+      // single bed around the reserved tower (Gitea #32) and throws
+      // KitPlateFitError when they won't fit; the mono path emits the one-piece
+      // abacus. Both hand back the same {bytes, bodies, wipeTower}, so the
+      // ticket, idempotency, upload and job plumbing below are shared verbatim —
+      // a kit's filament slots ARE the mono print's slots, same abacus.
+      const model = kit
+        ? buildKitPlateThreeMf({
+            parts: await raceRender(kit.requestExportModuleParts()),
+            filamentMap,
+            slotLabels,
+            supportsAtSlice: supportsWanted,
+            bed,
+            wipeTower: wipeTower ?? undefined,
+          })
+        : buildAbacusThreeMf({
+            ...(await raceRender(requestExportParts())),
+            filamentMap,
+            slotLabels,
+            supportsAtSlice: supportsWanted,
+            bed,
+            wipeTower: wipeTower ?? undefined,
+          })
+      const designId = await snapshot
 
+      // A packed kit plate carries its arrangement into the key: everything else
+      // in the signature DERIVES the layout, so a packer change is the one way
+      // two submits differ with no user-visible input moving. See kitPlateSignature.
+      const kitLayout = 'placements' in model ? kitPlateSignature(model) : undefined
       // Reuse the key only for an identical resubmit; any edit rotates it.
       const idem = resolveIdempotencyKey(
         idemRef.current,
@@ -463,27 +493,36 @@ export function PrintPanel(props: PrintPanelProps) {
           supportInterfaceSlotId: supportPick,
           printerBed,
           wipeTower,
+          kitLayout,
         }),
         () => crypto.randomUUID()
       )
       idemRef.current = idem
+      // A kit is named for what lands on the bed — the operator reading the job
+      // list sees N loose modules to assemble, not one finished abacus.
+      const label = kit ? `${params.cols}-column abacus kit` : `${params.cols}-column abacus`
       const baseTicket = buildAbacusTicket({
-        name: `Abacus — ${params.cols} columns`,
+        name: kit ? `Abacus kit — ${params.cols} columns` : `Abacus — ${params.cols} columns`,
         // With a persisted snapshot the artifact IS the design row (abaci#22);
-        // a failed persist degrades to the pre-#22 shallow provenance.
+        // a failed persist degrades to the pre-#22 shallow provenance. The kit
+        // suffix keeps the two OUTPUTS of one design row distinguishable — the
+        // same design prints as a one-piece abacus or as a module kit, and a
+        // job pointing at "the design" alone couldn't say which shipped.
         source: designId
           ? {
-              artifactId: `design-${designId}`,
+              artifactId: kit ? `design-${designId}-kit` : `design-${designId}`,
               artifactUrl: `${window.location.origin}${studioHref('/create/abacus', {
                 playerId: null,
                 designId,
               })}`,
-              label: `${params.cols}-column abacus`,
+              label,
             }
           : {
-              artifactId: `abacus-${params.cols}col-x${params.scale_factor}`,
+              artifactId: kit
+                ? `abacus-kit-${params.cols}col-x${params.scale_factor}`
+                : `abacus-${params.cols}col-x${params.scale_factor}`,
               artifactUrl: `${window.location.origin}/create/abacus`,
-              label: `${params.cols}-column abacus`,
+              label,
             },
         bodies: model.bodies,
         catalog,
@@ -511,9 +550,11 @@ export function PrintPanel(props: PrintPanelProps) {
       const form = new FormData()
       form.set(
         'model',
-        new File([model.bytes as BlobPart], abacusModelFileName(params.cols, idem.sig), {
-          type: 'model/3mf',
-        })
+        new File(
+          [model.bytes as BlobPart],
+          abacusModelFileName(params.cols, idem.sig, kit ? 'kit' : 'abacus'),
+          { type: 'model/3mf' }
+        )
       )
       form.set('job', JSON.stringify(ticket))
       const cq = connectionId ? `?connectionId=${encodeURIComponent(connectionId)}` : ''
@@ -531,7 +572,24 @@ export function PrintPanel(props: PrintPanelProps) {
     },
   })
 
-  const submitFailure = submit.error instanceof PrintServiceError ? submit.error.failure : null
+  // Two kinds of "no": the service refused the ticket, or WE refused to build a
+  // plate that can't be printed (Gitea #32 — the kit needs more than one bed).
+  // The second never leaves the browser, but it's the same shape of news to the
+  // user, so it renders through the same notice instead of a parallel one. The
+  // `kit_` code prefix keeps them apart in the DOM and in any support screenshot.
+  const submitFailure: SubmitFailure | null =
+    submit.error instanceof PrintServiceError
+      ? submit.error.failure
+      : submit.error instanceof KitPlateFitError
+        ? {
+            code: `kit_${submit.error.reason.replace(/-/g, '_')}`,
+            headline: submit.error.headline,
+            remediation: submit.error.remediation,
+            blockingJobId: null,
+            invalidTicket: null,
+            missing: [],
+          }
+        : null
   const invalidDetail = submitFailure?.invalidTicket ?? undefined
   const applied = useMemo(() => extractApplied(submit.data), [submit.data])
 
@@ -882,7 +940,11 @@ export function PrintPanel(props: PrintPanelProps) {
               cursor: submitBlocked ? 'not-allowed' : 'pointer',
             }}
           >
-            {submit.isPending ? 'Rendering & submitting…' : '🖨 Print this abacus'}
+            {submit.isPending
+              ? 'Rendering & submitting…'
+              : kit
+                ? '🖨 Print this kit'
+                : '🖨 Print this abacus'}
           </button>
 
           {submit.isSuccess && (

--- a/apps/web/src/components/create/abacus/PrintPanel.tsx
+++ b/apps/web/src/components/create/abacus/PrintPanel.tsx
@@ -458,6 +458,14 @@ export function PrintPanel(props: PrintPanelProps) {
       // abacus. Both hand back the same {bytes, bodies, wipeTower}, so the
       // ticket, idempotency, upload and job plumbing below are shared verbatim —
       // a kit's filament slots ARE the mono print's slots, same abacus.
+      //
+      // `extraFilaments` is what the ticket adds that no body carries — the routed
+      // support-interface spool. It has to reach the model builder because the tower's
+      // reservation is sized from the plate's filament COUNT (the service publishes a
+      // shallower envelope for fewer filaments), and that reservation is decided before
+      // the ticket exists. The panel withholds design slots from the pickable interface
+      // roster, so a pick is always a filament the bodies don't already carry.
+      const extraFilaments = supportPick ? 1 : 0
       const model = kit
         ? buildKitPlateThreeMf({
             parts: await raceRender(kit.requestExportModuleParts()),
@@ -466,6 +474,7 @@ export function PrintPanel(props: PrintPanelProps) {
             supportsAtSlice: supportsWanted,
             bed,
             wipeTower: wipeTower ?? undefined,
+            extraFilaments,
           })
         : buildAbacusThreeMf({
             ...(await raceRender(requestExportParts())),
@@ -474,6 +483,7 @@ export function PrintPanel(props: PrintPanelProps) {
             supportsAtSlice: supportsWanted,
             bed,
             wipeTower: wipeTower ?? undefined,
+            extraFilaments,
           })
       const designId = await snapshot
 
@@ -539,12 +549,26 @@ export function PrintPanel(props: PrintPanelProps) {
       // FINAL routed filament list (including an added support-interface spool) is inside
       // the profile's tested bound. Older/over-capacity jobs still carry the embedded pin
       // and follow THH's non-blocking legacy leg.
+      //
+      // `packedForFilaments` is the count the reservation was SIZED for, and the service
+      // rejects it outright if it disagrees with the plan it resolves. It can only ever
+      // over-count here (the ticket drops an interface entry that coincides with a model
+      // slot — unreachable through the panel, but a real branch in the builder), which
+      // means an over-reserved hole: harmless to the slice, fatal to the cross-check. So
+      // on a disagreement, drop the field rather than the whole contract — the pin still
+      // rides, and THH takes its legacy leg instead of 400ing a plate that would print.
       const ticket =
         wipeTower &&
         model.wipeTower &&
         baseTicket.filaments.length > 1 &&
         baseTicket.filaments.length <= wipeTower.maxFilaments
-          ? { ...baseTicket, wipeTower: model.wipeTower }
+          ? {
+              ...baseTicket,
+              wipeTower:
+                model.wipeTower.packedForFilaments === baseTicket.filaments.length
+                  ? model.wipeTower
+                  : { profile: model.wipeTower.profile, pinMm: model.wipeTower.pinMm },
+            }
           : baseTicket
 
       const form = new FormData()

--- a/apps/web/src/components/create/abacus/__tests__/abacus-3mf-assembly.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-3mf-assembly.test.ts
@@ -15,9 +15,11 @@ import {
   assembleAbacus3mf,
   BAMBU_256_BED,
   DEFAULT_WIPE_TOWER_PROFILE,
+  envelopeForFilaments,
   SUPPORT_TRANSITION_HEIGHT_MM,
   SUPPORT_TRANSITION_NAME,
   SUPPORT_TRANSITION_SPEED_MM_S,
+  type WipeTowerProfileGeometry,
 } from '../abacus-3mf-assembly'
 
 /** One triangle spanning [x0,x1]×[y0,y1] at z=0..2 (9 floats). */
@@ -230,7 +232,12 @@ describe('assembleAbacus3mf — support opts (printed feet, Gitea #23)', () => {
     ]
     const { wipeTower } = assembleAbacus3mf(cols3, BAMBU_256_BED, { support: true })
     expect(wipeTower.xMm).toBeCloseTo(177.25, 3)
-    expect(wipeTower.yMm).toBeCloseTo(102, 3)
+    // Centered on the model in y. Derived from the advertised envelope rather than
+    // restated as a number: the reservation's DEPTH is the service's to change (#34
+    // corrected the bound from the stale 56 to 59, and a per-filament row makes it
+    // shallower still), and a depth change is not a placement regression.
+    const e = DEFAULT_WIPE_TOWER_PROFILE.envelopeMm
+    expect(wipeTower.yMm + (e.minY + e.maxY) / 2).toBeCloseTo(128, 3)
   })
 
   it('leaves the no-support placement beside the model, not cornered', () => {
@@ -242,7 +249,7 @@ describe('assembleAbacus3mf — support opts (printed feet, Gitea #23)', () => {
     const { wipeTower } = assembleAbacus3mf(abacus, BAMBU_256_BED)
     // front gap, centered on the model in x — TOWER_GAP below the footprint
     expect(wipeTower.xMm).toBeCloseTo(97, 3)
-    expect(wipeTower.yMm).toBeCloseTo(77.75 - 6 - 56, 3)
+    expect(wipeTower.yMm).toBeCloseTo(77.75 - 6 - DEFAULT_WIPE_TOWER_PROFILE.envelopeMm.maxY, 3)
   })
 })
 
@@ -274,9 +281,10 @@ describe('assembleAbacus3mf — supportsAtSlice (supports from the ticket style)
   it('clears the support-grown footprint, with the full gap on top of the skirt', () => {
     const t = tower(assembleAbacus3mf(cols3, BAMBU_256_BED, { supportsAtSlice: true }).wipeTower)
     expect(hits(t, skirted)).toBe(false)
-    // beside the model on the roomy side, gap measured from the GROWN edge
+    // beside the model on the roomy side, gap measured from the GROWN edge, and
+    // centered on the model in the cross axis (see the note on envelope depth above)
     expect(t.x0).toBeCloseTo(167.25 + 6, 3)
-    expect(t.y0).toBeCloseTo(98, 3)
+    expect((t.y0 + t.y1) / 2).toBeCloseTo(128, 3)
     expect(t.x1).toBeLessThanOrEqual(256)
     expect(t.y1).toBeLessThanOrEqual(256)
   })
@@ -303,7 +311,76 @@ describe('assembleAbacus3mf — supportsAtSlice (supports from the ticket style)
     // fails to declare that supports will be on.
     const t = tower(assembleAbacus3mf(cols3, BAMBU_256_BED).wipeTower)
     expect(t.x0).toBeCloseTo(165.25, 3)
-    expect(t.y0).toBeCloseTo(98, 3)
+    expect((t.y0 + t.y1) / 2).toBeCloseTo(128, 3)
     expect(hits(t, skirted)).toBe(true) // inside the support growth → the trigger
+  })
+})
+
+// The service measures the tower per filament count and publishes both the table and
+// the count-unaware bound (things-haunt-house#433). Reserving the bound for every
+// plate throws away bed depth nothing will print on — 42 mm of it on a two-filament
+// plate, which is the difference between a full kit fitting one bed and being refused.
+describe('envelopeForFilaments (reserve the row, not the worst case)', () => {
+  const depth = (e: { minY: number; maxY: number }): number => e.maxY - e.minY
+
+  it('takes the row for the count it is given', () => {
+    expect(depth(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, 2))).toBeCloseTo(21, 6)
+    expect(depth(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, 3))).toBeCloseTo(31.5, 6)
+    expect(depth(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, 6))).toBeCloseTo(63, 6)
+  })
+
+  it('is monotonic, and its top row IS the count-unaware bound', () => {
+    // Two promises the table has to keep: more filaments never reserves less, and a
+    // consumer that ignores the table entirely is still safe.
+    const depths = [2, 3, 4, 5, 6].map((n) =>
+      depth(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, n))
+    )
+    for (let i = 1; i < depths.length; i++) expect(depths[i]).toBeGreaterThanOrEqual(depths[i - 1])
+    expect(depths.at(-1)).toBeCloseTo(depth(DEFAULT_WIPE_TOWER_PROFILE.envelopeMm), 6)
+  })
+
+  it('floors at the two-filament row', () => {
+    // A one-filament plate grows a tower the moment routing attaches a support
+    // interface, and the plate is packed before that resolves. Row 2 is the hedge —
+    // and at 21 mm deep it is nearly free, which is what makes reserving
+    // unconditionally defensible in the first place.
+    for (const n of [0, 1, 2]) {
+      expect(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, n)).toEqual(
+        envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, 2)
+      )
+    }
+  })
+
+  it('falls back to the bound rather than shrink on anything unusable', () => {
+    const bound = DEFAULT_WIPE_TOWER_PROFILE.envelopeMm
+    const noTable: WipeTowerProfileGeometry = {
+      profile: DEFAULT_WIPE_TOWER_PROFILE.profile,
+      envelopeMm: bound,
+      process: DEFAULT_WIPE_TOWER_PROFILE.process,
+    }
+    // no count asked for; no table published; over the profile's capacity; and a
+    // malformed row — a bad optional field must never under-reserve.
+    expect(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE)).toEqual(bound)
+    expect(envelopeForFilaments(noTable, 2)).toEqual(bound)
+    expect(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, 99)).toEqual(bound)
+    expect(envelopeForFilaments(DEFAULT_WIPE_TOWER_PROFILE, Number.NaN)).toEqual(bound)
+    const broken: WipeTowerProfileGeometry = {
+      ...DEFAULT_WIPE_TOWER_PROFILE,
+      envelopeByFilamentsMm: { '2': { minX: 0, minY: 0, maxX: 0, maxY: Number.NaN } },
+    }
+    expect(envelopeForFilaments(broken, 2)).toEqual(bound)
+  })
+
+  it('reserves the shallower row on the plate itself, not just in the arithmetic', () => {
+    const cols3: AssemblyBody[] = [
+      { positions: tri(0, 0, 62.5, 100.5), colorHex: '#c9a26e', label: 'Frame', extruder: 1 },
+      { positions: tri(10, 10, 40, 50), colorHex: '#2e86ab', label: 'Beads', extruder: 2 },
+    ]
+    // Same model, same side, same gap — the pin moves only because the reservation
+    // centered on the model is shallower.
+    const two = assembleAbacus3mf(cols3, BAMBU_256_BED, { filaments: 2 }).wipeTower
+    const six = assembleAbacus3mf(cols3, BAMBU_256_BED, { filaments: 6 }).wipeTower
+    expect(two.xMm).toBeCloseTo(six.xMm, 6)
+    expect(two.yMm).toBeGreaterThan(six.yMm)
   })
 })

--- a/apps/web/src/components/create/abacus/__tests__/abacus-ticket.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-ticket.test.ts
@@ -194,6 +194,28 @@ describe('buildAbacusTicket', () => {
       ])
     })
 
+    it('counts filaments the way the plate reserved bed for them (#34)', () => {
+      // The tower's reservation is sized from `bodies + extraFilaments` BEFORE this
+      // ticket exists, and the count is echoed as `packedForFilaments` for the
+      // service to cross-check. This is the same arithmetic on the far side of that
+      // pipe: bodies, plus one when an interface spool is routed.
+      const count = (supportInterfaceSlotId: string | null): number =>
+        buildAbacusTicket({
+          ...base,
+          catalog: supportCatalog,
+          bodies: supportBodies,
+          supportInterfaceSlotId,
+        }).filaments.length
+      expect(count(null)).toBe(supportBodies.length)
+      expect(count('0.3')).toBe(supportBodies.length + 1)
+      // The one case where the panel's +1 over-counts: a pick that coincides with a
+      // model slot is not appended. Unreachable through the UI (the panel withholds
+      // design slots from the pickable roster) but real here — and it can only ever
+      // OVER-reserve, so the plate still slices; the panel drops the declared count
+      // rather than send one the service would reject.
+      expect(count('0.2')).toBe(supportBodies.length)
+    })
+
     it('null and absent both mean "interface prints in the model material" — no role entry', () => {
       const withNull = buildAbacusTicket({
         ...base,

--- a/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
@@ -156,6 +156,24 @@ const rectOf = (pl: KitPlatePlacement): Rect => ({
 const overlaps = (a: Rect, b: Rect): boolean =>
   a.x0 < b.x1 - 1e-6 && a.x1 > b.x0 + 1e-6 && a.y0 < b.y1 - 1e-6 && a.y1 > b.y0 + 1e-6
 
+/** The smallest edge-to-edge separation between any two modules on the plate —
+ *  the distance the slicer's extrusions actually have to live within. Two
+ *  disjoint rects are apart on at least one axis; the larger of the two axis
+ *  separations is their true clearance. */
+const closestApproach = (layout: { placements: readonly KitPlatePlacement[] }): number => {
+  let closest = Number.POSITIVE_INFINITY
+  const rects = layout.placements.map(rectOf)
+  for (let i = 0; i < rects.length; i++) {
+    for (let j = i + 1; j < rects.length; j++) {
+      const a = rects[i]
+      const b = rects[j]
+      const apart = Math.max(Math.max(b.x0 - a.x1, a.x0 - b.x1), Math.max(b.y0 - a.y1, a.y0 - b.y1))
+      if (apart < closest) closest = apart
+    }
+  }
+  return closest
+}
+
 describe('kitPlateInstances (counts → placeable modules)', () => {
   it('expands a 13-column place-value kit into 13 modules with unique ids and labels', () => {
     const instances = kitPlateInstances(p(), fmPlace)
@@ -399,10 +417,53 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
   })
 
   it('reserves a wider ring when the plate will slice with supports', () => {
-    const plain = packKitPlate({ instances, bases })
-    const supported = packKitPlate({ instances, bases, supportsAtSlice: true })
+    // On a bed big enough that neither pack refuses — this is about the RING,
+    // and a supports-on 13-module kit genuinely doesn't fit a 256 (below).
+    const roomy: BedSize = { wMm: 400, dMm: 400 }
+    const plain = packKitPlate({ instances, bases, bed: roomy })
+    const supported = packKitPlate({ instances, bases, bed: roomy, supportsAtSlice: true })
     expect(supported.tower.wMm).toBeGreaterThan(plain.tower.wMm)
     expect(supported.tower.dMm).toBeGreaterThan(plain.tower.dMm)
+  })
+
+  // The exit-192 regression. Orca refused a real plate whose declared boxes were
+  // disjoint: supports grow past every outline, and 4 mm between modules wasn't
+  // two brims wide, let alone two support skirts. The gap has to move with
+  // `supportsAtSlice` exactly as the tower ring does.
+  it('spaces modules further apart when the plate will slice with supports', () => {
+    const roomy: BedSize = { wMm: 400, dMm: 400 }
+    const plain = packKitPlate({ instances, bases, bed: roomy })
+    const supported = packKitPlate({ instances, bases, bed: roomy, supportsAtSlice: true })
+    // Closest approach, not overall span: the packer is free to answer a wider
+    // gap by using more rows, so the envelope can shrink while every neighbour
+    // moves further apart. Separation is the property that keeps extrusions off
+    // each other; the envelope is just how the packer chose to spend the bed.
+    expect(closestApproach(supported)).toBeGreaterThan(closestApproach(plain))
+    expect(closestApproach(supported)).toBeGreaterThanOrEqual(16 - 1e-6)
+  })
+
+  it('holds two brims between neighbours even with supports off', () => {
+    // 4 mm — the shared bundler's default, and what this used to ship — cannot
+    // hold two 5 mm brims.
+    expect(
+      closestApproach(packKitPlate({ instances, bases, bed: { wMm: 400, dMm: 400 } }))
+    ).toBeGreaterThanOrEqual(10 - 1e-6)
+  })
+
+  it('refuses a printed-feet 13-column kit on a 256 bed rather than one the slicer rejects', () => {
+    // Honest physics, and the whole point of the refusal: 13 modules at
+    // supports-on spacing plus the widened tower reserve do not fit a 256 plate.
+    // Better to name it and keep the zip than to ship a plate that slices to
+    // "Object conflicts were detected".
+    let caught: KitPlateFitError | null = null
+    try {
+      packKitPlate({ instances, bases, supportsAtSlice: true })
+    } catch (err) {
+      caught = err as KitPlateFitError
+    }
+    expect(caught).toBeInstanceOf(KitPlateFitError)
+    expect(caught?.reason).toBe('overflow')
+    expect(caught?.remediation).toMatch(/fewer columns|scale the design down|bigger bed/)
   })
 
   it('refuses an overfull plate by name rather than dropping a module', () => {
@@ -520,7 +581,14 @@ describe('buildKitPlateThreeMf (the whole kit as one plate)', () => {
   it('flows printed feet onto the plate on their own slot, and drops the plate on them', () => {
     const feetParams = p({ color_scheme: 'heaven-earth', feet_mode: 'printed' })
     const fm: FilamentMap = { ...fmHeavenEarth, feet: 2 }
-    const plate = buildKitPlateThreeMf({ parts: kitParts(feetParams, true), filamentMap: fm })
+    // Printed feet mean supports, and supports mean wider gaps — 13 of these
+    // don't fit a 256 (see the refusal test above). This is about where the feet
+    // FLOW, so give it a bed that holds all 13 and keep the count assertion real.
+    const plate = buildKitPlateThreeMf({
+      parts: kitParts(feetParams, true),
+      filamentMap: fm,
+      bed: { wMm: 400, dMm: 400 },
+    })
     // 3 foot triangles per module × 13 modules
     expect(plate.bodies.find((b) => b.slot === 2)).toMatchObject({ triangleCount: 39 })
     // The studs still sit 2mm below the frame plane in the mesh — the CONTAINER

--- a/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
@@ -450,11 +450,11 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
     ).toBeGreaterThanOrEqual(10 - 1e-6)
   })
 
-  it('refuses a printed-feet 13-column kit on a 256 bed rather than one the slicer rejects', () => {
-    // Honest physics, and the whole point of the refusal: 13 modules at
-    // supports-on spacing plus the widened tower reserve do not fit a 256 plate.
-    // Better to name it and keep the zip than to ship a plate that slices to
-    // "Object conflicts were detected".
+  it('refuses a printed-feet 13-column kit when it must reserve the worst-case tower', () => {
+    // No filament count given, so the reserve falls back to the profile's
+    // count-unaware bound — and 13 modules at supports-on spacing plus a
+    // six-filament tower genuinely do not fit a 256 plate. Naming that and keeping
+    // the zip beats shipping a plate that slices to "Object conflicts were detected".
     let caught: KitPlateFitError | null = null
     try {
       packKitPlate({ instances, bases, supportsAtSlice: true })
@@ -464,6 +464,32 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
     expect(caught).toBeInstanceOf(KitPlateFitError)
     expect(caught?.reason).toBe('overflow')
     expect(caught?.remediation).toMatch(/fewer columns|scale the design down|bigger bed/)
+  })
+
+  it('fits that same kit once it reserves the tower its filament count needs', () => {
+    // The refusal above is not physics — it is the worst case. A wood-PLA kit with
+    // printed TPU feet and a routed support interface is a THREE-filament plate, and
+    // the service publishes a 70×31.5 envelope for that instead of 70×63. The 42 mm
+    // of depth handed back is exactly what the thirteenth module needs.
+    const fitted = packKitPlate({ instances, bases, supportsAtSlice: true, filaments: 3 })
+    expect(fitted.placements).toHaveLength(instances.length)
+    const rects = fitted.placements.map(rectOf)
+    for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) expect(overlaps(rects[i], rects[j])).toBe(false)
+    }
+    // and the separation law still holds at the tighter reserve
+    expect(closestApproach(fitted)).toBeGreaterThanOrEqual(16 - 1e-6)
+    // the win is depth: same tower width, shallower reserve
+    const roomy: BedSize = { wMm: 400, dMm: 400 }
+    const worst = packKitPlate({
+      instances,
+      bases,
+      supportsAtSlice: true,
+      filaments: 6,
+      bed: roomy,
+    })
+    expect(fitted.tower.wMm).toBeCloseTo(worst.tower.wMm, 6)
+    expect(fitted.tower.dMm).toBeLessThan(worst.tower.dMm)
   })
 
   it('refuses an overfull plate by name rather than dropping a module', () => {
@@ -531,6 +557,21 @@ describe('buildKitPlateThreeMf (the whole kit as one plate)', () => {
       { slot: 3, label: 'Filament 4', colorHex: '#2e86ab', triangleCount: 13 },
     ])
     expect([...plate.bytes.slice(0, 4)]).toEqual([0x50, 0x4b, 0x03, 0x04])
+  })
+
+  it('declares the filament count it reserved for — bodies plus what routing adds', () => {
+    // The number the service cross-checks against its resolved plan. It is the same
+    // arithmetic the ticket does (one entry per distinct body slot, then the
+    // support-interface entry), computed from the same slot set — so a plate can't
+    // reserve for one count and declare another.
+    expect(plateOf().wipeTower?.packedForFilaments).toBe(3)
+    expect(plateOf({ extraFilaments: 1 }).wipeTower?.packedForFilaments).toBe(4)
+  })
+
+  it('spends less bed on the tower once it knows the count', () => {
+    // Same plate, same modules: only the reservation's depth moves, because the
+    // service publishes a shallower envelope for fewer filaments.
+    expect(plateOf().tower.dMm).toBeLessThan(plateOf({ extraFilaments: 3 }).tower.dMm)
   })
 
   it('ships the modules WHERE THEY WERE PACKED — no re-centering, no re-derived tower', () => {

--- a/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
@@ -1,0 +1,565 @@
+/**
+ * Single-plate module-kit tests (Gitea #32, Phase A): the count → instance
+ * expansion, footprint extraction off the gated soups, the RIGID-GROUP transform
+ * (the piece with no upstream precedent — everything else is Frame Studio's
+ * packer), the packed plate end to end, and the refusals that send an overfull
+ * kit back to the zip.
+ *
+ * Fixtures follow module-kit.test.ts: synthetic triangle soups shaped the way
+ * `analyzeModuleShells` reads them — one frame strip spanning the full outer
+ * depth plus exactly one column of bead triangles at the module's known local x
+ * — so a mid module's footprint really is scW × outerD and the plate's geometry
+ * is the same triangles the zip would have shipped.
+ */
+
+import type { BedSize } from '@eink/frames-engine/print-bundle'
+import { writeBinaryStl } from '@eink/frames-engine/stl'
+import { strFromU8, unzipSync } from 'fflate'
+import { describe, expect, it } from 'vitest'
+import { BAMBU_256_BED } from '../abacus-3mf-assembly'
+import {
+  buildKitPlateThreeMf,
+  KitPlateFitError,
+  type KitPlatePlacement,
+  kitPlateInstances,
+  type ModuleBasis,
+  moduleBasis,
+  packKitPlate,
+  placeModuleBodies,
+} from '../abacus-kit-plate'
+import { defaultParams, derived, type FilamentMap, type Params } from '../abacus-model'
+import { type ModuleExportParts, moduleSoups } from '../abacus-module-kit'
+
+const p = (over: Partial<Params> = {}): Params => ({
+  ...defaultParams, // 13 cols, earth 4, place-value/default, scale 1
+  seam_mode: 'modular',
+  feet_mode: 'adhesive', // feet-path tests opt back in explicitly
+  text_mode: 'emboss',
+  ...over,
+})
+
+// place-value map with every role on its own slot (frame on 0)
+const fmPlace: FilamentMap = {
+  slots: ['#c9a26e', '#e11', '#e22', '#e33', '#e44', '#e55'],
+  frame: 0,
+  markerWhite: 0,
+  markerBlack: 0,
+  beadRoles: [1, 2, 3, 4, 5],
+  markerContrast: 21,
+}
+
+const fmHeavenEarth: FilamentMap = {
+  slots: ['#c9a26e', '#f5f5f5', '#111111', '#2e86ab'],
+  frame: 0,
+  markerWhite: 1,
+  markerBlack: 2,
+  beadRoles: [3, 1], // heaven → 3, earth → 1
+  markerContrast: 21,
+}
+
+const toBuffer = (bytes: Uint8Array): ArrayBuffer => {
+  const buffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(buffer).set(bytes)
+  return buffer
+}
+
+/** A small isolated triangle whose bounding-box centroid is exactly (x, y). */
+const tri = (x: number, y: number, z = 0): number[] => [
+  x - 1,
+  y - 1,
+  z,
+  x + 1,
+  y - 1,
+  z,
+  x,
+  y + 1,
+  z,
+]
+
+/** Synthetic module soup: a frame strip spanning the full outer depth plus one
+ *  column of beads (1 heaven + earth) at the module's known local x. */
+function moduleSoup(pp: Params, kind: 'left' | 'mid' | 'right'): Float32Array {
+  const d = derived(pp)
+  const border = pp.border_w * pp.scale_factor
+  const cx = kind === 'left' ? border + d.sEm : d.scW / 2
+  const w = kind === 'mid' ? d.scW : d.modWe
+  const tris: number[] = [
+    ...[0, 0, 0, w, 0, 0, w, d.outerD, 0],
+    ...[0, 0, 0, w, d.outerD, 0, 0, d.outerD, 0],
+    ...tri(cx, border + d.sHy),
+  ]
+  for (let k = 0; k < pp.earth; k++) tris.push(...tri(cx, border + d.sElo + k * d.sEp))
+  return new Float32Array(tris)
+}
+
+const moduleStl = (pp: Params, kind: 'left' | 'mid' | 'right'): ArrayBuffer =>
+  toBuffer(writeBinaryStl(moduleSoup(pp, kind)))
+
+/** A synthetic feet render: studs INSIDE the module footprint that dip below
+ *  z=0, the way printed TPU feet stand the frame off the bed. */
+const feetStl = (n = 3): ArrayBuffer => {
+  const positions = new Float32Array(n * 9)
+  for (let t = 0; t < n; t++) positions.set(tri(3 + t * 3, 10, -2), t * 9)
+  return toBuffer(writeBinaryStl(positions))
+}
+
+/** A synthetic side-text render: one triangle inside the module footprint at a
+ *  distinct x per group (so assertGroupsDiffer sees differing geometry). */
+const textStlAt = (x: number): ArrayBuffer =>
+  toBuffer(writeBinaryStl(new Float32Array(tri(x, 5, 1))))
+
+const kitParts = (pp: Params, feet = false): ModuleExportParts => ({
+  left: moduleStl(pp, 'left'),
+  mid: moduleStl(pp, 'mid'),
+  right: moduleStl(pp, 'right'),
+  leftFeet: feet ? feetStl() : null,
+  midFeet: feet ? feetStl() : null,
+  rightFeet: feet ? feetStl() : null,
+  leftText: [],
+  rightText: [],
+  params: pp,
+})
+
+const basesFor = (pp: Params, fm: FilamentMap, parts: ModuleExportParts) => ({
+  left: moduleBasis(
+    'left',
+    moduleSoups({ body: parts.left, kind: 'left', column: 0, params: pp, filamentMap: fm })
+  ),
+  mid: moduleBasis(
+    'mid',
+    moduleSoups({ body: parts.mid, kind: 'mid', column: 1, params: pp, filamentMap: fm })
+  ),
+  right: moduleBasis(
+    'right',
+    moduleSoups({
+      body: parts.right,
+      kind: 'right',
+      column: pp.cols - 1,
+      params: pp,
+      filamentMap: fm,
+    })
+  ),
+})
+
+interface Rect {
+  x0: number
+  y0: number
+  x1: number
+  y1: number
+}
+const rectOf = (pl: KitPlatePlacement): Rect => ({
+  x0: pl.xMm,
+  y0: pl.yMm,
+  x1: pl.xMm + pl.wMm,
+  y1: pl.yMm + pl.hMm,
+})
+const overlaps = (a: Rect, b: Rect): boolean =>
+  a.x0 < b.x1 - 1e-6 && a.x1 > b.x0 + 1e-6 && a.y0 < b.y1 - 1e-6 && a.y1 > b.y0 + 1e-6
+
+describe('kitPlateInstances (counts → placeable modules)', () => {
+  it('expands a 13-column place-value kit into 13 modules with unique ids and labels', () => {
+    const instances = kitPlateInstances(p(), fmPlace)
+    expect(instances).toHaveLength(13)
+    expect(new Set(instances.map((i) => i.id)).size).toBe(13)
+    expect(new Set(instances.map((i) => i.label)).size).toBe(13)
+    expect(instances[0]).toEqual({
+      id: 'left',
+      label: 'left end',
+      kind: 'left',
+      column: 0,
+      file: 'module-left.3mf',
+    })
+    expect(instances.at(-1)).toEqual({
+      id: 'right',
+      label: 'right end',
+      kind: 'right',
+      column: 12,
+      file: 'module-right.3mf',
+    })
+  })
+
+  it('numbers mids across variants — eleven pieces is what comes off the plate', () => {
+    const mids = kitPlateInstances(p(), fmPlace).filter((i) => i.kind === 'mid')
+    expect(mids).toHaveLength(11)
+    expect(mids.map((i) => i.label)).toEqual(
+      Array.from({ length: 11 }, (_, k) => `mid ${k + 1} of 11`)
+    )
+    expect(mids.map((i) => i.id)).toEqual(Array.from({ length: 11 }, (_, k) => `mid-${k + 1}`))
+  })
+
+  it('carries each instance’s OWN column — bead color varies per column', () => {
+    // 5 bead-slot variants covering 11 mid columns: 3 + 2 + 2 + 2 + 2, each
+    // instance stamped with its variant's representative column.
+    const mids = kitPlateInstances(p(), fmPlace).filter((i) => i.kind === 'mid')
+    const runs: [number, number][] = []
+    for (const m of mids) {
+      const last = runs.at(-1)
+      if (last && last[0] === m.column) last[1]++
+      else runs.push([m.column, 1])
+    }
+    expect(runs).toEqual([
+      [1, 3],
+      [2, 2],
+      [3, 2],
+      [4, 2],
+      [5, 2],
+    ])
+    // and the variant identity rides the file, not the label
+    expect(mids[0].file).toBe('module-mid-10s-x3.3mf')
+    expect(mids.at(-1)?.file).toBe('module-mid-100s-x2.3mf')
+  })
+
+  it('a single-variant kit still numbers its eleven mids', () => {
+    const mids = kitPlateInstances(p({ color_scheme: 'heaven-earth' }), fmHeavenEarth).filter(
+      (i) => i.kind === 'mid'
+    )
+    expect(mids).toHaveLength(11)
+    expect(mids.every((m) => m.column === 1 && m.file === 'module-mid-x11.3mf')).toBe(true)
+    expect(mids[2].label).toBe('mid 3 of 11')
+  })
+
+  it('a lone mid drops the ordinal rather than reading "mid 1 of 1"', () => {
+    const instances = kitPlateInstances(p({ cols: 3 }), fmPlace)
+    expect(instances.map((i) => i.label)).toEqual(['left end', 'mid', 'right end'])
+  })
+})
+
+describe('moduleBasis (footprints off the gated soups)', () => {
+  const pp = p()
+  const d = derived(pp)
+  const parts = kitParts(pp)
+
+  it('measures a mid module as one column wide by the full outer depth', () => {
+    const basis = basesFor(pp, fmPlace, parts).mid
+    expect(basis.wMm).toBeCloseTo(d.scW, 6)
+    expect(basis.hMm).toBeCloseTo(d.outerD, 6)
+    expect(basis).toMatchObject({ kind: 'mid', minX: 0, minY: 0 })
+  })
+
+  it('the ends are wider than a mid by their end wall', () => {
+    const bases = basesFor(pp, fmPlace, parts)
+    expect(bases.left.wMm).toBeCloseTo(d.modWe, 6)
+    expect(bases.right.wMm).toBeCloseTo(d.modWe, 6)
+    expect(bases.left.wMm).toBeGreaterThan(bases.mid.wMm)
+  })
+
+  it('takes the union of every soup that ships — a part pass can only grow it', () => {
+    const feetParams = p({ feet_mode: 'printed' })
+    const fm: FilamentMap = { ...fmPlace, feet: 3 }
+    const basisOf = (feet: ArrayBuffer) =>
+      moduleBasis(
+        'mid',
+        moduleSoups({
+          body: moduleStl(feetParams, 'mid'),
+          feet,
+          kind: 'mid',
+          column: 1,
+          params: feetParams,
+          filamentMap: fm,
+        })
+      )
+    // studs inside the frame's pockets leave the packed footprint alone …
+    expect(basisOf(feetStl()).wMm).toBeCloseTo(derived(feetParams).scW, 6)
+    // … but one that pokes proud of the frame widens the box the packer clears
+    const proud = toBuffer(writeBinaryStl(new Float32Array(tri(-4, 10, -2))))
+    const wide = basisOf(proud)
+    expect(wide.minX).toBeCloseTo(-5, 6)
+    expect(wide.wMm).toBeCloseTo(derived(feetParams).scW + 5, 6)
+  })
+
+  it('a feet render that is NOT printed never enters the footprint', () => {
+    // same renders, adhesive feet: the gate drops the feet pass, so must the basis
+    const proud = toBuffer(writeBinaryStl(new Float32Array(tri(-4, 10, -2))))
+    const basis = moduleBasis(
+      'mid',
+      moduleSoups({
+        body: moduleStl(pp, 'mid'),
+        feet: proud,
+        kind: 'mid',
+        column: 1,
+        params: pp,
+        filamentMap: fmPlace,
+      })
+    )
+    expect(basis.minX).toBe(0)
+    expect(basis.wMm).toBeCloseTo(d.scW, 6)
+  })
+})
+
+describe('placeModuleBodies (the rigid-group transform)', () => {
+  // A two-body module: a 6 × 8 frame sitting at z=0, and a foot inside its
+  // footprint dipping 2mm below it at a known XY offset.
+  const basis: ModuleBasis = { kind: 'mid', minX: 10, minY: 20, wMm: 6, hMm: 8 }
+  const frame = new Float32Array([10, 20, 0, 16, 20, 0, 16, 28, 0])
+  const foot = new Float32Array([12, 22, -2, 13, 22, -2, 13, 23, -2])
+  const bodies = [
+    { slot: 0, positions: frame },
+    { slot: 1, positions: foot },
+  ]
+
+  it('moves the module to its slot: min corner to (x, y), Z left to the container', () => {
+    const [f, ft] = placeModuleBodies(bodies, basis, { xMm: 100, yMm: 50, rotated: false })
+    expect([...f.positions]).toEqual([100, 50, 0, 106, 50, 0, 106, 58, 0])
+    expect([...ft.positions]).toEqual([102, 52, -2, 103, 52, -2, 103, 53, -2])
+    expect([f.slot, ft.slot]).toEqual([0, 1])
+  })
+
+  it('re-origins on ONE shared basis — a body never lands on its own corner', () => {
+    const [, ft] = placeModuleBodies(bodies, basis, { xMm: 100, yMm: 50, rotated: false })
+    // The bug this whole module exists to not have: per-body re-origin would put
+    // the foot's own min corner at the placement corner, on top of the frame's.
+    expect(ft.positions[0]).not.toBe(100)
+    expect(ft.positions[1]).not.toBe(50)
+  })
+
+  it('turns the WHOLE module when the packer turns it', () => {
+    const [f, ft] = placeModuleBodies(bodies, basis, { xMm: 100, yMm: 50, rotated: true })
+    // (x, y) → (−y, x), re-origined on the GROUP box: x' = maxY − y + X, y' = x − minX + Y
+    expect([...f.positions]).toEqual([108, 50, 0, 108, 56, 0, 100, 56, 0])
+    expect([...ft.positions]).toEqual([106, 52, -2, 106, 53, -2, 105, 53, -2])
+  })
+
+  it('keeps every body registered to every other, turned or not', () => {
+    for (const rotated of [false, true]) {
+      const [f, ft] = placeModuleBodies(bodies, basis, { xMm: 100, yMm: 50, rotated })
+      const before = [foot[0] - frame[0], foot[1] - frame[1], foot[2] - frame[2]]
+      const after = [
+        ft.positions[0] - f.positions[0],
+        ft.positions[1] - f.positions[1],
+        ft.positions[2] - f.positions[2],
+      ]
+      // A rigid motion: z and the in-plane distance survive, and the offset
+      // itself rotates with the module rather than staying put.
+      expect(after[2]).toBeCloseTo(before[2], 6)
+      expect(Math.hypot(after[0], after[1])).toBeCloseTo(Math.hypot(before[0], before[1]), 6)
+      expect(after.slice(0, 2)).toEqual(rotated ? [-before[1], before[0]] : [before[0], before[1]])
+    }
+  })
+
+  it('lands the placed footprint exactly on its packed cell', () => {
+    for (const rotated of [false, true]) {
+      const placed = placeModuleBodies(bodies, basis, { xMm: 100, yMm: 50, rotated })
+      const xs = placed.flatMap((b) => [...b.positions].filter((_, i) => i % 3 === 0))
+      const ys = placed.flatMap((b) => [...b.positions].filter((_, i) => i % 3 === 1))
+      expect(Math.min(...xs)).toBeCloseTo(100, 6)
+      expect(Math.min(...ys)).toBeCloseTo(50, 6)
+      expect(Math.max(...xs) - 100).toBeCloseTo(rotated ? basis.hMm : basis.wMm, 6)
+      expect(Math.max(...ys) - 50).toBeCloseTo(rotated ? basis.wMm : basis.hMm, 6)
+    }
+  })
+})
+
+describe('packKitPlate (tower first, then the modules around it)', () => {
+  const pp = p({ color_scheme: 'heaven-earth' })
+  const parts = kitParts(pp)
+  const bases = basesFor(pp, fmHeavenEarth, parts)
+  const instances = kitPlateInstances(pp, fmHeavenEarth)
+
+  it('lays all 13 modules on one 256 plate, none overlapping, all on the bed', () => {
+    const { placements, tower, bed } = packKitPlate({ instances, bases })
+    expect(placements.map((pl) => pl.id).sort()).toEqual(instances.map((i) => i.id).sort())
+    const rects = placements.map(rectOf)
+    for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) {
+        expect(overlaps(rects[i], rects[j])).toBe(false)
+      }
+      expect(rects[i].x0).toBeGreaterThanOrEqual(0)
+      expect(rects[i].y0).toBeGreaterThanOrEqual(0)
+      expect(rects[i].x1).toBeLessThanOrEqual(bed.wMm)
+      expect(rects[i].y1).toBeLessThanOrEqual(bed.dMm)
+    }
+    expect(tower.wMm).toBeGreaterThan(0)
+  })
+
+  it('keeps the modules clear of the reserved tower and the printer keep-out', () => {
+    const { placements, tower, bed } = packKitPlate({ instances, bases })
+    const towerRect: Rect = {
+      x0: tower.xMm,
+      y0: tower.yMm,
+      x1: tower.xMm + tower.wMm,
+      y1: tower.yMm + tower.dMm,
+    }
+    const keepOuts: Rect[] = [
+      towerRect,
+      ...(bed.exclude ?? []).map((e) => ({
+        x0: e.xMm,
+        y0: e.yMm,
+        x1: e.xMm + e.wMm,
+        y1: e.yMm + e.dMm,
+      })),
+    ]
+    for (const pl of placements) {
+      for (const k of keepOuts) expect(overlaps(rectOf(pl), k)).toBe(false)
+    }
+    // the pin sits INSIDE its reservation — the tower spills below-left of it
+    expect(tower.pinXMm).toBeGreaterThan(tower.xMm)
+    expect(tower.pinYMm).toBeGreaterThan(tower.yMm)
+    expect(tower.pinXMm).toBeLessThan(towerRect.x1)
+    expect(tower.pinYMm).toBeLessThan(towerRect.y1)
+  })
+
+  it('reserves a wider ring when the plate will slice with supports', () => {
+    const plain = packKitPlate({ instances, bases })
+    const supported = packKitPlate({ instances, bases, supportsAtSlice: true })
+    expect(supported.tower.wMm).toBeGreaterThan(plain.tower.wMm)
+    expect(supported.tower.dMm).toBeGreaterThan(plain.tower.dMm)
+  })
+
+  it('refuses an overfull plate by name rather than dropping a module', () => {
+    const smallBed: BedSize = { wMm: 150, dMm: 150 }
+    let caught: KitPlateFitError | null = null
+    try {
+      packKitPlate({ instances, bases, bed: smallBed })
+    } catch (err) {
+      caught = err as KitPlateFitError
+    }
+    expect(caught).toBeInstanceOf(KitPlateFitError)
+    expect(caught?.reason).toBe('overflow')
+    expect(caught?.modules.length).toBeGreaterThan(0)
+    // every named module is a real instance label, and the message names a knob
+    for (const name of caught?.modules ?? []) {
+      expect(instances.map((i) => i.label)).toContain(name)
+    }
+    expect(caught?.message).toMatch(/build plates/)
+    expect(caught?.message).toMatch(/fewer columns|scale the design down|bigger bed/)
+  })
+
+  it('refuses a module too big for the bed even alone', () => {
+    const big = p({ cols: 3, scale_factor: 3, color_scheme: 'heaven-earth' })
+    const bigParts = kitParts(big)
+    let caught: KitPlateFitError | null = null
+    try {
+      packKitPlate({
+        instances: kitPlateInstances(big, fmHeavenEarth),
+        bases: basesFor(big, fmHeavenEarth, bigParts),
+      })
+    } catch (err) {
+      caught = err as KitPlateFitError
+    }
+    expect(caught?.reason).toBe('too-big')
+    expect(caught?.modules).toContain('mid')
+    expect(caught?.message).toMatch(/too big for this 256 × 256 mm bed/)
+  })
+
+  it('refuses when no rectangle is left for the purge tower', () => {
+    let caught: KitPlateFitError | null = null
+    try {
+      packKitPlate({ instances, bases, bed: { wMm: 60, dMm: 60 } })
+    } catch (err) {
+      caught = err as KitPlateFitError
+    }
+    expect(caught?.reason).toBe('no-tower-room')
+    expect(caught?.modules).toEqual([])
+    expect(caught?.message).toMatch(/purge tower/)
+  })
+})
+
+describe('buildKitPlateThreeMf (the whole kit as one plate)', () => {
+  const pp = p({ color_scheme: 'heaven-earth' })
+
+  const plateOf = (over: Partial<Parameters<typeof buildKitPlateThreeMf>[0]> = {}) =>
+    buildKitPlateThreeMf({ parts: kitParts(pp), filamentMap: fmHeavenEarth, ...over })
+
+  it('carries every module’s geometry, bucketed by filament slot', () => {
+    const plate = plateOf()
+    expect(plate.placements).toHaveLength(13)
+    // each synthetic module is 2 frame + 1 heaven + 4 earth triangles, ×13
+    expect(plate.bodies).toEqual([
+      { slot: 0, label: 'Filament 1', colorHex: '#c9a26e', triangleCount: 26 },
+      { slot: 1, label: 'Filament 2', colorHex: '#f5f5f5', triangleCount: 52 },
+      { slot: 3, label: 'Filament 4', colorHex: '#2e86ab', triangleCount: 13 },
+    ])
+    expect([...plate.bytes.slice(0, 4)]).toEqual([0x50, 0x4b, 0x03, 0x04])
+  })
+
+  it('ships the modules WHERE THEY WERE PACKED — no re-centering, no re-derived tower', () => {
+    const plate = plateOf()
+    const members = unzipSync(plate.bytes)
+    const model = strFromU8(members['3D/3dmodel.model'])
+    // the build item is a pure identity: the bodies already carry the layout
+    expect(model).toContain('<item objectid="1000" transform="1 0 0 0 1 0 0 0 1 0 0 0"/>')
+
+    // and the geometry really spans the packed placements
+    const verts = [...model.matchAll(/<vertex x="([-\d.]+)" y="([-\d.]+)"/g)].map((m) => [
+      Number(m[1]),
+      Number(m[2]),
+    ])
+    const rects = plate.placements.map(rectOf)
+    expect(Math.min(...verts.map((v) => v[0]))).toBeCloseTo(Math.min(...rects.map((r) => r.x0)), 3)
+    expect(Math.min(...verts.map((v) => v[1]))).toBeCloseTo(Math.min(...rects.map((r) => r.y0)), 3)
+    expect(Math.max(...verts.map((v) => v[0]))).toBeCloseTo(Math.max(...rects.map((r) => r.x1)), 3)
+    expect(Math.max(...verts.map((v) => v[1]))).toBeCloseTo(Math.max(...rects.map((r) => r.y1)), 3)
+
+    // the tower is pinned at the reservation the packer left room for
+    const settings = JSON.parse(strFromU8(members['Metadata/project_settings.config']))
+    expect(Number(settings.wipe_tower_x)).toBeCloseTo(plate.tower.pinXMm, 3)
+    expect(Number(settings.wipe_tower_y)).toBeCloseTo(plate.tower.pinYMm, 3)
+    expect(plate.wipeTower?.pinMm).toEqual({ x: plate.tower.pinXMm, y: plate.tower.pinYMm })
+  })
+
+  it('every module lands on the bed, clear of its neighbours', () => {
+    const plate = plateOf()
+    const rects = plate.placements.map(rectOf)
+    for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) {
+        expect(overlaps(rects[i], rects[j])).toBe(false)
+      }
+      expect(rects[i].x1).toBeLessThanOrEqual(BAMBU_256_BED.wMm)
+      expect(rects[i].y1).toBeLessThanOrEqual(BAMBU_256_BED.dMm)
+    }
+  })
+
+  it('runs each module through its own export gate — a footless module still refuses', () => {
+    const feetParams = p({ color_scheme: 'heaven-earth', feet_mode: 'printed' })
+    const fm: FilamentMap = { ...fmHeavenEarth, feet: 2 }
+    expect(() => buildKitPlateThreeMf({ parts: kitParts(feetParams), filamentMap: fm })).toThrow(
+      /module_left_feet render is missing/
+    )
+  })
+
+  it('flows printed feet onto the plate on their own slot, and drops the plate on them', () => {
+    const feetParams = p({ color_scheme: 'heaven-earth', feet_mode: 'printed' })
+    const fm: FilamentMap = { ...fmHeavenEarth, feet: 2 }
+    const plate = buildKitPlateThreeMf({ parts: kitParts(feetParams, true), filamentMap: fm })
+    // 3 foot triangles per module × 13 modules
+    expect(plate.bodies.find((b) => b.slot === 2)).toMatchObject({ triangleCount: 39 })
+    // The studs still sit 2mm below the frame plane in the mesh — the CONTAINER
+    // lifts the whole plate onto the bed, which is what keeps the frame's z=0
+    // plane (and the support-transition modifier pinned to it) where it belongs.
+    const model = strFromU8(unzipSync(plate.bytes)['3D/3dmodel.model'])
+    expect(model).toContain('<item objectid="1000" transform="1 0 0 0 1 0 0 0 1 0 0 2"/>')
+  })
+
+  it('flows inset side text onto the END modules only', () => {
+    const textParams = p({
+      color_scheme: 'heaven-earth',
+      text_mode: 'inset',
+      aid_10: 'off',
+      aid_5: 'off',
+      edge_left: 'L',
+      edge_right: 'R',
+    })
+    const fm: FilamentMap = { ...fmHeavenEarth, textRoles: [2] }
+    const plate = buildKitPlateThreeMf({
+      parts: {
+        ...kitParts(textParams),
+        leftText: [{ group: 0, stl: textStlAt(3) }],
+        rightText: [{ group: 0, stl: textStlAt(6) }],
+      },
+      filamentMap: fm,
+    })
+    // one inlay triangle per END module, and nothing on the eleven mids
+    expect(plate.bodies.find((b) => b.slot === 2)).toMatchObject({ triangleCount: 2 })
+  })
+
+  it('refuses a mono design — a plate of modules is a modular export', () => {
+    const mono = { ...pp, seam_mode: 'mono' as const }
+    expect(() =>
+      buildKitPlateThreeMf({ parts: kitParts(mono), filamentMap: fmHeavenEarth })
+    ).toThrow(/seam_mode "mono"/)
+  })
+
+  it('refuses an overfull bed rather than shipping a partial kit', () => {
+    expect(() => plateOf({ bed: { wMm: 150, dMm: 150 } })).toThrow(KitPlateFitError)
+  })
+})

--- a/apps/web/src/components/create/abacus/__tests__/kit-print-wiring.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/kit-print-wiring.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The submit path's kit wiring (Gitea #32, items 6–7) — the seams between the
+ * packer and the print panel, tested where they're pure.
+ *
+ * The panel component itself isn't mounted here: its submit needs a live THH
+ * roster, a three.js export bundle and a network round-trip. What IS testable
+ * without any of that is every decision the wiring makes — which bed the packer
+ * is handed, what identity a packed plate has, and whether a kit and a one-piece
+ * abacus can be told apart once they're jobs on a service.
+ */
+import { describe, expect, it } from 'vitest'
+import type { ThhBedGeometry } from '@/lib/abacus/print/filament-wire'
+import { bedSizeFromThh } from '../abacus-3mf'
+import {
+  KitPlateFitError,
+  type KitPlateLayout,
+  type KitPlatePlacement,
+  kitPlateSignature,
+} from '../abacus-kit-plate'
+import { abacusModelFileName, abacusPrintSignature } from '../print-idempotency'
+
+// ---- bedSizeFromThh ---------------------------------------------------------
+
+describe('bedSizeFromThh (THH machine geometry → the packer/emitter plate)', () => {
+  it('is undefined without a bed — the caller falls back to the bundled plate', () => {
+    expect(bedSizeFromThh(undefined)).toBeUndefined()
+  })
+
+  it('carries the reported size through, with no exclusions to reserve', () => {
+    expect(bedSizeFromThh({ sizeMm: { x: 256, y: 256, z: 256 } })).toEqual({
+      wMm: 256,
+      dMm: 256,
+      exclude: [],
+    })
+  })
+
+  it('reduces an exclusion polygon to its bounding rect', () => {
+    // A triangle in the back-right corner: everything downstream reserves
+    // rectangles, so it must arrive as the rect that CONTAINS the triangle.
+    const bed: ThhBedGeometry = {
+      sizeMm: { x: 256, y: 256 },
+      exclusionsMm: [
+        {
+          pointsMm: [
+            [200, 210],
+            [240, 210],
+            [220, 250],
+          ],
+        },
+      ],
+    }
+    expect(bedSizeFromThh(bed)?.exclude).toEqual([{ xMm: 200, yMm: 210, wMm: 40, dMm: 40 }])
+  })
+
+  it('over-reserves rather than under-reserves — the rect covers every vertex', () => {
+    const bed: ThhBedGeometry = {
+      sizeMm: { x: 256, y: 256 },
+      exclusionsMm: [
+        {
+          pointsMm: [
+            [10, 90],
+            [30, 20],
+            [70, 60],
+            [25, 95],
+          ],
+        },
+      ],
+    }
+    const rect = bedSizeFromThh(bed)?.exclude?.[0]
+    expect(rect).toBeDefined()
+    for (const [x, y] of bed.exclusionsMm?.[0].pointsMm ?? []) {
+      expect(x).toBeGreaterThanOrEqual(rect?.xMm ?? Number.NaN)
+      expect(x).toBeLessThanOrEqual((rect?.xMm ?? 0) + (rect?.wMm ?? 0))
+      expect(y).toBeGreaterThanOrEqual(rect?.yMm ?? Number.NaN)
+      expect(y).toBeLessThanOrEqual((rect?.yMm ?? 0) + (rect?.dMm ?? 0))
+    }
+  })
+
+  it('drops a zero-point zone instead of emitting a degenerate rect', () => {
+    // Math.min() of nothing is Infinity — a kept zone here would poison the bed
+    // with a keep-out of infinite extent and nothing would ever pack.
+    const bed: ThhBedGeometry = {
+      sizeMm: { x: 256, y: 256 },
+      exclusionsMm: [{ pointsMm: [] }, { pointsMm: [[5, 5]] }],
+    }
+    expect(bedSizeFromThh(bed)?.exclude).toEqual([{ xMm: 5, yMm: 5, wMm: 0, dMm: 0 }])
+  })
+})
+
+// ---- kitPlateSignature ------------------------------------------------------
+
+const placement = (id: string, xMm: number, yMm: number, rotated = false): KitPlatePlacement => ({
+  id,
+  label: id,
+  kind: 'mid',
+  column: 1,
+  file: `${id}.stl`,
+  xMm,
+  yMm,
+  rotated,
+  wMm: 15.5,
+  hMm: 100.5,
+})
+
+const layout = (over: Partial<KitPlateLayout> = {}): KitPlateLayout => ({
+  placements: [placement('a', 10, 10), placement('b', 30, 10, true)],
+  tower: { xMm: 158, yMm: 16, wMm: 82, dMm: 72, pinXMm: 168, pinYMm: 26 },
+  bed: { wMm: 256, dMm: 256 },
+  ...over,
+})
+
+describe('kitPlateSignature (identity of a packed arrangement)', () => {
+  it('is stable for the same plate', () => {
+    expect(kitPlateSignature(layout())).toBe(kitPlateSignature(layout()))
+  })
+
+  it('does not depend on the order the placements come back in', () => {
+    // The packer is free to emit in any order; the same physical plate is the
+    // same plate, and a spurious rotation here would cost a duplicate job.
+    const forward = layout()
+    const reversed = layout({ placements: [...forward.placements].reverse() })
+    expect(kitPlateSignature(reversed)).toBe(kitPlateSignature(forward))
+  })
+
+  it('changes when a module moves', () => {
+    const moved = layout({ placements: [placement('a', 10, 10), placement('b', 31, 10, true)] })
+    expect(kitPlateSignature(moved)).not.toBe(kitPlateSignature(layout()))
+  })
+
+  it('changes when a module is turned', () => {
+    const turned = layout({
+      placements: [placement('a', 10, 10, true), placement('b', 30, 10, true)],
+    })
+    expect(kitPlateSignature(turned)).not.toBe(kitPlateSignature(layout()))
+  })
+
+  it('changes when the tower moves', () => {
+    const moved = layout({
+      tower: { xMm: 20, yMm: 16, wMm: 82, dMm: 72, pinXMm: 30, pinYMm: 26 },
+    })
+    expect(kitPlateSignature(moved)).not.toBe(kitPlateSignature(layout()))
+  })
+
+  it('changes on a different bed', () => {
+    expect(kitPlateSignature(layout({ bed: { wMm: 220, dMm: 220 } }))).not.toBe(
+      kitPlateSignature(layout())
+    )
+  })
+
+  it('ignores sub-micron float wobble — packing arithmetic is not a new plate', () => {
+    const wobbled = layout({
+      placements: [placement('a', 10 + 1e-9, 10), placement('b', 30, 10 - 1e-9, true)],
+    })
+    expect(kitPlateSignature(wobbled)).toBe(kitPlateSignature(layout()))
+  })
+
+  it('still separates plates a micron apart', () => {
+    const nudged = layout({
+      placements: [placement('a', 10.001, 10), placement('b', 30, 10, true)],
+    })
+    expect(kitPlateSignature(nudged)).not.toBe(kitPlateSignature(layout()))
+  })
+})
+
+// ---- the idempotency signature ---------------------------------------------
+
+const sigInputs = {
+  params: { cols: 13, scale_factor: 1 } as never,
+  filamentMap: { frame: 0 } as never,
+  slotLabels: ['PLA Black'],
+  style: { process: {} } as never,
+  startPolicy: 'auto' as const,
+  supportInterfaceSlotId: null,
+}
+
+describe('abacusPrintSignature carries the packed layout', () => {
+  it('rotates the key when the packer arranges the same design differently', () => {
+    // The point of the field: nothing else in the signature moved. A packer
+    // change with a reused key makes THH replay the OLD arrangement and report
+    // success, silently discarding the plate we just built.
+    const before = abacusPrintSignature({ ...sigInputs, kitLayout: kitPlateSignature(layout()) })
+    const after = abacusPrintSignature({
+      ...sigInputs,
+      kitLayout: kitPlateSignature(
+        layout({ placements: [placement('a', 10, 10), placement('b', 30, 40, true)] })
+      ),
+    })
+    expect(before).not.toBe(after)
+  })
+
+  it('holds the key for an identical repack — the retry idempotency exists for', () => {
+    expect(abacusPrintSignature({ ...sigInputs, kitLayout: kitPlateSignature(layout()) })).toBe(
+      abacusPrintSignature({ ...sigInputs, kitLayout: kitPlateSignature(layout()) })
+    )
+  })
+
+  it('tells a kit apart from the one-piece abacus it was cut from', () => {
+    expect(abacusPrintSignature({ ...sigInputs, kitLayout: kitPlateSignature(layout()) })).not.toBe(
+      abacusPrintSignature(sigInputs)
+    )
+  })
+})
+
+describe('abacusModelFileName', () => {
+  it('names a kit plate distinctly from the one-piece abacus', () => {
+    const sig = 'some-signature'
+    expect(abacusModelFileName(13, sig, 'kit')).not.toBe(abacusModelFileName(13, sig))
+    expect(abacusModelFileName(13, sig, 'kit')).toMatch(/^abacus-kit-13col-h[0-9a-f]+\.3mf$/)
+  })
+
+  it('defaults to the one-piece name, so the mono path is untouched', () => {
+    expect(abacusModelFileName(13, 'x', 'abacus')).toBe(abacusModelFileName(13, 'x'))
+  })
+})
+
+// ---- the refusal ------------------------------------------------------------
+
+describe('KitPlateFitError splits what happened from what to do', () => {
+  it('keeps `message` as the whole story for logs and bare readers', () => {
+    const err = new KitPlateFitError('overflow', ['mid 3 of 11'], 'It did not fit.', 'Try fewer.')
+    expect(err.message).toBe('It did not fit. Try fewer.')
+    expect(err.headline).toBe('It did not fit.')
+    expect(err.remediation).toBe('Try fewer.')
+    expect(err).toBeInstanceOf(Error)
+  })
+
+  it('always leaves somewhere to go — a refusal without a next step is a dead end', () => {
+    const err = new KitPlateFitError('too-big', ['mid'], 'Too big.', 'Scale it down.')
+    expect(err.remediation.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/components/create/abacus/abacus-3mf-assembly.ts
+++ b/apps/web/src/components/create/abacus/abacus-3mf-assembly.ts
@@ -57,14 +57,21 @@ export interface Assembled3mf {
   readonly wipeTower: { readonly xMm: number; readonly yMm: number }
 }
 
+export interface WipeTowerEnvelopeMm {
+  readonly minX: number
+  readonly minY: number
+  readonly maxX: number
+  readonly maxY: number
+}
+
 export interface WipeTowerProfileGeometry {
   readonly profile: string
-  readonly envelopeMm: {
-    readonly minX: number
-    readonly minY: number
-    readonly maxX: number
-    readonly maxY: number
-  }
+  /** The count-unaware bound — the max-filament row. */
+  readonly envelopeMm: WipeTowerEnvelopeMm
+  /** The bound per filament count, keyed by the count as a string. See
+   *  {@link envelopeForFilaments}: reserving the bound on a two-filament plate
+   *  throws away bed depth the tower will never occupy. */
+  readonly envelopeByFilamentsMm?: Readonly<Record<string, WipeTowerEnvelopeMm>>
   readonly process: {
     readonly prime_tower_width: number
     readonly prime_tower_brim_width: number
@@ -74,15 +81,60 @@ export interface WipeTowerProfileGeometry {
 
 /** Download/back-compat twin of THH's v1 bounded profile. The print path replaces this
  * with the selected printer's advertised copy, so a deploy can update geometry without
- * an Abaci release. */
+ * an Abaci release.
+ *
+ * The rows mirror THH's measured table (things-haunt-house#433): width is
+ * count-independent, depth grows ~10.5 mm per filament. The bound was 56 here until
+ * #34 — the pre-#433 number, which THH's own source records as escaped by the
+ * six-filament fine-layer tower it claimed to hold. */
 export const DEFAULT_WIPE_TOWER_PROFILE: WipeTowerProfileGeometry = {
   profile: 'orca-rectangle-60-v1',
-  envelopeMm: { minX: -4, minY: -4, maxX: 66, maxY: 56 },
+  envelopeMm: { minX: -4, minY: -4, maxX: 66, maxY: 59 },
+  envelopeByFilamentsMm: {
+    '2': { minX: -4, minY: -4, maxX: 66, maxY: 17 },
+    '3': { minX: -4, minY: -4, maxX: 66, maxY: 27.5 },
+    '4': { minX: -4, minY: -4, maxX: 66, maxY: 38 },
+    '5': { minX: -4, minY: -4, maxX: 66, maxY: 48.5 },
+    '6': { minX: -4, minY: -4, maxX: 66, maxY: 59 },
+  },
   process: {
     prime_tower_width: 60,
     prime_tower_brim_width: 3,
     wipe_tower_wall_type: 'rectangle',
   },
+}
+
+/**
+ * The envelope to reserve for a plate that loads `filaments` filaments.
+ *
+ * The service measures the tower per filament count and publishes the table
+ * alongside the count-unaware bound. Two filaments purge into a 70×21 band; six
+ * need 70×63. Reserving the bound for everything costs 42 mm of bed depth that
+ * nothing will ever print on — on a 256 bed that is the difference between a
+ * 13-column kit fitting one plate and being refused.
+ *
+ * The floor of 2 is deliberate and is the same reason the reserve is unconditional
+ * at all: a one-filament plate grows a tower the moment ticket routing attaches a
+ * support-interface spool, and the plate is packed before that routing resolves. At
+ * row-2 cost that hedge is nearly free.
+ *
+ * Falls back to the bound whenever the table is absent (a pre-#433 service), has no
+ * row for this count (more filaments than the profile is bounded for), or the row is
+ * malformed — a bad optional field must never shrink a reservation.
+ */
+export function envelopeForFilaments(
+  profile: WipeTowerProfileGeometry,
+  filaments?: number
+): WipeTowerEnvelopeMm {
+  const table = profile.envelopeByFilamentsMm
+  if (!table || filaments === undefined || !Number.isFinite(filaments)) return profile.envelopeMm
+  const row = table[String(Math.max(2, Math.floor(filaments)))]
+  const usable =
+    !!row &&
+    [row.minX, row.minY, row.maxX, row.maxY].every(Number.isFinite) &&
+    row.maxX > row.minX &&
+    row.maxY > row.minY
+  return usable ? row : profile.envelopeMm
 }
 
 export interface Assemble3mfOpts {
@@ -128,6 +180,11 @@ export interface Assemble3mfOpts {
     /** Orca's `wipe_tower_x/y`, from the reservation the packer left room for. */
     readonly towerPinMm: { readonly x: number; readonly y: number }
   }
+  /** How many filaments this plate will load once the ticket resolves — the
+   *  emitted bodies plus anything routing adds (a support-interface spool). Picks
+   *  the profile's envelope row; see {@link envelopeForFilaments}. Omitted, the
+   *  count-unaware bound is reserved, which is safe and wasteful. */
+  readonly filaments?: number
 }
 
 /** The printed-feet frame starts at source Z=0, above feet that dip below zero.
@@ -361,7 +418,7 @@ function placeWipeTower(
   const cx = (obj.x0 + obj.x1) / 2
   const cy = (obj.y0 + obj.y1) / 2
   const profile = opts.wipeTower ?? DEFAULT_WIPE_TOWER_PROFILE
-  const envelope = profile.envelopeMm
+  const envelope = envelopeForFilaments(profile, opts.filaments)
   const pinMidX = (envelope.minX + envelope.maxX) / 2
   const pinMidY = (envelope.minY + envelope.maxY) / 2
 

--- a/apps/web/src/components/create/abacus/abacus-3mf-assembly.ts
+++ b/apps/web/src/components/create/abacus/abacus-3mf-assembly.ts
@@ -105,6 +105,29 @@ export interface Assemble3mfOpts {
    *  between WipeTower and abacus" (exit 155). That is what prod hit on 2026-07-29.
    *  See SUPPORT_SKIRT. `support` implies this. */
   readonly supportsAtSlice?: boolean
+  /** The bodies ALREADY sit where they print on THIS bed — the packed module-kit
+   *  plate (Gitea #32), whose x/y came out of a packer that ran against this bed's
+   *  keep-outs and a purge-tower rect reserved BEFORE packing.
+   *
+   *  Two things change, and both are the same point: on a packed plate the layout
+   *  is a decision, not a pose.
+   *   1. No bed-centering. Recentering preserves the arrangement but slides it off
+   *      the coordinates the packer cleared, which can walk a module into the
+   *      filament-cutter zone it was packed around.
+   *   2. The tower pin is taken, not derived. `placeWipeTower` reasons about the
+   *      model's bounding BOX, and a plate's box swallows the hole reserved inside
+   *      it — so re-deriving would either waste the reservation or fail outright on
+   *      a full plate. The reserve is what makes the tower fit; honour it.
+   *
+   *  Also relaxes the >= 2 bodies guard: a plate is a multi-object layout even when
+   *  every object rides one filament, and the `meshesToThreeMf` path would re-origin
+   *  it into the bed corner. Z is NOT affected: `tz` still drops the plate to the
+   *  bed exactly as it drops a mono abacus, which is what keeps the support-transition
+   *  modifier on the frame's z=0 plane rather than under the feet. */
+  readonly placedOnBed?: {
+    /** Orca's `wipe_tower_x/y`, from the reservation the packer left room for. */
+    readonly towerPinMm: { readonly x: number; readonly y: number }
+  }
 }
 
 /** The printed-feet frame starts at source Z=0, above feet that dip below zero.
@@ -122,7 +145,11 @@ export const BAMBU_256_BED: BedSize = {
   exclude: [{ xMm: 0, yMm: 0, wMm: 18, dMm: 28 }],
 }
 
-const TOWER_GAP = 6
+/** Clear space kept between the tower and the model. Exported because the packed
+ *  kit plate (abacus-kit-plate.ts) reserves its tower rect BEFORE packing rather
+ *  than placing it beside a finished model — same clearance law, applied at the
+ *  other end of the pipeline, so the number must not be restated there. */
+export const TOWER_GAP = 6
 
 // Extra reserve once supports are on: the first layer stops being the model's own
 // footprint. Support material grows outward from the overhangs it holds, so extrusion
@@ -147,7 +174,9 @@ const TOWER_GAP = 6
 // disprove it: the log says `before arrange, need_arrange=0` — arrange never runs on a
 // 3MF project — and the model printed at its declared min corner (declared 90.25,77.75
 // vs printed 90.46,75.96), in its declared orientation. Distance is the only lever.
-const SUPPORT_SKIRT = 8
+//
+// Exported alongside TOWER_GAP for the packed kit plate's pre-pack reserve.
+export const SUPPORT_SKIRT = 8
 // How far a cornered tower keeps off the bed edge. The reserve above covers the
 // tower's own extrusion, but a tower pushed flush into the corner still trips the
 // multi-extruder printable-area check (exit 154, "gcode in unprintable area") —
@@ -433,7 +462,7 @@ export function assembleAbacus3mf(
   if (bodies.length === 0) {
     throw new Error('assembleAbacus3mf needs at least one filament body')
   }
-  if (bodies.length < 2 && !opts.support) {
+  if (bodies.length < 2 && !opts.support && !opts.placedOnBed) {
     throw new Error(
       'assembleAbacus3mf needs >= 2 filament bodies (single color rides meshesToThreeMf)'
     )
@@ -456,11 +485,14 @@ export function assembleAbacus3mf(
     }
   }
 
-  // Center the footprint on the bed and drop it to z=0.
+  // Center the footprint on the bed and drop it to z=0 — unless the bodies were
+  // PLACED on this bed already (see Assemble3mfOpts.placedOnBed), in which case
+  // their x/y are the layout and only the z-drop applies.
   const bedCx = bed.wMm / 2
   const bedCy = bed.dMm / 2
-  const tx = bedCx - (minX + maxX) / 2
-  const ty = bedCy - (minY + maxY) / 2
+  const placed = opts.placedOnBed
+  const tx = placed ? 0 : bedCx - (minX + maxX) / 2
+  const ty = placed ? 0 : bedCy - (minY + maxY) / 2
   const tz = -minZ
 
   const objBox: Box = {
@@ -469,7 +501,9 @@ export function assembleAbacus3mf(
     x1: bedCx + (maxX - minX) / 2,
     y1: bedCy + (maxY - minY) / 2,
   }
-  const tower = placeWipeTower(bed, objBox, opts)
+  const tower = placed
+    ? { xMm: placed.towerPinMm.x, yMm: placed.towerPinMm.y }
+    : placeWipeTower(bed, objBox, opts)
 
   // ---- 3D/3dmodel.model ----
   const childIds = bodies.map((_, i) => i + 2)

--- a/apps/web/src/components/create/abacus/abacus-3mf.ts
+++ b/apps/web/src/components/create/abacus/abacus-3mf.ts
@@ -113,6 +113,10 @@ export interface AbacusThreeMf {
   wipeTower: {
     profile: string
     pinMm: { x: number; y: number }
+    /** The filament count whose envelope row sized this reservation. Echoed to the
+     *  service, which cross-checks it against the resolved plan and rejects a
+     *  disagreement up front rather than letting a wrong-sized hole reach the slicer. */
+    packedForFilaments: number
   } | null
 }
 
@@ -189,6 +193,9 @@ export function buildAbacusThreeMf(args: {
   bed?: BedSize
   /** Selected printer's bounded profile; download-only callers use the bundled twin. */
   wipeTower?: WipeTowerProfileGeometry
+  /** Filaments the ticket adds beyond the emitted bodies — the support-interface
+   *  spool. A download adds none. */
+  extraFilaments?: number
 }): AbacusThreeMf {
   const {
     stl,
@@ -202,6 +209,7 @@ export function buildAbacusThreeMf(args: {
     supportsAtSlice,
     bed = BAMBU_256_BED,
     wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
+    extraFilaments,
   } = args
 
   const mesh = parseStl(stl)
@@ -312,6 +320,7 @@ export function buildAbacusThreeMf(args: {
     supportsAtSlice,
     bed,
     wipeTower,
+    extraFilaments,
   })
 }
 
@@ -342,6 +351,10 @@ export function emitThreeMfBodies(args: {
    *  a plate is a placed layout even when it lands on one filament, and the
    *  single-body path would re-origin it into the bed corner. */
   placedOnBed?: { towerPinMm: { x: number; y: number } }
+  /** Filaments the resolved ticket will load that no body carries — today the
+   *  support-interface spool, so 0 or 1. Added to the emitted body count to pick
+   *  the tower's envelope row and to report `packedForFilaments`. */
+  extraFilaments?: number
 }): AbacusThreeMf {
   const {
     mesh,
@@ -355,6 +368,7 @@ export function emitThreeMfBodies(args: {
     bed,
     wipeTower,
     placedOnBed,
+    extraFilaments = 0,
   } = args
 
   // Count triangles per slot, then bucket the position soup (9 floats/tri).
@@ -424,12 +438,19 @@ export function emitThreeMfBodies(args: {
   // tower just 6 mm from a supported model before exit 155 (2026-07-29); a later A/B
   // slices that same 6 mm clean, so read the extra room as margin, not a proven cure.
   // Single filament needs neither: no second extruder, no tower, nothing to collide with.
+  // What the plate will actually load: one filament per emitted body, plus whatever
+  // routing adds on top. This is the same arithmetic the ticket does downstream (one
+  // entry per distinct body slot, then the support-interface entry), derived from the
+  // same slot set, so the reservation and the declared count cannot disagree.
+  const plateFilaments = bodies.length + extraFilaments
+
   if (assemblyBodies.length >= 2 || feetPrinted || placedOnBed) {
     const assembled = assembleAbacus3mf(assemblyBodies, bed, {
       support: feetPrinted,
       supportsAtSlice,
       wipeTower,
       placedOnBed,
+      filaments: plateFilaments,
     })
     return {
       bytes: assembled.bytes,
@@ -440,6 +461,7 @@ export function emitThreeMfBodies(args: {
       wipeTower: {
         profile: wipeTower.profile,
         pinMm: { x: assembled.wipeTower.xMm, y: assembled.wipeTower.yMm },
+        packedForFilaments: plateFilaments,
       },
     }
   }

--- a/apps/web/src/components/create/abacus/abacus-3mf.ts
+++ b/apps/web/src/components/create/abacus/abacus-3mf.ts
@@ -47,6 +47,7 @@
  */
 import { type BedSize, type ColorBody, meshesToThreeMf } from '@eink/frames-engine/print-bundle'
 import { parseStl, type StlMesh, writeBinaryStl } from '@eink/frames-engine/stl'
+import type { ThhBedGeometry } from '@/lib/abacus/print/filament-wire'
 import {
   type AssemblyBody,
   assembleAbacus3mf,
@@ -113,6 +114,37 @@ export interface AbacusThreeMf {
     profile: string
     pinMm: { x: number; y: number }
   } | null
+}
+
+/**
+ * Project THH's reported machine geometry onto the `BedSize` the emitter and
+ * the packer both take. Shared by the one-piece submit and the module-kit
+ * plate (Gitea #32) so the two can't drift into disagreeing about the plate
+ * they're laying parts on.
+ *
+ * Exclusion POLYGONS collapse to their axis-aligned bounding rect: everything
+ * downstream reserves rectangles, and over-reserving a keep-out only costs
+ * area, while under-reserving it puts a part where the printer can't print.
+ * A zero-point zone is dropped rather than becoming a degenerate rect at the
+ * origin — `Math.min()` of nothing is `Infinity`, which would poison the bed.
+ *
+ * Returns `undefined` for an absent bed, which every caller reads as "use the
+ * bundled fallback plate" — a download-only path has no printer to ask.
+ */
+export function bedSizeFromThh(bed: ThhBedGeometry | undefined): BedSize | undefined {
+  if (!bed) return undefined
+  return {
+    wMm: bed.sizeMm.x,
+    dMm: bed.sizeMm.y,
+    exclude: (bed.exclusionsMm ?? []).flatMap((zone) => {
+      if (zone.pointsMm.length === 0) return []
+      const xs = zone.pointsMm.map((point) => point[0])
+      const ys = zone.pointsMm.map((point) => point[1])
+      const x0 = Math.min(...xs)
+      const y0 = Math.min(...ys)
+      return [{ xMm: x0, yMm: y0, wMm: Math.max(...xs) - x0, dMm: Math.max(...ys) - y0 }]
+    }),
+  }
 }
 
 /**

--- a/apps/web/src/components/create/abacus/abacus-3mf.ts
+++ b/apps/web/src/components/create/abacus/abacus-3mf.ts
@@ -305,6 +305,11 @@ export function emitThreeMfBodies(args: {
   supportsAtSlice?: boolean
   bed: BedSize
   wipeTower: WipeTowerProfileGeometry
+  /** The soups are already laid out on this bed (the packed module-kit plate,
+   *  Gitea #32) — see `Assemble3mfOpts.placedOnBed`. Forces the assembly path:
+   *  a plate is a placed layout even when it lands on one filament, and the
+   *  single-body path would re-origin it into the bed corner. */
+  placedOnBed?: { towerPinMm: { x: number; y: number } }
 }): AbacusThreeMf {
   const {
     mesh,
@@ -317,6 +322,7 @@ export function emitThreeMfBodies(args: {
     supportsAtSlice,
     bed,
     wipeTower,
+    placedOnBed,
   } = args
 
   // Count triangles per slot, then bucket the position soup (9 floats/tri).
@@ -386,11 +392,12 @@ export function emitThreeMfBodies(args: {
   // tower just 6 mm from a supported model before exit 155 (2026-07-29); a later A/B
   // slices that same 6 mm clean, so read the extra room as margin, not a proven cure.
   // Single filament needs neither: no second extruder, no tower, nothing to collide with.
-  if (assemblyBodies.length >= 2 || feetPrinted) {
+  if (assemblyBodies.length >= 2 || feetPrinted || placedOnBed) {
     const assembled = assembleAbacus3mf(assemblyBodies, bed, {
       support: feetPrinted,
       supportsAtSlice,
       wipeTower,
+      placedOnBed,
     })
     return {
       bytes: assembled.bytes,

--- a/apps/web/src/components/create/abacus/abacus-kit-plate.ts
+++ b/apps/web/src/components/create/abacus/abacus-kit-plate.ts
@@ -102,12 +102,26 @@ export type KitPlateRefusal =
 export class KitPlateFitError extends Error {
   readonly reason: KitPlateRefusal
   readonly modules: readonly string[]
+  /** What happened, on its own — the UI headline. */
+  readonly headline: string
+  /** The knob to turn, on its own. Every refusal has one, so this is never null:
+   *  a plate we won't ship must always leave the user somewhere to go. */
+  readonly remediation: string
 
-  constructor(reason: KitPlateRefusal, modules: readonly string[], message: string) {
-    super(message)
+  constructor(
+    reason: KitPlateRefusal,
+    modules: readonly string[],
+    headline: string,
+    remediation: string
+  ) {
+    // `message` stays the whole story so a log line or a bare `.message` reader
+    // loses nothing; the split above is for a UI that renders the two apart.
+    super(`${headline} ${remediation}`)
     this.name = 'KitPlateFitError'
     this.reason = reason
     this.modules = modules
+    this.headline = headline
+    this.remediation = remediation
   }
 }
 
@@ -314,6 +328,33 @@ export interface KitPlateLayout {
 }
 
 /**
+ * A compact string identity for a packed arrangement — same plate in, same
+ * string out; move any module and it changes.
+ *
+ * Feeds the submit's idempotency signature (see `print-idempotency`), where it
+ * covers the one way two submits can differ that none of the user's own inputs
+ * would show: the PACKER changing its mind. Every field the panel already
+ * hashes (params, bed, tower profile) derives this layout today, so a packer
+ * heuristic tweak — or the pending swap onto `@eink/plate-packing` — is exactly
+ * the case where the design looks unchanged and the plate isn't. Reusing the
+ * key there would make THH replay the previously-arranged job and quietly
+ * discard the new arrangement.
+ *
+ * Coordinates are rounded to a micron before hashing: they come out of
+ * floating-point packing arithmetic, and a 1e-12 wobble is not a new plate.
+ */
+export function kitPlateSignature(layout: KitPlateLayout): string {
+  const µm = (mm: number): number => Math.round(mm * 1000)
+  const parts = layout.placements
+    .map((pl) => `${pl.id}@${µm(pl.xMm)},${µm(pl.yMm)}${pl.rotated ? 'r' : ''}`)
+    .sort()
+    .join('|')
+  return `${µm(layout.bed.wMm)}x${µm(layout.bed.dMm)};t${µm(layout.tower.xMm)},${µm(
+    layout.tower.yMm
+  )};${parts}`
+}
+
+/**
  * The tower footprint to keep clear, from the printer's own bounded profile.
  *
  * Mirrors `towerReserveFromCapability`'s envelope → rect translation (it can't be
@@ -422,7 +463,8 @@ export function packKitPlate(args: {
         reserve.dMm
       )} mm rectangle for the purge tower on this ${bedLabel(
         bed
-      )} — refusing to ship a multi-filament plate the slicer would reject. Select a printer with a bigger bed, or print the kit module by module from the zip.`
+      )} — refusing to ship a multi-filament plate the slicer would reject.`,
+      'Select a printer with a bigger bed, or print the kit module by module from the zip.'
     )
   }
 
@@ -445,7 +487,8 @@ export function packKitPlate(args: {
       names,
       `${names.join(', ')} ${
         names.length === 1 ? 'is' : 'are'
-      } too big for this ${bedLabel(bed)} even alone — refusing to ship a plate the printer can't print. Scale the design down, or select a printer with a bigger bed.`
+      } too big for this ${bedLabel(bed)} even alone — refusing to ship a plate the printer can't print.`,
+      'Scale the design down, or select a printer with a bigger bed.'
     )
   }
   if (packed.plateCount > 1) {
@@ -455,9 +498,8 @@ export function packKitPlate(args: {
       spilled,
       `this kit needs ${packed.plateCount} build plates — ${spilled.join(
         ', '
-      )} won't fit beside the rest on this ${bedLabel(
-        bed
-      )}. Refusing to ship a plate with modules missing: print fewer columns, scale the design down, or select a printer with a bigger bed. The kit zip still prints module by module.`
+      )} won't fit beside the rest on this ${bedLabel(bed)}.`,
+      'Refusing to ship a plate with modules missing: print fewer columns, scale the design down, or select a printer with a bigger bed. The kit zip still prints module by module.'
     )
   }
 

--- a/apps/web/src/components/create/abacus/abacus-kit-plate.ts
+++ b/apps/web/src/components/create/abacus/abacus-kit-plate.ts
@@ -1,0 +1,647 @@
+/**
+ * The modular column kit on ONE build plate (Gitea #32, Phase A).
+ *
+ * A print ticket is one plate, one sliced job — there is no quantity field
+ * anywhere in the contract and no batch concept. So for the kit to become "hit
+ * print", somebody has to lay 13 modules out on a bed. Today that somebody is
+ * the user, in their slicer, from the kit zip. This module is that somebody.
+ *
+ * WHAT IS BORROWED. Frame Studio already solved plate packing and the packer is
+ * shared: MaxRects under a 12-way tournament (3 fit heuristics × 4 biggest-first
+ * orderings, fewest plates then tightest envelope), gap applied by inflating
+ * footprints, free 90° rotation. The purge tower is RESERVED BEFORE packing, as
+ * a keep-out the parts pack around — a tower that lands on a part is a slice the
+ * printer refuses outright, which is our own exit-154/155 history in someone
+ * else's words. Bed truth comes from the printer, not a constant.
+ *
+ * WHAT IS OURS. Frame Studio packs single-body parts. A module is a multi-body
+ * assembly — frame + its bead column + printed TPU feet + inset text inlays —
+ * whose bodies must stay registered to each other or the beads come off their
+ * rods and the inlays miss their pockets. So the new piece is {@link
+ * placeModuleBodies}: one placement (the free 90° turn AND the translate)
+ * applied to EVERY body of that module through ONE shared basis. Per-body
+ * re-origin is the bug this module exists to not have — it is what "rigid group"
+ * means, and it is why the basis ({@link ModuleBasis}) is computed once per
+ * module kind and used by BOTH the packer's footprint and the transform. If
+ * those two ever came from different boxes, every module would print shifted
+ * from where the packer thought it was.
+ *
+ * WHAT IS SHARED WITH THE ZIP PATH. Everything upstream of placement:
+ * `moduleSoups` runs the same hard-error gate (shell topology, footless module,
+ * empty text pockets) each module's standalone 3MF runs, and the plate emits
+ * through the same `emitThreeMfBodies` tail, so container law and role→filament
+ * law each still live in exactly one place. The per-module zip path is
+ * unchanged — a plate is a different container, not a different abacus.
+ *
+ * REFUSALS. This ticket either fits one plate or falls back to the zip. An
+ * overfull plate, a module too big for the bed, or a tower with nowhere to go
+ * all raise {@link KitPlateFitError} naming what didn't fit and which knob moves
+ * it. Never silently drop a module: a kit missing a column is not a kit.
+ *
+ * IMPORT NOTE. `packPlates`, `meshBounds` and the tower reserve come from
+ * `@eink/frames-engine` today. They move to `@eink/plate-packing` (eink PR #569)
+ * once it publishes — a pure extraction with identical signatures, so that
+ * switch is an import-line edit.
+ */
+import {
+  type BedRect,
+  type BedSize,
+  meshBounds,
+  type PackItem,
+  packPlates,
+} from '@eink/frames-engine/print-bundle'
+import {
+  type PlacedTower,
+  placeTowerReserve,
+  type TowerReserve,
+  towerMargin,
+} from '@eink/frames-engine/wipe-tower'
+import { type AbacusThreeMf, emitThreeMfBodies, type SpoolBodySummary } from './abacus-3mf'
+import {
+  BAMBU_256_BED,
+  DEFAULT_WIPE_TOWER_PROFILE,
+  SUPPORT_SKIRT,
+  TOWER_GAP,
+  type WipeTowerProfileGeometry,
+} from './abacus-3mf-assembly'
+import { type FilamentMap, isModular, type Params } from './abacus-model'
+import {
+  type ModuleExportParts,
+  type ModuleKind,
+  type ModuleSoups,
+  moduleKitPlan,
+  moduleSoups,
+} from './abacus-module-kit'
+
+const EPS = 1e-6
+
+/** Gap left between neighbouring modules on the plate. Matches the shared
+ *  bundler's own default — enough for each module's brim without spending bed. */
+const KIT_PLATE_GAP_MM = 4
+
+// ---- refusals ---------------------------------------------------------------
+
+/** Why a kit can't ship as one plate. Each wants a different move from the
+ *  person who composed the design, so they stay distinguishable. */
+export type KitPlateRefusal =
+  /** Everything fits the bed alone, but not together. */
+  | 'overflow'
+  /** One module exceeds the usable bed even by itself. */
+  | 'too-big'
+  /** No clear rectangle left for the purge tower. */
+  | 'no-tower-room'
+
+/**
+ * A kit that cannot be laid out on one plate. `modules` names the labels that
+ * didn't fit (empty for a tower refusal — nothing is at fault but the bed), so a
+ * caller can point at them instead of re-deriving the diagnosis from prose.
+ *
+ * Typed rather than a bare Error because the fallback differs: the zip download
+ * still prints every one of these module by module, and the UI should say so.
+ */
+export class KitPlateFitError extends Error {
+  readonly reason: KitPlateRefusal
+  readonly modules: readonly string[]
+
+  constructor(reason: KitPlateRefusal, modules: readonly string[], message: string) {
+    super(message)
+    this.name = 'KitPlateFitError'
+    this.reason = reason
+    this.modules = modules
+  }
+}
+
+const bedLabel = (bed: BedSize): string => `${bed.wMm} × ${bed.dMm} mm bed`
+
+// ---- instances --------------------------------------------------------------
+
+/** One physically printed module on the plate: which geometry, which global
+ *  column's bead roles ink it, and the two names that follow it downstream. */
+export interface KitPlateInstance {
+  /** Stable and unique within the plate — what the packer keys on. */
+  readonly id: string
+  /** Unique human name — what a job binding, a bed preview or an error names. */
+  readonly label: string
+  readonly kind: ModuleKind
+  /** The GLOBAL column whose bead roles color this instance's beads. Bead color
+   *  varies per column, so an instance carries its own — a placed module that
+   *  borrowed its neighbour's column would print the wrong beads. */
+  readonly column: number
+  /** The kit-zip member this instance is a copy of. The label deliberately does
+   *  NOT encode the mid variant (`mid 3 of 11` reads better than
+   *  `mid-10s 1 of 3`), so the machine-readable variant identity lives here. */
+  readonly file: string
+}
+
+/**
+ * Expand the kit plan's counts into individually placeable instances: `mid ×11`
+ * becomes eleven modules, each with its own id and label.
+ *
+ * Mid instances are numbered ACROSS variants, in plan order — the five bead-slot
+ * variants of a 13-column kit are eleven mid modules to the person at the
+ * printer, and eleven pieces is what they'll count off the plate. A kit with a
+ * single mid (a 3-column design) drops the ordinal rather than reading `mid 1
+ * of 1`. Ends are never numbered: there is exactly one of each.
+ */
+export function kitPlateInstances(p: Params, fm: FilamentMap): KitPlateInstance[] {
+  const entries = moduleKitPlan(p, fm)
+  const mids = entries.reduce((n, e) => n + (e.kind === 'mid' ? e.count : 0), 0)
+  const out: KitPlateInstance[] = []
+  let nth = 0
+  for (const e of entries) {
+    for (let k = 0; k < e.count; k++) {
+      if (e.kind === 'mid') {
+        nth++
+        out.push({
+          id: `mid-${nth}`,
+          label: mids === 1 ? 'mid' : `mid ${nth} of ${mids}`,
+          kind: 'mid',
+          column: e.column,
+          file: e.file,
+        })
+      } else {
+        out.push({
+          id: e.kind,
+          label: `${e.kind} end`,
+          kind: e.kind,
+          column: e.column,
+          file: e.file,
+        })
+      }
+    }
+  }
+  return out
+}
+
+// ---- footprints -------------------------------------------------------------
+
+/**
+ * A module kind's XY footprint and the origin its bodies are measured from —
+ * the ONE box that both the packer and {@link placeModuleBodies} read.
+ *
+ * Measured off the GATED soups rather than the raw renders, so what's measured
+ * is exactly what ships: a feet render present on a design whose feet aren't
+ * printed never enters the geometry and must never enter the footprint either.
+ * In practice the frame body decides the box (feet sit in its pockets, inlays in
+ * its carved text), but the union costs one pass and cannot be wrong if some
+ * future part pass pokes proud.
+ */
+export interface ModuleBasis {
+  readonly kind: ModuleKind
+  /** XY origin of the module's own render frame — subtracted on placement. There
+   *  is deliberately no Z here: placement is an XY decision, and the plate's drop
+   *  to the bed stays with the container (see {@link placeModuleBodies}). */
+  readonly minX: number
+  readonly minY: number
+  /** Footprint fed to the packer (un-rotated). */
+  readonly wMm: number
+  readonly hMm: number
+}
+
+/** Measure one kind's basis from its gated soups. Every instance of a kind
+ *  renders from the same passes — one render per geometry is the kit's whole
+ *  dedupe premise — so this is computed once per kind and shared. */
+export function moduleBasis(kind: ModuleKind, soups: ModuleSoups): ModuleBasis {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  const all = [
+    soups.mesh,
+    ...soups.partSoups.map((s) => ({
+      positions: s.positions,
+      triangleCount: s.positions.length / 9,
+    })),
+  ]
+  for (const s of all) {
+    if (s.triangleCount === 0) continue
+    const b = meshBounds(s)
+    if (b.minX < minX) minX = b.minX
+    if (b.minY < minY) minY = b.minY
+    if (b.maxX > maxX) maxX = b.maxX
+    if (b.maxY > maxY) maxY = b.maxY
+  }
+  if (!Number.isFinite(minX)) {
+    throw new Error(`the module_${kind} render has no triangles — nothing to place`)
+  }
+  return { kind, minX, minY, wMm: maxX - minX, hMm: maxY - minY }
+}
+
+// ---- rigid-group placement --------------------------------------------------
+
+/** The classified body soup's slots live per SHELL, not per soup, so its slot
+ *  field is unread on the way through the group transform. */
+const SLOT_PER_SHELL = -1
+
+/** A triangle soup bound to a filament slot. */
+export interface SlotSoup {
+  readonly slot: number
+  readonly positions: Float32Array
+}
+
+/** Where the packer put one module: min corner on the bed, and whether it was
+ *  turned 90° about Z (free for printing — the print face stays down). */
+export interface ModulePlacement {
+  readonly xMm: number
+  readonly yMm: number
+  readonly rotated: boolean
+}
+
+/**
+ * Apply ONE placement to EVERY body of one module — the rigid-group transform.
+ *
+ * The upstream single-body path rotates a part's soup by (x, y) → (−y, x) and
+ * then re-origins it by re-measuring its own bounds. Re-measuring per body is
+ * exactly what must not happen here: a module's feet and its frame have
+ * different bounds, so each would land on its own origin and the module would
+ * come apart — feet under the wrong column, inlays beside their pockets.
+ *
+ * So the basis is shared and applied analytically. Under (x, y) → (−y, x) the
+ * group's box maps to x ∈ [−maxY, −minY], y ∈ [minX, maxX], so re-origining the
+ * ROTATED group means subtracting −maxY from x and minX from y. Both are
+ * constants of the group, never of the body:
+ *
+ *   un-rotated   x' = x − minX + X        y' = y − minY + Y
+ *   rotated      x' = maxY − y + X        y' = x − minX + Y
+ *
+ * Z is left exactly as rendered. Packing is an XY decision, and dropping the
+ * print onto the bed is the container's job — `assembleAbacus3mf` already
+ * translates the whole assembly by −minZ, and doing it here instead would move
+ * the frame's z=0 plane out from under the support-transition modifier, which is
+ * pinned to that plane (printed feet dip BELOW zero and the modifier follows the
+ * frame/support boundary, not the feet).
+ *
+ * The result is the module standing at its packed slot with every internal
+ * relationship — bead-to-channel clearance, foot-to-pocket registration —
+ * untouched, because a rotation and a translation are the same rigid motion for
+ * all of its bodies.
+ */
+export function placeModuleBodies(
+  bodies: readonly SlotSoup[],
+  basis: ModuleBasis,
+  at: ModulePlacement
+): SlotSoup[] {
+  const maxY = basis.minY + basis.hMm
+  return bodies.map((body) => {
+    const src = body.positions
+    const out = new Float32Array(src.length)
+    for (let i = 0; i < src.length; i += 3) {
+      const x = src[i]
+      const y = src[i + 1]
+      out[i] = (at.rotated ? maxY - y : x - basis.minX) + at.xMm
+      out[i + 1] = (at.rotated ? x - basis.minX : y - basis.minY) + at.yMm
+      out[i + 2] = src[i + 2]
+    }
+    return { slot: body.slot, positions: out }
+  })
+}
+
+// ---- packing ----------------------------------------------------------------
+
+/** One module as laid out, footprint resolved post-rotation — enough to draw the
+ *  bed, and enough for a test to prove nothing overlaps. */
+export interface KitPlatePlacement extends KitPlateInstance, ModulePlacement {
+  readonly wMm: number
+  readonly hMm: number
+}
+
+export interface KitPlateLayout {
+  readonly placements: readonly KitPlatePlacement[]
+  /** The reserved purge-tower rect and the pin inside it. */
+  readonly tower: PlacedTower
+  /** The bed everything above is in the coordinates of. */
+  readonly bed: BedSize
+}
+
+/**
+ * The tower footprint to keep clear, from the printer's own bounded profile.
+ *
+ * Mirrors `towerReserveFromCapability`'s envelope → rect translation (it can't be
+ * called directly: the service capability carries `version`/`maxFilaments` that
+ * the bundled geometry twin doesn't) and adds the clearance ring the mono
+ * placement keeps — TOWER_GAP, plus SUPPORT_SKIRT when supports will be on,
+ * which is the exit-155 lesson: supports push the first layer past the model
+ * outline while the tower's brim reaches back, and the two must not meet.
+ *
+ * The ring has to be part of the RESERVE, not left to the packer's gap: the
+ * packer inflates each footprint on its high sides only, so a module may sit
+ * flush against the low edges of any keep-out.
+ */
+function plateTowerReserve(
+  profile: WipeTowerProfileGeometry,
+  supports: boolean
+): Extract<TowerReserve, { kind: 'reserve' }> {
+  const clear = TOWER_GAP + (supports ? SUPPORT_SKIRT : 0)
+  const e = profile.envelopeMm
+  return {
+    kind: 'reserve',
+    profile: profile.profile,
+    wMm: e.maxX - e.minX + 2 * clear,
+    dMm: e.maxY - e.minY + 2 * clear,
+    // Pin such that the envelope sits centred in the reserved rect: the tower
+    // spills below-left of its pin, so the pin is NOT the rect's min corner.
+    pinOffsetXMm: clear - e.minX,
+    pinOffsetYMm: clear - e.minY,
+  }
+}
+
+/** Maximal free rectangles of `f` once `ex` is carved out (the two overlap-free
+ *  cases return `f` untouched). */
+function splitRect(f: BedRect, ex: BedRect): BedRect[] {
+  const fx1 = f.xMm + f.wMm
+  const fy1 = f.yMm + f.dMm
+  const ex1 = ex.xMm + ex.wMm
+  const ey1 = ex.yMm + ex.dMm
+  const disjoint =
+    ex.xMm >= fx1 - EPS || ex1 <= f.xMm + EPS || ex.yMm >= fy1 - EPS || ey1 <= f.yMm + EPS
+  if (disjoint) return [f]
+  const out: BedRect[] = []
+  if (ex.xMm > f.xMm + EPS) out.push({ xMm: f.xMm, yMm: f.yMm, wMm: ex.xMm - f.xMm, dMm: f.dMm })
+  if (ex1 < fx1 - EPS) out.push({ xMm: ex1, yMm: f.yMm, wMm: fx1 - ex1, dMm: f.dMm })
+  if (ex.yMm > f.yMm + EPS) out.push({ xMm: f.xMm, yMm: f.yMm, wMm: f.wMm, dMm: ex.yMm - f.yMm })
+  if (ey1 < fy1 - EPS) out.push({ xMm: f.xMm, yMm: ey1, wMm: f.wMm, dMm: fy1 - ey1 })
+  return out
+}
+
+/** The bed's genuinely usable rectangles at `margin`, printer keep-outs carved
+ *  out — what the tower reservation searches. Mirrors the packer's own free-space
+ *  seed, which frames-engine keeps private; it comes across with the rest of the
+ *  import block when `@eink/plate-packing` publishes. Overlapping candidates are
+ *  left in: they only widen the search, never move its answer. */
+function bedFreeRects(bed: BedSize, margin: number): BedRect[] {
+  const wMm = bed.wMm - 2 * margin
+  const dMm = bed.dMm - 2 * margin
+  if (wMm <= EPS || dMm <= EPS) return []
+  let free: BedRect[] = [{ xMm: margin, yMm: margin, wMm, dMm }]
+  for (const ex of bed.exclude ?? []) free = free.flatMap((f) => splitRect(f, ex))
+  return free
+}
+
+/**
+ * Reserve the purge tower, then pack every instance around it onto ONE plate.
+ *
+ * The tower goes first and the parts pack around the hole it leaves — reversing
+ * that order is how a tower ends up on top of a module, which the slicer refuses
+ * outright. The reservation is unconditional: like the mono export's pin, it
+ * stays available because ticket routing can add a support-interface filament and
+ * turn a one-filament plate into a real two-filament slice. Bed area is the
+ * cheaper thing to spend.
+ *
+ * @throws {KitPlateFitError} when the kit needs more than one plate, when a
+ * module exceeds the bed alone, or when no rectangle is left for the tower.
+ * Phase A ships one plate or nothing.
+ */
+export function packKitPlate(args: {
+  instances: readonly KitPlateInstance[]
+  bases: Record<ModuleKind, ModuleBasis>
+  /** THH's reported geometry for the selected printer; download-only callers get
+   *  the fallback plate. */
+  bed?: BedSize
+  gapMm?: number
+  wipeTower?: WipeTowerProfileGeometry
+  /** Supports will be on when this plate is sliced (printed feet, or the
+   *  operator's ticket style) — widens the tower's clearance ring. */
+  supportsAtSlice?: boolean
+}): KitPlateLayout {
+  const {
+    instances,
+    bases,
+    bed = BAMBU_256_BED,
+    gapMm = KIT_PLATE_GAP_MM,
+    wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
+    supportsAtSlice = false,
+  } = args
+
+  const reserve = plateTowerReserve(wipeTower, supportsAtSlice)
+  const tower = placeTowerReserve(bed, reserve, bedFreeRects(bed, towerMargin(bed)))
+  if (!tower) {
+    throw new KitPlateFitError(
+      'no-tower-room',
+      [],
+      `no clear ${Math.round(reserve.wMm)} × ${Math.round(
+        reserve.dMm
+      )} mm rectangle for the purge tower on this ${bedLabel(
+        bed
+      )} — refusing to ship a multi-filament plate the slicer would reject. Select a printer with a bigger bed, or print the kit module by module from the zip.`
+    )
+  }
+
+  const items: PackItem[] = instances.map((inst) => ({
+    id: inst.id,
+    wMm: bases[inst.kind].wMm,
+    hMm: bases[inst.kind].hMm,
+  }))
+  const packed = packPlates(items, bed, gapMm, tower)
+  const byId = new Map(packed.placements.map((pl) => [pl.id, pl]))
+  const labelOf = (id: string): string =>
+    instances.find((inst) => inst.id === id)?.label ?? `module ${id}`
+
+  // Too-big first: it is the more specific diagnosis, and it also shows up as an
+  // overflow (each too-big part is parked on a plate of its own).
+  if (packed.tooBig.length > 0) {
+    const names = packed.tooBig.map(labelOf)
+    throw new KitPlateFitError(
+      'too-big',
+      names,
+      `${names.join(', ')} ${
+        names.length === 1 ? 'is' : 'are'
+      } too big for this ${bedLabel(bed)} even alone — refusing to ship a plate the printer can't print. Scale the design down, or select a printer with a bigger bed.`
+    )
+  }
+  if (packed.plateCount > 1) {
+    const spilled = packed.placements.filter((pl) => pl.plate > 0).map((pl) => labelOf(pl.id))
+    throw new KitPlateFitError(
+      'overflow',
+      spilled,
+      `this kit needs ${packed.plateCount} build plates — ${spilled.join(
+        ', '
+      )} won't fit beside the rest on this ${bedLabel(
+        bed
+      )}. Refusing to ship a plate with modules missing: print fewer columns, scale the design down, or select a printer with a bigger bed. The kit zip still prints module by module.`
+    )
+  }
+
+  const placements = instances.map((inst): KitPlatePlacement => {
+    const pl = byId.get(inst.id)
+    if (!pl) {
+      // packPlates returns one placement per item id; a hole means the ids the
+      // packer saw and the ids we expanded disagree (programming error).
+      throw new Error(`the packer returned no placement for ${inst.label}`)
+    }
+    const basis = bases[inst.kind]
+    return {
+      ...inst,
+      xMm: pl.xMm,
+      yMm: pl.yMm,
+      rotated: pl.rotated,
+      wMm: pl.rotated ? basis.hMm : basis.wMm,
+      hMm: pl.rotated ? basis.wMm : basis.hMm,
+    }
+  })
+
+  return { placements, tower, bed }
+}
+
+// ---- the plate --------------------------------------------------------------
+
+export interface KitPlate extends KitPlateLayout {
+  /** The finished single-plate multi-material `.3mf` (zip bytes). */
+  readonly bytes: Uint8Array
+  /** One entry per emitted body, ascending slot order. */
+  readonly bodies: readonly SpoolBodySummary[]
+  /** The tower pin written into the plate's project settings. */
+  readonly wipeTower: AbacusThreeMf['wipeTower']
+}
+
+/**
+ * Build the whole kit as ONE plate: expand the plan into instances, gate and
+ * classify each module exactly as its standalone 3MF would, pack the footprints
+ * around a reserved purge tower, apply each placement rigidly to every body of
+ * its module, and emit the lot through the shared bucket/emit tail.
+ *
+ * Classification happens BEFORE placement, and that ordering is load-bearing:
+ * `analyzeModuleShells` reads bead centers at the module's known local x and
+ * hard-errors on anything else, so a rotated or translated module would fail its
+ * own gate. Placement is the last thing that touches geometry.
+ *
+ * @throws {KitPlateFitError} when the kit doesn't fit one plate — the caller
+ * falls back to the kit zip.
+ */
+export function buildKitPlateThreeMf(args: {
+  /** The snapshot-once module renders — the same bundle the kit zip builds from. */
+  parts: ModuleExportParts
+  filamentMap: FilamentMap
+  slotLabels?: readonly string[]
+  supportsAtSlice?: boolean
+  bed?: BedSize
+  wipeTower?: WipeTowerProfileGeometry
+  gapMm?: number
+}): KitPlate {
+  const {
+    parts,
+    filamentMap,
+    slotLabels,
+    supportsAtSlice,
+    bed = BAMBU_256_BED,
+    wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
+    gapMm,
+  } = args
+  const p = parts.params
+  if (!isModular(p)) {
+    throw new Error('a kit plate is a modular-mode export — this design is seam_mode "mono"')
+  }
+
+  const bodyOf: Record<ModuleKind, ArrayBuffer> = {
+    left: parts.left,
+    mid: parts.mid,
+    right: parts.right,
+  }
+  const feetOf: Record<ModuleKind, ArrayBuffer | null> = {
+    left: parts.leftFeet,
+    mid: parts.midFeet,
+    right: parts.rightFeet,
+  }
+  const textOf: Record<ModuleKind, ModuleExportParts['leftText']> = {
+    left: parts.leftText,
+    mid: [], // mid modules never carry text — the mid-variant dedupe depends on it
+    right: parts.rightText,
+  }
+
+  const instances = kitPlateInstances(p, filamentMap)
+
+  // One gate pass per (kind, column) — every instance of a plan entry shares
+  // both, and the geometry is shared across a kind's variants outright (one
+  // render per geometry). Placement is what differs, and that comes later.
+  const soupCache = new Map<string, ModuleSoups>()
+  const soupsFor = (inst: KitPlateInstance): ModuleSoups => {
+    const key = `${inst.kind}:${inst.column}`
+    const hit = soupCache.get(key)
+    if (hit) return hit
+    const made = moduleSoups({
+      body: bodyOf[inst.kind],
+      feet: feetOf[inst.kind],
+      text: textOf[inst.kind],
+      kind: inst.kind,
+      column: inst.column,
+      params: p,
+      filamentMap,
+    })
+    soupCache.set(key, made)
+    return made
+  }
+
+  const bases = {} as Record<ModuleKind, ModuleBasis>
+  for (const inst of instances) {
+    if (!bases[inst.kind]) bases[inst.kind] = moduleBasis(inst.kind, soupsFor(inst))
+  }
+
+  const feetPrinted = instances.some((inst) => soupsFor(inst).feetPrinted)
+  const layout = packKitPlate({
+    instances,
+    bases,
+    bed,
+    gapMm,
+    wipeTower,
+    supportsAtSlice: supportsAtSlice || feetPrinted,
+  })
+  const placementOf = new Map(layout.placements.map((pl) => [pl.id, pl]))
+
+  // Each instance contributes its classified body soup (placed, its shells
+  // renumbered into the plate's shell table) plus its already-slotted part
+  // soups. The plate's geometry is therefore the same triangles the zip would
+  // have shipped, moved as rigid groups — nothing is re-classified after a move.
+  const chunks: { positions: Float32Array; triShell: Int32Array; shellBase: number }[] = []
+  const slotOfShell: number[] = []
+  const partSoups: { slot: number; positions: Float32Array }[] = []
+  for (const inst of instances) {
+    const soups = soupsFor(inst)
+    const basis = bases[inst.kind]
+    const at = placementOf.get(inst.id)
+    if (!at) throw new Error(`no placement for ${inst.label}`)
+    const [main] = placeModuleBodies(
+      [{ slot: SLOT_PER_SHELL, positions: soups.mesh.positions }],
+      basis,
+      at
+    )
+    chunks.push({
+      positions: main.positions,
+      triShell: soups.triShell,
+      shellBase: slotOfShell.length,
+    })
+    slotOfShell.push(...soups.slotOfShell)
+    for (const soup of placeModuleBodies(soups.partSoups, basis, at)) {
+      partSoups.push({ slot: soup.slot, positions: soup.positions })
+    }
+  }
+
+  const triangleCount = chunks.reduce((n, c) => n + c.triShell.length, 0)
+  const positions = new Float32Array(triangleCount * 9)
+  const triShell = new Int32Array(triangleCount)
+  let triAt = 0
+  let posAt = 0
+  for (const c of chunks) {
+    positions.set(c.positions, posAt)
+    posAt += c.positions.length
+    for (let t = 0; t < c.triShell.length; t++) triShell[triAt + t] = c.triShell[t] + c.shellBase
+    triAt += c.triShell.length
+  }
+
+  const built = emitThreeMfBodies({
+    mesh: { positions, triangleCount },
+    triShell,
+    slotOfShell,
+    partSoups,
+    filamentMap,
+    slotLabels,
+    feetPrinted,
+    supportsAtSlice,
+    bed,
+    wipeTower,
+    // The modules are already where they print, around a tower whose rect the
+    // packer kept clear — so the container must not re-center them, and must pin
+    // the tower where the reservation is rather than beside the plate's box.
+    placedOnBed: { towerPinMm: { x: layout.tower.pinXMm, y: layout.tower.pinYMm } },
+  })
+
+  return { ...layout, bytes: built.bytes, bodies: built.bodies, wipeTower: built.wipeTower }
+}

--- a/apps/web/src/components/create/abacus/abacus-kit-plate.ts
+++ b/apps/web/src/components/create/abacus/abacus-kit-plate.ts
@@ -60,6 +60,7 @@ import { type AbacusThreeMf, emitThreeMfBodies, type SpoolBodySummary } from './
 import {
   BAMBU_256_BED,
   DEFAULT_WIPE_TOWER_PROFILE,
+  envelopeForFilaments,
   SUPPORT_SKIRT,
   TOWER_GAP,
   type WipeTowerProfileGeometry,
@@ -378,7 +379,9 @@ export function kitPlateSignature(layout: KitPlateLayout): string {
 }
 
 /**
- * The tower footprint to keep clear, from the printer's own bounded profile.
+ * The tower footprint to keep clear, from the printer's own bounded profile —
+ * sized to the envelope row for the filament count this plate will actually load,
+ * not the profile's worst case (see `envelopeForFilaments`).
  *
  * Mirrors `towerReserveFromCapability`'s envelope → rect translation (it can't be
  * called directly: the service capability carries `version`/`maxFilaments` that
@@ -393,10 +396,11 @@ export function kitPlateSignature(layout: KitPlateLayout): string {
  */
 function plateTowerReserve(
   profile: WipeTowerProfileGeometry,
-  supports: boolean
+  supports: boolean,
+  filaments?: number
 ): Extract<TowerReserve, { kind: 'reserve' }> {
   const clear = TOWER_GAP + (supports ? SUPPORT_SKIRT : 0)
-  const e = profile.envelopeMm
+  const e = envelopeForFilaments(profile, filaments)
   return {
     kind: 'reserve',
     profile: profile.profile,
@@ -470,6 +474,11 @@ export function packKitPlate(args: {
    *  gap between modules — supports grow past every outline on the plate, not
    *  just the one the tower happens to sit next to. */
   supportsAtSlice?: boolean
+  /** How many filaments this plate will load once the ticket resolves. Picks the
+   *  tower's envelope row — a three-filament kit purges into a far shallower band
+   *  than the profile's six-filament bound, and on a full bed that is the
+   *  difference between one plate and a refusal. */
+  filaments?: number
 }): KitPlateLayout {
   const {
     instances,
@@ -477,10 +486,11 @@ export function packKitPlate(args: {
     bed = BAMBU_256_BED,
     wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
     supportsAtSlice = false,
+    filaments,
   } = args
   const gapMm = args.gapMm ?? moduleGapMm(supportsAtSlice)
 
-  const reserve = plateTowerReserve(wipeTower, supportsAtSlice)
+  const reserve = plateTowerReserve(wipeTower, supportsAtSlice, filaments)
   const tower = placeTowerReserve(bed, reserve, bedFreeRects(bed, towerMargin(bed)))
   if (!tower) {
     throw new KitPlateFitError(
@@ -585,6 +595,9 @@ export function buildKitPlateThreeMf(args: {
   bed?: BedSize
   wipeTower?: WipeTowerProfileGeometry
   gapMm?: number
+  /** Filaments the ticket will add beyond the plate's own bodies — the
+   *  support-interface spool. A download adds none. */
+  extraFilaments?: number
 }): KitPlate {
   const {
     parts,
@@ -594,6 +607,7 @@ export function buildKitPlateThreeMf(args: {
     bed = BAMBU_256_BED,
     wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
     gapMm,
+    extraFilaments = 0,
   } = args
   const p = parts.params
   if (!isModular(p)) {
@@ -645,6 +659,20 @@ export function buildKitPlateThreeMf(args: {
   }
 
   const feetPrinted = instances.some((inst) => soupsFor(inst).feetPrinted)
+
+  // The tower's reservation has to be sized BEFORE the pack, so the filament count
+  // has to be known before the bodies are emitted. It is: a body is emitted per slot
+  // that carries geometry, and the slots are fixed once every instance is gated —
+  // placement moves triangles, it never changes which filament they print on. The
+  // emit tail recomputes the same set from the same soups, so the reserved hole and
+  // the count reported to the service are the same number by construction.
+  const plateSlots = new Set<number>()
+  for (const inst of instances) {
+    const soups = soupsFor(inst)
+    for (const slot of soups.slotOfShell) plateSlots.add(slot)
+    for (const soup of soups.partSoups) plateSlots.add(soup.slot)
+  }
+
   const layout = packKitPlate({
     instances,
     bases,
@@ -652,6 +680,7 @@ export function buildKitPlateThreeMf(args: {
     gapMm,
     wipeTower,
     supportsAtSlice: supportsAtSlice || feetPrinted,
+    filaments: plateSlots.size + extraFilaments,
   })
   const placementOf = new Map(layout.placements.map((pl) => [pl.id, pl]))
 
@@ -710,6 +739,7 @@ export function buildKitPlateThreeMf(args: {
     // packer kept clear — so the container must not re-center them, and must pin
     // the tower where the reservation is rather than beside the plate's box.
     placedOnBed: { towerPinMm: { x: layout.tower.pinXMm, y: layout.tower.pinYMm } },
+    extraFilaments,
   })
 
   return { ...layout, bytes: built.bytes, bodies: built.bodies, wipeTower: built.wipeTower }

--- a/apps/web/src/components/create/abacus/abacus-kit-plate.ts
+++ b/apps/web/src/components/create/abacus/abacus-kit-plate.ts
@@ -75,9 +75,32 @@ import {
 
 const EPS = 1e-6
 
-/** Gap left between neighbouring modules on the plate. Matches the shared
- *  bundler's own default — enough for each module's brim without spending bed. */
-const KIT_PLATE_GAP_MM = 4
+/**
+ * How far ONE module's first layer reaches past its declared outline.
+ *
+ * A brim is the floor: Orca's `brim_width` is 5 mm with auto_brim, and it rings
+ * the whole part. With supports on, `SUPPORT_SKIRT` (8 mm — the measured worst
+ * case with headroom, see abacus-3mf-assembly) dominates it outright.
+ *
+ * This is the SAME law the tower ring keeps, applied at the other end of the
+ * pipeline. Getting it wrong here is exit 192, "Object conflicts were detected":
+ * the plate's declared boxes are disjoint, Orca slices it, and the extrusions
+ * collide. The one-piece abacus can't reach this state — it is a single object,
+ * so there is nothing on the bed for it to conflict with but the tower.
+ */
+const MODULE_BRIM = 5
+
+/**
+ * Gap between neighbouring modules — BOTH grow, so it's twice one module's
+ * reach, never once.
+ *
+ * The 4 mm this used to be is the shared bundler's default, and it is wrong for
+ * a kit in both states: 4 mm doesn't even hold two 5 mm brims, let alone two
+ * support skirts. It survived review because the plan's rectangles are disjoint
+ * at 4 mm — the packer, the overlap tests and the bed preview all agree the
+ * plate is clean. Only the slicer sees the extrusion.
+ */
+const moduleGapMm = (supports: boolean): number => 2 * (supports ? SUPPORT_SKIRT : MODULE_BRIM)
 
 // ---- refusals ---------------------------------------------------------------
 
@@ -438,20 +461,24 @@ export function packKitPlate(args: {
   /** THH's reported geometry for the selected printer; download-only callers get
    *  the fallback plate. */
   bed?: BedSize
+  /** Override the derived inter-module gap. Leave unset — the default follows
+   *  `supportsAtSlice`, and that coupling is the whole point (see moduleGapMm). */
   gapMm?: number
   wipeTower?: WipeTowerProfileGeometry
   /** Supports will be on when this plate is sliced (printed feet, or the
-   *  operator's ticket style) — widens the tower's clearance ring. */
+   *  operator's ticket style). Widens BOTH the tower's clearance ring and the
+   *  gap between modules — supports grow past every outline on the plate, not
+   *  just the one the tower happens to sit next to. */
   supportsAtSlice?: boolean
 }): KitPlateLayout {
   const {
     instances,
     bases,
     bed = BAMBU_256_BED,
-    gapMm = KIT_PLATE_GAP_MM,
     wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
     supportsAtSlice = false,
   } = args
+  const gapMm = args.gapMm ?? moduleGapMm(supportsAtSlice)
 
   const reserve = plateTowerReserve(wipeTower, supportsAtSlice)
   const tower = placeTowerReserve(bed, reserve, bedFreeRects(bed, towerMargin(bed)))

--- a/apps/web/src/components/create/abacus/abacus-module-kit.ts
+++ b/apps/web/src/components/create/abacus/abacus-module-kit.ts
@@ -31,7 +31,7 @@
  * is the same silent-bug family as a markerless mono plate.
  */
 import type { BedSize } from '@eink/frames-engine/print-bundle'
-import { parseStl } from '@eink/frames-engine/stl'
+import { parseStl, type StlMesh } from '@eink/frames-engine/stl'
 import { strToU8, zipSync } from 'fflate'
 import {
   type AbacusThreeMf,
@@ -138,13 +138,40 @@ export function moduleKitPlan(p: Params, fm: FilamentMap): ModuleKitEntry[] {
 }
 
 /**
- * Build one per-module multi-material 3MF. Same downstream law as the
- * whole-abacus build: shells map to slots via `shellSlotIndex` (the bead
- * shells stamped with `column` so they ink with that column's roles), feet
- * merge unclassified into the plan's feet slot, and the container choice +
- * support keys ride `emitThreeMfBodies`.
+ * One module's export-gated geometry, in the module's OWN render frame and
+ * before any container decision: the classified body soup (per-triangle shell,
+ * per-shell filament slot) plus the part-pass soups already assigned to their
+ * slots.
+ *
+ * Two consumers: `buildModuleThreeMf` emits it as that module's own 3MF, and
+ * the single-plate kit build (abacus-kit-plate.ts) places a rigidly-transformed
+ * copy per instance and emits a whole plate as one. Factored rather than forked
+ * so every module on a packed plate passes the exact same hard-error gate its
+ * standalone 3MF would — a plate must never be the loophole that ships a
+ * footless module or an empty text pocket.
  */
-export function buildModuleThreeMf(args: {
+export interface ModuleSoups {
+  /** The module_{kind} body render, parsed. */
+  mesh: StlMesh
+  /** Per-triangle shell index into `slotOfShell` (from `analyzeModuleShells`). */
+  triShell: Int32Array
+  /** Filament slot per shell. */
+  slotOfShell: number[]
+  /** Feet + inset-text soups, each already assigned its plan slot. */
+  partSoups: { slot: number; positions: Float32Array }[]
+  /** Printed feet rode this module — forces the assembly path + support keys. */
+  feetPrinted: boolean
+}
+
+/**
+ * Classify one module and run every hard-error gate the kit ships under: shells
+ * map to slots via `shellSlotIndex` (bead shells stamped with `column` so they
+ * ink with that column's roles), feet merge unclassified into the plan's feet
+ * slot, inset side text merges per color group into its own slot. The result is
+ * still in the module's render frame — placement, container choice and support
+ * keys are the caller's.
+ */
+export function moduleSoups(args: {
   /** The module_{kind} body render. */
   body: ArrayBuffer
   /** The module_{kind}_feet render — required (and non-empty) when
@@ -159,24 +186,8 @@ export function buildModuleThreeMf(args: {
   column: number
   params: Params
   filamentMap: FilamentMap
-  slotLabels?: readonly string[]
-  supportsAtSlice?: boolean
-  bed?: BedSize
-  wipeTower?: WipeTowerProfileGeometry
-}): AbacusThreeMf {
-  const {
-    body,
-    feet,
-    text,
-    kind,
-    column,
-    params,
-    filamentMap,
-    slotLabels,
-    supportsAtSlice,
-    bed = BAMBU_256_BED,
-    wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
-  } = args
+}): ModuleSoups {
+  const { body, feet, text, kind, column, params, filamentMap } = args
 
   const mesh = parseStl(body)
   if (mesh.triangleCount === 0) {
@@ -262,14 +273,39 @@ export function buildModuleThreeMf(args: {
     }
   }
 
-  return emitThreeMfBodies({
-    mesh,
-    triShell,
-    slotOfShell,
-    partSoups,
+  return { mesh, triShell, slotOfShell, partSoups, feetPrinted }
+}
+
+/**
+ * Build one per-module multi-material 3MF: the gated soups above, emitted
+ * through the shared container tail. Same downstream law as the whole-abacus
+ * build — the container choice and support keys ride `emitThreeMfBodies`.
+ */
+export function buildModuleThreeMf(args: {
+  body: ArrayBuffer
+  feet?: ArrayBuffer | null
+  text?: TextPlugRender[] | null
+  kind: ModuleKind
+  column: number
+  params: Params
+  filamentMap: FilamentMap
+  slotLabels?: readonly string[]
+  supportsAtSlice?: boolean
+  bed?: BedSize
+  wipeTower?: WipeTowerProfileGeometry
+}): AbacusThreeMf {
+  const {
     filamentMap,
     slotLabels,
-    feetPrinted,
+    supportsAtSlice,
+    bed = BAMBU_256_BED,
+    wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
+  } = args
+
+  return emitThreeMfBodies({
+    ...moduleSoups(args),
+    filamentMap,
+    slotLabels,
     supportsAtSlice,
     bed,
     wipeTower,

--- a/apps/web/src/components/create/abacus/abacus-ticket.ts
+++ b/apps/web/src/components/create/abacus/abacus-ticket.ts
@@ -62,6 +62,12 @@ export interface AbacusTicketArgs {
 export interface AbacusWipeTowerRequest {
   profile: string
   pinMm: { x: number; y: number }
+  /** The filament count whose envelope row the plate reserved bed area for. THH
+   *  compares it against the resolved plan and rejects a disagreement synchronously
+   *  (`wipe_tower_filament_mismatch`) — a wrong-sized hole caught in the API call
+   *  instead of minutes later as a slice-time conflict. Omitted, the service takes
+   *  the pre-#433 legacy leg and checks nothing. */
+  packedForFilaments?: number
 }
 
 export interface AbacusPrintTicket extends PrintTicketV2 {

--- a/apps/web/src/components/create/abacus/print-idempotency.ts
+++ b/apps/web/src/components/create/abacus/print-idempotency.ts
@@ -45,6 +45,13 @@ export interface AbacusPrintSignatureInputs {
    *  can change the emitted 3MF without a user edit, so it must rotate the key too. */
   readonly printerBed?: ThhBedGeometry
   readonly wipeTower?: ThhWipeTowerCapability | null
+  /** The module kit's packed arrangement (Gitea #32) — `kitPlateSignature(layout)`,
+   *  or absent on a one-piece print. The inputs above DERIVE the layout today, so
+   *  this is belt-and-braces; it earns its place the moment the packer itself
+   *  changes (a heuristic tweak, or the swap to `@eink/plate-packing`), because
+   *  then the same design packs onto a different plate with none of the fields
+   *  above moving — and reusing the key there would replay the old arrangement. */
+  readonly kitLayout?: string
 }
 
 /** The content signature: identical inputs → identical string, any change → a
@@ -60,6 +67,7 @@ export function abacusPrintSignature(inputs: AbacusPrintSignatureInputs): string
     supportInterfaceSlotId: inputs.supportInterfaceSlotId,
     printerBed: inputs.printerBed,
     wipeTower: inputs.wipeTower,
+    kitLayout: inputs.kitLayout,
   })
 }
 
@@ -82,9 +90,19 @@ export function abacusPrintSignature(inputs: AbacusPrintSignatureInputs): string
  * The `h` prefix on the hash is load-bearing: THH's copy-counter rule strips a
  * trailing `-<digits>`, and an all-digit hex hash (~2.3% of them) would be eaten
  * right back off, silently restoring the collision we are fixing.
+ *
+ * `kind: 'kit'` names a packed module plate (Gitea #32). The hash already parts
+ * the two — a kit's params carry a modular `seam_mode` — so this is for the
+ * human reading the job list, who otherwise can't tell a one-piece 13-column
+ * abacus from the 13 modules that assemble into one.
  */
-export function abacusModelFileName(cols: number, sig: string): string {
-  return `abacus-${cols}col-h${fnv1a32Hex(sig)}.3mf`
+export function abacusModelFileName(
+  cols: number,
+  sig: string,
+  kind: 'abacus' | 'kit' = 'abacus'
+): string {
+  const stem = kind === 'kit' ? 'abacus-kit' : 'abacus'
+  return `${stem}-${cols}col-h${fnv1a32Hex(sig)}.3mf`
 }
 
 /**

--- a/apps/web/src/lib/abacus/print/filament-wire.ts
+++ b/apps/web/src/lib/abacus/print/filament-wire.ts
@@ -39,7 +39,14 @@ export interface ThhWipeTowerCapability {
   orcaVersion?: string
   maxFilaments: number
   pinReference?: string
+  /** The count-unaware bound — the max-filament row. Always safe to pack against. */
   envelopeMm: ThhWipeTowerEnvelope
+  /** The same promise per filament count, keyed by the count as a JSON string
+   *  (`"2"`…). The tower is far shallower at low counts — THH's measured table runs
+   *  70×21 at two filaments to 70×63 at six — so a plate that knows its count
+   *  reserves much less bed. Absent on a pre-#433 service; consumers fall back to
+   *  `envelopeMm` then. */
+  envelopeByFilamentsMm?: Readonly<Record<string, ThhWipeTowerEnvelope>>
   process: {
     prime_tower_width: number
     prime_tower_brim_width: number


### PR DESCRIPTION
Closes the gap between "download a zip and slice it yourself" and the actual goal: **hit print and the printer prints it out.**

A modular design used to dead-end at this note in the studio's fabrication rail:

> Print-service tickets for module kits aren't wired yet — download the kit above and slice it yourself.

Now the same print panel that prints a one-piece abacus prints the kit: every column module packed onto one bed around the reserved purge tower, submitted as a single multi-material 3MF through the existing ticket path.

### Four commits

**`13e23f6` — pack the kit onto one plate.** Expands the kit plan into uniquely-labeled instances, measures one footprint basis per module KIND, reserves the purge tower *before* packing (a tower landing on a part is a slicer hard refusal — the exit-155 lesson), packs with `packPlates`, then applies each placement rigidly to *every* body of its module. That last part is the piece with no upstream precedent: eink's packed path is single-body, but a module is a rigid group (frame + bead column + TPU feet + text inlays) and re-measuring bounds per body would scatter a module's feet under its neighbour. Rotation is analytic and shares one basis with the footprint the packer saw, so the transform and the packing can't disagree. Z is deliberately untouched — the container's existing drop stays in charge, which keeps the frame's z=0 plane under the support-transition modifier the printed feet install there.

**`ccdf31e` — wire it into the submit.** `PrintPanel` grows a `kit` prop; present ⇒ render the module bundle and pack it, absent ⇒ the one-piece abacus. Both produce the same `{bytes, bodies, wipeTower}`, so ticket, idempotency, upload and job plumbing are shared verbatim — a kit's filament slots *are* the mono print's slots.

**`01ac60e` — space modules for what the slicer actually extrudes.** The first live submit reached OrcaSlicer and was refused: `exit 192 · Object conflicts were detected`. The declared boxes were disjoint; the extrusions were not. Supports push the printed first layer past the declared outline (measured on this printer: 1.47 mm sides, 5.32 front, 1.32 back) and `brim_width 5` with `auto_brim` adds up to 5 mm more — and **a gap between two parts has to clear two of those growths, not one**. The tower ring already knew this (`TOWER_GAP + SUPPORT_SKIRT`); the inter-module gap was a flat 4 mm regardless. It's now `2 × SUPPORT_SKIRT` (16 mm) when supports will be on at slice time and `2 × brim` (10 mm) when they won't.

**`4d26ec3` — reserve the tower this plate needs, not the worst case.** THH publishes the tower footprint *per filament count* (things-haunt-house#433) and we were reading only the count-unaware bound. Every plate reserved 70 × 63 mm whether it loaded six filaments or two — the measured rows are 2 → 70×21, 3 → 70×31.5, 4 → 70×42, 5 → 70×52.5, 6 → 70×63. Reading the right row hands 42 mm of depth back to a two-filament plate, and that is exactly the depth the commit above was short by (see below). `packedForFilaments` now rides on the ticket so THH rejects a wrong-sized hole synchronously (`wipe_tower_filament_mismatch`) rather than letting it surface minutes later as an exit-155 slice conflict.

### Worth a reviewer's eye

- **The bed projection was factored, not copied.** THH machine geometry → the packer's `BedSize` was inline in the submit and about to become two call sites. Now `bedSizeFromThh`, with the test the inline version never had — including the zero-point exclusion zone that would otherwise reserve `Infinity` and make nothing ever pack.
- **The filament count is derived *before* the pack, from the slot union.** Chicken-and-egg: the tower's keep-out has to be sized before the bodies are placed, but the ticket's filament list is built after the model exists. It's derivable — a body is emitted per filament slot that carries geometry, and placement moves triangles without changing which slot they print on, so the union of `slotOfShell` and the part soups' slots *is* the model filament count, known the moment instances are gated. The support-interface pick adds one on top, and `buildAbacusTicket` may drop that entry when it coincides with a model slot — so the estimate can only ever **over**-count. That asymmetry is the safety property: an over-reserved hole wastes bed, an under-reserved one is a slicer refusal. When the estimate and the ticket disagree, the panel sends the pin *without* the declaration rather than send a number THH will 400.
- **The packed arrangement enters the idempotency signature.** Looks redundant: everything else in that signature *derives* the layout. It earns its place the moment the **packer** changes its mind (a heuristic tweak, or the pending swap onto `@eink/plate-packing`) — same design, different plate, nothing else moved. Reusing the key there would make THH replay the old arrangement and report success while discarding the plate we just built.
- **A kit and the abacus it was cut from stay distinguishable** once they're jobs on a service: distinct model filename (THH derives model identity from the filename), distinct `artifactId`, and a job name that says kit.
- **Refusals never dead-end.** `KitPlateFitError` now carries `headline` and `remediation` apart and renders through the existing submit-error notice rather than a second one. Every reason names the knob — scale, columns, or bed — and the kit zip is still there to print module by module. Nothing is ever silently dropped from a plate.
- **A wider gap can *shrink* the packed envelope.** The packer answers more spacing by using more rows. Tests assert true edge-to-edge separation between neighbours, not bounding-box span — the obvious assertion is wrong.

### Where the 13-column kit stands

`01ac60e` had to refuse a 13-column kit with printed TPU feet on a 256 bed at honest spacing. `4d26ec3` establishes that the refusal was mostly the *reserve*, not the modules. Measured, supports on:

| filaments the plate loads | 13 columns + printed feet on a 256 |
|---|---|
| 2, 3 | fits |
| 4, 5, 6 | still refuses |

Supports off (adhesive feet, 10 mm gaps), every count fits. So the one-click path for a full-width printed-feet kit now works for a frame-plus-two-bead-colours plate and still wants adhesive feet, fewer columns, or Phase B multi-plate composition (Gitea #33) once a fourth spool joins — most likely a separately-routed support interface, which is exactly the spool the count is now careful to include.

### Open design call

The purge tower is still reserved **unconditionally**, not only when the plate is multi-filament. That mattered more before this last commit — the floor is now the 2-filament row (70 × 21) rather than 70 × 63, so reserving on a mono plate costs a strip rather than a corner. Reserving always is still the safe direction (a tower that appears and lands on a part is a hard refusal), but if a mono kit should keep even that, say so and it becomes conditional on the emitted body count.

### Verification

`tsc --noEmit` clean, biome clean on all changed files, **678 abacus tests passing (60 new across the four commits, zero regressions)** — including a real-layout check that 13 modules (11 mids at 15.5×100.5, 2 ends at 26×100.5) pack onto one 256 bed with mixed rotations, tower reserved clear of them.

The plate has been proven to reach a real THH service and a real slicer. **The exit-192 fix itself has not been re-sliced** — the diagnosis is arithmetic from this printer's own measured clearances (4 mm cannot hold two 5 mm brims), not a green slice. The physical print is still unverified.

Follow-on work is filed and planned, not in this PR: Gitea #35 (epic — one plate contract for every app that prints), #36, eink #570, things-haunt-house #434 and #435.

Refs Gitea #30, #31, #32, #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKx8T1Y3skF8G83atrxmG4
