### PR TITLE
Slide the kit plate off the printer's keep-out — the real exit 192

### DIFF
--- a/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
@@ -426,10 +426,11 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
     expect(supported.tower.dMm).toBeGreaterThan(plain.tower.dMm)
   })
 
-  // The exit-192 regression. Orca refused a real plate whose declared boxes were
-  // disjoint: supports grow past every outline, and 4 mm between modules wasn't
-  // two brims wide, let alone two support skirts. The gap has to move with
-  // `supportsAtSlice` exactly as the tower ring does.
+  // Two modules whose first layers meet print fused. That is a defect the slicer
+  // never reports — it is NOT the exit 192 this pair of tests used to claim, which
+  // is a keep-out check and can't see inter-module spacing at all (see the keep-out
+  // tests below). The gap still has to move with `supportsAtSlice`, because supports
+  // start outboard of the outline they hold.
   it('spaces modules further apart when the plate will slice with supports', () => {
     const roomy: BedSize = { wMm: 400, dMm: 400 }
     const plain = packKitPlate({ instances, bases, bed: roomy })
@@ -439,38 +440,32 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
     // moves further apart. Separation is the property that keeps extrusions off
     // each other; the envelope is just how the packer chose to spend the bed.
     expect(closestApproach(supported)).toBeGreaterThan(closestApproach(plain))
-    expect(closestApproach(supported)).toBeGreaterThanOrEqual(16 - 1e-6)
+    // 2 × (brim_object_gap 0.1 + brim_width 5 + support_object_xy_distance 0.35)
+    expect(closestApproach(supported)).toBeGreaterThanOrEqual(10.9 - 1e-6)
   })
 
   it('holds two brims between neighbours even with supports off', () => {
     // 4 mm — the shared bundler's default, and what this used to ship — cannot
-    // hold two 5 mm brims.
+    // hold two brims. 10.2 is two of THH's published 5.1 mm growths; the 10 this
+    // asserted before quietly dropped `brim_object_gap`.
     expect(
       closestApproach(packKitPlate({ instances, bases, bed: { wMm: 400, dMm: 400 } }))
-    ).toBeGreaterThanOrEqual(10 - 1e-6)
+    ).toBeGreaterThanOrEqual(10.2 - 1e-6)
   })
 
-  it('refuses a printed-feet 13-column kit when it must reserve the worst-case tower', () => {
-    // No filament count given, so the reserve falls back to the profile's
-    // count-unaware bound — and 13 modules at supports-on spacing plus a
-    // six-filament tower genuinely do not fit a 256 plate. Naming that and keeping
-    // the zip beats shipping a plate that slices to "Object conflicts were detected".
-    let caught: KitPlateFitError | null = null
-    try {
-      packKitPlate({ instances, bases, supportsAtSlice: true })
-    } catch (err) {
-      caught = err as KitPlateFitError
-    }
-    expect(caught).toBeInstanceOf(KitPlateFitError)
-    expect(caught?.reason).toBe('overflow')
-    expect(caught?.remediation).toMatch(/fewer columns|scale the design down|bigger bed/)
+  it('fits a printed-feet 13-column kit on a 256 even at the worst-case tower', () => {
+    // This asserted a REFUSAL while the supports-on gap was 2 × SUPPORT_SKIRT = 16 mm.
+    // Most of that was skirt — a loop `skirt_loops = 0` means this printer never draws,
+    // and which would ring the plate rather than run between two modules if it did.
+    // At the honest 10.9 the thirteenth module fits beside a six-filament tower.
+    const plate = packKitPlate({ instances, bases, supportsAtSlice: true })
+    expect(plate.placements).toHaveLength(instances.length)
   })
 
-  it('fits that same kit once it reserves the tower its filament count needs', () => {
-    // The refusal above is not physics — it is the worst case. A wood-PLA kit with
-    // printed TPU feet and a routed support interface is a THREE-filament plate, and
-    // the service publishes a 70×31.5 envelope for that instead of 70×63. The 42 mm
-    // of depth handed back is exactly what the thirteenth module needs.
+  it('reserves a shallower tower once it knows the filament count', () => {
+    // A wood-PLA kit with printed TPU feet and a routed support interface is a THREE-
+    // filament plate, and the service publishes a 70×31.5 envelope for that instead of
+    // 70×63 — bed the plate gets to keep.
     const fitted = packKitPlate({ instances, bases, supportsAtSlice: true, filaments: 3 })
     expect(fitted.placements).toHaveLength(instances.length)
     const rects = fitted.placements.map(rectOf)
@@ -478,7 +473,7 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
       for (let j = i + 1; j < rects.length; j++) expect(overlaps(rects[i], rects[j])).toBe(false)
     }
     // and the separation law still holds at the tighter reserve
-    expect(closestApproach(fitted)).toBeGreaterThanOrEqual(16 - 1e-6)
+    expect(closestApproach(fitted)).toBeGreaterThanOrEqual(10.9 - 1e-6)
     // the win is depth: same tower width, shallower reserve
     const roomy: BedSize = { wMm: 400, dMm: 400 }
     const worst = packKitPlate({
@@ -490,6 +485,100 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
     })
     expect(fitted.tower.wMm).toBeCloseTo(worst.tower.wMm, 6)
     expect(fitted.tower.dMm).toBeLessThan(worst.tower.dMm)
+  })
+
+  // ---- the real exit-192 law -------------------------------------------------
+  //
+  // Orca refuses a plate when a model volume's CONVEX HULL touches the printer's
+  // keep-out zone. Our volumes are per-filament-slot, so one body spans every module
+  // that rides that slot — and the hull of an L-shaped arrangement covers the notch
+  // the packer carved. The plate that took a 192 on 2026-08-05 had zero geometry in
+  // the X1C's cutter corner; nudging it 28.5 mm in +y sliced the identical bytes.
+  // Hence: the plate's BOX must clear the keep-out, not just its parts.
+  describe('keeping the plate clear of the printer keep-out', () => {
+    const boxOf = (layout: ReturnType<typeof packKitPlate>): Rect => {
+      const rects: Rect[] = [
+        ...layout.placements.map(rectOf),
+        {
+          x0: layout.tower.xMm,
+          y0: layout.tower.yMm,
+          x1: layout.tower.xMm + layout.tower.wMm,
+          y1: layout.tower.yMm + layout.tower.dMm,
+        },
+      ]
+      return {
+        x0: Math.min(...rects.map((r) => r.x0)),
+        y0: Math.min(...rects.map((r) => r.y0)),
+        x1: Math.max(...rects.map((r) => r.x1)),
+        y1: Math.max(...rects.map((r) => r.y1)),
+      }
+    }
+
+    it('leaves no keep-out inside the whole plate box, on the real X1C bed', () => {
+      const layout = packKitPlate({ instances, bases, supportsAtSlice: true, filaments: 3 })
+      const box = boxOf(layout)
+      // Non-vacuous: the packer seeds from the bed origin, so this plate comes out of
+      // packPlates touching (0, 0) — the staged 3MF that took the 192 had exactly that
+      // box. What this asserts is that it does not STAY there.
+      expect(box.y0).toBeGreaterThanOrEqual(28 - 1e-6)
+      for (const e of layout.bed.exclude ?? []) {
+        expect(overlaps(box, { x0: e.xMm, y0: e.yMm, x1: e.xMm + e.wMm, y1: e.yMm + e.dMm })).toBe(
+          false
+        )
+      }
+    })
+
+    it('slides the plate off a keep-out instead of merely packing around it', () => {
+      // A bed whose cutter corner is deliberately big enough that the packer's own
+      // carve leaves an L: parts avoid the zone, the box does not.
+      const notched: BedSize = {
+        wMm: 400,
+        dMm: 400,
+        exclude: [{ xMm: 0, yMm: 0, wMm: 60, dMm: 40 }],
+      }
+      const layout = packKitPlate({ instances, bases, bed: notched })
+      const zone: Rect = { x0: 0, y0: 0, x1: 60, y1: 40 }
+      // every part clears it (the packer's job) AND so does the box (this fix's job)
+      for (const pl of layout.placements) expect(overlaps(rectOf(pl), zone)).toBe(false)
+      expect(overlaps(boxOf(layout), zone)).toBe(false)
+    })
+
+    it('carries the tower with the plate so every internal clearance survives', () => {
+      const notched: BedSize = {
+        wMm: 400,
+        dMm: 400,
+        exclude: [{ xMm: 0, yMm: 0, wMm: 60, dMm: 40 }],
+      }
+      const plain = packKitPlate({ instances, bases, bed: { wMm: 400, dMm: 400 } })
+      const slid = packKitPlate({ instances, bases, bed: notched })
+      // A rigid slide: the module-to-module and module-to-tower distances are the
+      // same numbers they were before, which is the whole reason for moving the
+      // layout bodily rather than re-packing into a smaller region.
+      expect(closestApproach(slid)).toBeCloseTo(closestApproach(plain), 6)
+      const gapToTower = (l: ReturnType<typeof packKitPlate>): number =>
+        Math.min(
+          ...l.placements.map((pl) => {
+            const r = rectOf(pl)
+            return Math.max(
+              l.tower.xMm - r.x1,
+              r.x0 - (l.tower.xMm + l.tower.wMm),
+              l.tower.yMm - r.y1,
+              r.y0 - (l.tower.yMm + l.tower.dMm)
+            )
+          })
+        )
+      expect(gapToTower(slid)).toBeCloseTo(gapToTower(plain), 6)
+      // and the pin stays inside its own reservation after the slide
+      expect(slid.tower.pinXMm).toBeGreaterThan(slid.tower.xMm)
+      expect(slid.tower.pinYMm).toBeGreaterThan(slid.tower.yMm)
+    })
+
+    // The 'keep-out' refusal itself has no test, and that is the honest state of it:
+    // the packer seeds its free space from the same zones, so a bed it can pack at all
+    // leaves somewhere to slide toward. It stays as a guard for the case where those
+    // two ever disagree — a THH zone shape the seed rounds differently, or the pending
+    // swap onto @eink/plate-packing — because the alternative to refusing is emitting
+    // a plate the slicer rejects after the user has waited for the render.
   })
 
   it('refuses an overfull plate by name rather than dropping a module', () => {

--- a/apps/web/src/components/create/abacus/abacus-kit-plate.ts
+++ b/apps/web/src/components/create/abacus/abacus-kit-plate.ts
@@ -77,31 +77,37 @@ import {
 const EPS = 1e-6
 
 /**
- * How far ONE module's first layer reaches past its declared outline.
+ * How far ONE module's first layer reaches past its declared outline, per side.
  *
- * A brim is the floor: Orca's `brim_width` is 5 mm with auto_brim, and it rings
- * the whole part. With supports on, `SUPPORT_SKIRT` (8 mm — the measured worst
- * case with headroom, see abacus-3mf-assembly) dominates it outright.
+ * Both numbers are THH's published `clearance.outlineGrowthMm` (things-haunt-house
+ * #434), folded out of the very presets it slices us with rather than measured
+ * here:
+ *   - no supports: `brim_object_gap` 0.1 + `brim_width` 5 = 5.1
+ *   - supports:    + `support_object_xy_distance` 0.35 + `support_expansion` 0 = 5.45
  *
- * This is the SAME law the tower ring keeps, applied at the other end of the
- * pipeline. Getting it wrong here is exit 192, "Object conflicts were detected":
- * the plate's declared boxes are disjoint, Orca slices it, and the extrusions
- * collide. The one-piece abacus can't reach this state — it is a single object,
- * so there is nothing on the bed for it to conflict with but the tower.
+ * Restated as constants only because the live block rides on an unmerged service
+ * change; read them off the printer row once it lands, and delete these.
+ *
+ * NOT included, deliberately: the skirt. `skirt_loops` is 0 on every intent — no
+ * skirt is drawn at all — and a skirt would ring the plate's convex hull anyway,
+ * never the space between two modules. `SUPPORT_SKIRT` (8 mm) is still right for
+ * the tower ring, which is a different measurement of a different thing; using it
+ * here spent ~5 mm of bed per gap on a loop this printer never prints.
  */
-const MODULE_BRIM = 5
+const MODULE_GROWTH_MM = 5.1
+const MODULE_GROWTH_SUPPORTED_MM = 5.45
 
 /**
  * Gap between neighbouring modules — BOTH grow, so it's twice one module's
  * reach, never once.
  *
- * The 4 mm this used to be is the shared bundler's default, and it is wrong for
- * a kit in both states: 4 mm doesn't even hold two 5 mm brims, let alone two
- * support skirts. It survived review because the plan's rectangles are disjoint
- * at 4 mm — the packer, the overlap tests and the bed preview all agree the
- * plate is clean. Only the slicer sees the extrusion.
+ * The 4 mm this started as is the shared bundler's default, and it is wrong for a
+ * kit in both states: it doesn't hold two brims. What it is NOT is the cause of
+ * the exit 192 this file used to blame it for — see `clearOfKeepOuts`. Two modules
+ * whose brims overlap slice without complaint; they just print fused.
  */
-const moduleGapMm = (supports: boolean): number => 2 * (supports ? SUPPORT_SKIRT : MODULE_BRIM)
+const moduleGapMm = (supports: boolean): number =>
+  2 * (supports ? MODULE_GROWTH_SUPPORTED_MM : MODULE_GROWTH_MM)
 
 // ---- refusals ---------------------------------------------------------------
 
@@ -114,6 +120,8 @@ export type KitPlateRefusal =
   | 'too-big'
   /** No clear rectangle left for the purge tower. */
   | 'no-tower-room'
+  /** The plate can't be slid off the printer's keep-out zone (see `clearOfKeepOuts`). */
+  | 'keep-out'
 
 /**
  * A kit that cannot be laid out on one plate. `modules` names the labels that
@@ -413,6 +421,81 @@ function plateTowerReserve(
   }
 }
 
+/**
+ * Slide the whole layout until it clears the printer's keep-out zones — the real
+ * cause of exit 192, "Object conflicts were detected".
+ *
+ * Orca's `layered_print_cleareance_valid` (libslic3r/Print.cpp) has exactly three
+ * hard refusals, and all three are keep-out intersections: a model volume's
+ * CONVEX HULL against `bed_exclude_area`, the same against the clumping-detection
+ * area, and the prime tower's rect against `bed_exclude_area`. Everything else it
+ * finds — parts overlapping each other, the tower overlapping a part — it records
+ * as a warning and slices anyway. No amount of inter-module spacing has ever been
+ * able to cause a 192, and the gap this file widened to chase one never could.
+ *
+ * The hull is the whole trap. `emitThreeMfBodies` merges every module riding a
+ * filament slot into ONE volume, so a body's hull is the hull of modules scattered
+ * across the plate — and the hull of an L-shaped arrangement covers the notch the
+ * packer carefully carved out. The 13-module plate that took a 192 on 2026-08-05
+ * (staged as `29037c8a….raw.3mf`) had ZERO vertices inside the X1C's 18 × 28 mm
+ * cutter corner and was refused anyway, because two bodies spanned from one side
+ * of that corner to the other. Nudging the identical plate 28.5 mm in +y sliced it
+ * clean.
+ *
+ * So the invariant a packed plate has to keep is not about its parts, it is about
+ * its BOUNDING BOX: no keep-out may touch it. Sliding the layout bodily preserves
+ * every internal clearance exactly — the tower moves with the modules — which is
+ * why this runs after packing rather than shrinking the region packed into. A pure
+ * inset would spend a 256-wide strip of bed to avoid an 18 × 28 corner.
+ */
+function clearOfKeepOuts(
+  bed: BedSize,
+  rects: readonly BedRect[]
+): { dxMm: number; dyMm: number } | null {
+  if (rects.length === 0) return { dxMm: 0, dyMm: 0 }
+  const box = {
+    x0: Math.min(...rects.map((r) => r.xMm)),
+    y0: Math.min(...rects.map((r) => r.yMm)),
+    x1: Math.max(...rects.map((r) => r.xMm + r.wMm)),
+    y1: Math.max(...rects.map((r) => r.yMm + r.dMm)),
+  }
+  const excludes = (bed.exclude ?? []).map((e) => ({
+    x0: e.xMm,
+    y0: e.yMm,
+    x1: e.xMm + e.wMm,
+    y1: e.yMm + e.dMm,
+  }))
+  const clears = (dx: number, dy: number): boolean => {
+    const b = { x0: box.x0 + dx, y0: box.y0 + dy, x1: box.x1 + dx, y1: box.y1 + dy }
+    if (b.x0 < -EPS || b.y0 < -EPS || b.x1 > bed.wMm + EPS || b.y1 > bed.dMm + EPS) return false
+    return !excludes.some(
+      (e) => b.x0 < e.x1 - EPS && b.x1 > e.x0 + EPS && b.y0 < e.y1 - EPS && b.y1 > e.y0 + EPS
+    )
+  }
+
+  // Staying put is always the first candidate; the rest are the minimal single-axis
+  // pushes that clear one zone. With several zones a push can land on another, so
+  // every candidate is re-checked against all of them and the shortest survivor wins.
+  const candidates: { dx: number; dy: number }[] = [{ dx: 0, dy: 0 }]
+  for (const e of excludes) {
+    candidates.push(
+      { dx: e.x1 - box.x0, dy: 0 },
+      { dx: e.x0 - box.x1, dy: 0 },
+      { dx: 0, dy: e.y1 - box.y0 },
+      { dx: 0, dy: e.y0 - box.y1 }
+    )
+  }
+  let best: { dxMm: number; dyMm: number } | null = null
+  for (const c of candidates) {
+    if (!clears(c.dx, c.dy)) continue
+    const move = Math.hypot(c.dx, c.dy)
+    if (best === null || move < Math.hypot(best.dxMm, best.dyMm) - EPS) {
+      best = { dxMm: c.dx, dyMm: c.dy }
+    }
+  }
+  return best
+}
+
 /** Maximal free rectangles of `f` once `ex` is carved out (the two overlap-free
  *  cases return `f` untouched). */
 function splitRect(f: BedRect, ex: BedRect): BedRect[] {
@@ -540,7 +623,7 @@ export function packKitPlate(args: {
     )
   }
 
-  const placements = instances.map((inst): KitPlatePlacement => {
+  const packedPlacements = instances.map((inst): KitPlatePlacement => {
     const pl = byId.get(inst.id)
     if (!pl) {
       // packPlates returns one placement per item id; a hole means the ids the
@@ -558,7 +641,42 @@ export function packKitPlate(args: {
     }
   })
 
-  return { placements, tower, bed }
+  // The plate's BOX has to clear the printer's keep-outs, not just its parts —
+  // Orca hulls each volume, and our volumes span the plate. See clearOfKeepOuts.
+  const shift = clearOfKeepOuts(bed, [
+    ...packedPlacements.map((pl) => ({ xMm: pl.xMm, yMm: pl.yMm, wMm: pl.wMm, dMm: pl.hMm })),
+    { xMm: tower.xMm, yMm: tower.yMm, wMm: tower.wMm, dMm: tower.dMm },
+  ])
+  if (!shift) {
+    throw new KitPlateFitError(
+      'keep-out',
+      [],
+      `this kit fills the ${bedLabel(
+        bed
+      )} so completely that it can't be slid clear of the printer's keep-out zone — the slicer would refuse it as an object conflict.`,
+      'Print fewer columns, scale the design down, or select a printer with a bigger bed. The kit zip still prints module by module.'
+    )
+  }
+  const placements =
+    shift.dxMm === 0 && shift.dyMm === 0
+      ? packedPlacements
+      : packedPlacements.map((pl) => ({
+          ...pl,
+          xMm: pl.xMm + shift.dxMm,
+          yMm: pl.yMm + shift.dyMm,
+        }))
+  const placedTower =
+    shift.dxMm === 0 && shift.dyMm === 0
+      ? tower
+      : {
+          ...tower,
+          xMm: tower.xMm + shift.dxMm,
+          yMm: tower.yMm + shift.dyMm,
+          pinXMm: tower.pinXMm + shift.dxMm,
+          pinYMm: tower.pinYMm + shift.dyMm,
+        }
+
+  return { placements, tower: placedTower, bed }
 }
 
 // ---- the plate --------------------------------------------------------------


### PR DESCRIPTION
Fixes the exit 192 that has been blocking the one-click kit print, and reverts the wrong fix for it.

## What 192 actually is

OrcaSlicer's CLI exit codes are **negative** and reach the shell mod 256. `CLI_OBJECT_COLLISION_IN_LAYER_PRINT` is `-64` → **192**. (The ones we already knew decode the same way: `-101` → 155 gcode path conflicts, `-102` → 154 unprintable area.)

It comes from `layered_print_cleareance_valid` (`src/libslic3r/Print.cpp`), which has exactly **three** hard refusals — and every one is a keep-out intersection:

```cpp
if (!intersection(exclude_polys, volume_hull).empty())          // volume hull vs bed_exclude_area
    return {name + " is too close to exclusion area..."};
...
if (!intersection(convex_hulls_other, current_instance_hulls).empty()) {
    warning->is_warning = true;                                  // part vs part = WARNING ONLY
...
if (!intersection(convex_hulls_other, convex_hulls_temp).empty())
    warning->string += "Prime Tower is too close to others...";  // tower vs part = WARNING ONLY
if (!intersection(exclude_polys, convex_hulls_temp).empty())
    return {"Prime Tower is too close to an exclusion area..."}; // tower vs bed_exclude_area
```

**No inter-module gap can produce a 192, at any distance.** Bench agrees — six slices through the production leg, two 20 mm boxes, varying only spacing:

| configuration | gaps | result |
|---|---|---|
| supports off | 0.2 / 1 / 2 / 4 mm | all OK |
| supports on | 0.5 / 2 / 4 mm | all OK |
| `brim_type: outer_only`, brims overlapping by 8 mm | 2 / 4 / 8 / 10 / 12 mm | all OK |
| meshes overlapping | −1 / −5 mm | exit **155** |

Direct confirmation of the real trigger, first try:

```
both clear of the corner (control)           -> OK
a MODULE overlaps the exclusion corner       -> FAIL exit 192
the TOWER overlaps the exclusion corner      -> FAIL exit 192
module 2 mm clear of the corner              -> OK
```

## What hit us

The X1C reserves `bed_exclude_area = 0x0, 18x0, 18x28, 0x28` — 18 × 28 mm at the bed origin, for the filament cutter. The packer already carves it out, and **no module was ever inside it**. The staged plate that failed (`29037c8a….raw.3mf`, 13:16 today) has **zero vertices** in the corner:

```
Bambu Lab PLA Wood    normal_part    0 vertices inside the corner
Bambu Lab TPU for AMS normal_part    0 vertices inside the corner
...
```

But `emitThreeMfBodies` merges every module riding a filament slot into **one volume**, and Orca hulls each volume. Two of the five bodies spanned from right of the corner to above it, so their **convex hulls covered the notch the packer had carefully left empty**:

```
Bambu Lab PLA Wood     bbox x[  0.00,129.50] y[  0.00,140.00]  <<< HULL COVERS THE CORNER
Bambu Lab TPU for AMS  bbox x[  1.50,118.22] y[  1.50,137.18]  <<< HULL COVERS THE CORNER
```

End-to-end proof — the exact failing plate, same bytes, same settings, only its position on the bed changed:

```
as staged (plate min corner at 0, 0)     -> FAIL exit 192
same plate nudged +28.5 mm in y          -> OK
```

## The fix

The invariant a packed plate has to keep is about its **bounding box**, not its parts. `clearOfKeepOuts` slides the whole layout — modules *and* tower together — by the shortest push that clears every zone and stays on the bed, so every internal clearance survives untouched, and refuses by name (`keep-out`) if no such push exists.

Sliding beats packing into an inset region: avoiding an 18 × 28 corner by insetting would spend a 256 mm strip of bed.

## The gap goes back down

`01ac60e8b` widened the inter-module gap 4 → 16 mm to chase this. The gap does govern something real — two neighbours printing *fused* — but not this, and 16 was the wrong number for what it governs. Both values now come from THH's published `clearance` (things-haunt-house#434), folded out of the presets we slice with:

- supports off: 2 × 5.1 = **10.2 mm** (`brim_object_gap` 0.1 + `brim_width` 5)
- supports on: 2 × 5.45 = **10.9 mm** (+ `support_object_xy_distance` 0.35)

The 16 was `2 × SUPPORT_SKIRT`, and most of SUPPORT_SKIRT is skirt — `skirt_loops` is **0**, so it is a loop this printer never draws, and it would ring the plate rather than run between two modules if it did. SUPPORT_SKIRT keeps its job in the tower ring, which measures something else.

**Consequence: a printed-feet 13-column kit fits one 256 plate again**, even at the count-unaware worst-case tower. The test that asserted it refuses now asserts it fits.

## Verification

tsc clean, biome clean, 681 abacus tests. Four new tests around the keep-out law: the box is clear on the real X1C bed (non-vacuous — it asserts the plate does not *stay* at the origin the packer seeds it from), a slide that the packer's own carve cannot achieve, and a rigid slide that preserves module-to-module and module-to-tower distances to 1e-6. The `keep-out` refusal is documented as untested, and why.

Refs Gitea #32, things-haunt-house#434, #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKx8T1Y3skF8G83atrxmG4
