### PR TITLE
Show the build plate before printing it

### DIFF
--- a/apps/web/src/components/create/abacus/KitPlatePreview.stories.tsx
+++ b/apps/web/src/components/create/abacus/KitPlatePreview.stories.tsx
@@ -1,0 +1,154 @@
+// Abacus Studio — KitPlatePreview stories (Gitea #32).
+//
+// Every state of the bed picture, staged without a printer, a WASM export or a
+// mesh. The GEOMETRY IS REAL: `packKitPlate` needs only footprint numbers and a
+// bed, not triangles, so each story runs the actual packer over the actual
+// module dimensions (mid 15.5 mm, end 26 mm, 100.5 mm deep at scale 1) and draws
+// what it answers. Hand-typed placements would drift from the packer the first
+// time a heuristic changed and nobody would notice — the picture would simply
+// stop being a picture of anything.
+//
+// The refusals are staged the same way: the packer is asked for something
+// impossible and its own KitPlateFitError copy is what renders, so the words in
+// Storybook are the words a user gets.
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { BAMBU_256_BED } from './abacus-3mf-assembly'
+import {
+  KitPlateFitError,
+  type KitPlateLayout,
+  kitPlateInstances,
+  type ModuleBasis,
+  packKitPlate,
+} from './abacus-kit-plate'
+import { defaultParams, type FilamentMap, type Params } from './abacus-model'
+import type { ModuleKind } from './abacus-module-kit'
+import { KitPlatePreview } from './KitPlatePreview'
+
+const params = (over: Partial<Params> = {}): Params => ({
+  ...defaultParams,
+  seam_mode: 'modular',
+  feet_mode: 'adhesive',
+  ...over,
+})
+
+const fm: FilamentMap = {
+  slots: ['#c9a26e', '#f5f5f5', '#111111', '#2e86ab'],
+  frame: 0,
+  markerWhite: 1,
+  markerBlack: 2,
+  beadRoles: [3, 1],
+  markerContrast: 21,
+}
+
+/** Measured module footprints at scale 1 — what `moduleBasis` reports off the
+ *  real renders, restated here so a story needs no geometry pipeline. */
+const bases: Record<ModuleKind, ModuleBasis> = {
+  left: { kind: 'left', minX: 0, minY: 0, wMm: 26, hMm: 100.5 },
+  mid: { kind: 'mid', minX: 0, minY: 0, wMm: 15.5, hMm: 100.5 },
+  right: { kind: 'right', minX: 0, minY: 0, wMm: 26, hMm: 100.5 },
+}
+
+function pack(args: {
+  cols?: number
+  bed?: typeof BAMBU_256_BED
+  supportsAtSlice?: boolean
+  filaments?: number
+}): { layout: KitPlateLayout | null; refusal: KitPlatePreviewRefusal | null } {
+  const p = params({ cols: args.cols ?? 13 })
+  try {
+    return {
+      layout: packKitPlate({
+        instances: kitPlateInstances(p, fm),
+        bases,
+        bed: args.bed ?? BAMBU_256_BED,
+        supportsAtSlice: args.supportsAtSlice ?? false,
+        filaments: args.filaments ?? 3,
+      }),
+      refusal: null,
+    }
+  } catch (err) {
+    if (err instanceof KitPlateFitError) {
+      return {
+        layout: null,
+        refusal: { headline: err.headline, remediation: err.remediation, modules: err.modules },
+      }
+    }
+    throw err
+  }
+}
+
+type KitPlatePreviewRefusal = {
+  headline: string
+  remediation: string
+  modules: readonly string[]
+}
+
+const meta: Meta<typeof KitPlatePreview> = {
+  title: 'AbacusStudio/KitPlatePreview',
+  component: KitPlatePreview,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      // the studio's dark print panel; the preview's palette assumes it
+      <div
+        style={{
+          width: 340,
+          padding: 12,
+          borderRadius: 12,
+          background: 'rgba(17,24,39,0.95)',
+          color: 'rgba(226,232,240,0.95)',
+          fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+          fontSize: 12,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof KitPlatePreview>
+
+/** The shipped case: 13 columns, three filaments, one 256 bed. */
+export const FullKit: Story = {
+  args: { ...pack({ filaments: 3 }), filaments: 3 },
+}
+
+/** Supports on (printed feet, or the operator's style) widens every gap AND the
+ *  tower's clearance ring — the same kit, visibly looser. */
+export const SupportsOn: Story = {
+  args: { ...pack({ supportsAtSlice: true, filaments: 3 }), filaments: 3 },
+}
+
+/** A fourth spool (the routed support interface) buys the tower a deeper
+ *  envelope row, and on a full bed that is the difference between fitting and
+ *  not. Compare the reserve against FullKit. */
+export const FourFilaments: Story = {
+  args: { ...pack({ filaments: 4 }), filaments: 4 },
+}
+
+/** Few enough modules that the bed is mostly tower and empty space. */
+export const SmallKit: Story = {
+  args: { ...pack({ cols: 4, filaments: 3 }), filaments: 3 },
+}
+
+/** A printer with no declared keep-out — the hatched corner is a property of the
+ *  machine, not of the drawing. */
+export const NoKeepOut: Story = {
+  args: {
+    ...pack({ bed: { wMm: 256, dMm: 256 }, filaments: 3 }),
+    filaments: 3,
+  },
+}
+
+/** The honest refusal, in the packer's own words. */
+export const WontFit: Story = {
+  args: pack({ cols: 13, bed: { wMm: 180, dMm: 180 }, filaments: 3 }),
+}
+
+/** Waiting on the module export. */
+export const Packing: Story = {
+  args: { layout: null, pending: true },
+}

--- a/apps/web/src/components/create/abacus/KitPlatePreview.tsx
+++ b/apps/web/src/components/create/abacus/KitPlatePreview.tsx
@@ -1,0 +1,280 @@
+// Abacus Studio — the build-plate preview (Gitea #32).
+//
+// Frame Studio's Print track has shown its packed bed as an inline SVG for a
+// while (`PrintTrack.tsx`): a viewBox in MILLIMETRES, so the drawing is the bed
+// at 1:1 and no scale factor is ever computed; parts as their packed footprint
+// rects; the purge tower as a dashed reserve. This is that, for a kit.
+//
+// TWO DELIBERATE DIVERGENCES FROM EINK.
+//
+//  1. It DRAWS THE KEEP-OUT. eink's packer honours `bed.exclude` but its preview
+//     never draws it, so parts just mysteriously avoid a corner. For us that
+//     corner is the whole story: the X1C's 18 × 28 mm filament-cutter zone is
+//     what made the first live kit submit die at the slicer with exit 192, and
+//     `clearOfKeepOuts` now slides the entire layout — modules and tower
+//     together — to clear it. A preview that hid the thing we slide against
+//     would hide the interesting part.
+//
+//  2. It is READ-ONLY. eink's is editable because a frame job spans several
+//     plates and the user owns MEMBERSHIP (which plate a part is on) while the
+//     packer owns positions. Phase A ships one plate or an honest refusal, so
+//     there is no membership to edit and nothing here to drag. When Phase B
+//     (#33) adds plates, eink's tap-tap-plus-drag model is the one to copy.
+//
+// Colour follows eink's rule and carries NO identity: every module is the same
+// fill whatever its kind, because a legend keyed on hue is a legend some readers
+// can't use. Which module a rectangle is lives in its label and its <title>.
+//
+// Presentational and hook-free of data — the layout arrives as a prop, so every
+// state (fits, refuses, still rendering) is reproducible in Storybook without a
+// paired printer or a WASM export.
+
+import { useId } from 'react'
+import type { KitPlateLayout, KitPlatePlacement } from './abacus-kit-plate'
+
+export interface KitPlatePreviewProps {
+  /** The packed plate. Null while it's being computed, or when it was refused. */
+  layout: KitPlateLayout | null
+  /** Why there is no plate, straight off `KitPlateFitError`. Rendered instead of
+   *  the bed: a refusal is not an empty bed, and drawing one as the other is how
+   *  a user ends up waiting for a print that was never going to happen. */
+  refusal?: { headline: string; remediation: string; modules: readonly string[] } | null
+  /** The layout is being (re)computed — the export it needs takes a moment. */
+  pending?: boolean
+  /** Printer name for the caption. Falls back to the bed's size. */
+  printerName?: string
+  /** How many filaments this plate resolves to, for the caption. */
+  filaments?: number
+}
+
+const BED_FILL = 'rgba(15,23,42,0.72)'
+const BED_STROKE = 'rgba(148,163,184,0.45)'
+const MODULE_FILL = 'rgba(56,189,248,0.30)'
+const MODULE_STROKE = 'rgba(56,189,248,0.85)'
+const MODULE_TEXT = 'rgba(224,242,254,0.95)'
+const TOWER_STROKE = 'rgba(148,163,184,0.9)'
+const KEEPOUT_STROKE = 'rgba(248,113,113,0.85)'
+
+/**
+ * Font size for a label inside a `w × h` mm rect, or 0 to draw no label.
+ *
+ * eink's formula (`Math.min(11, h * 0.55, (w * 1.5) / label.length)`, hidden
+ * under 5) with one addition: a kit's modules are tall narrow strips — 15.5 mm
+ * wide by 100 mm deep is typical — so measuring the text against the rect's
+ * WIDTH would hide every label on the plate. The long side is whichever it is,
+ * and the caller turns the text to match.
+ */
+export function labelFit(wMm: number, hMm: number, label: string): number {
+  const along = Math.max(wMm, hMm)
+  const across = Math.min(wMm, hMm)
+  const size = Math.min(11, across * 0.55, (along * 1.5) / Math.max(label.length, 1))
+  return size >= 5 ? size : 0
+}
+
+/** One packed module. */
+function ModuleRect({ at, dMm }: { at: KitPlatePlacement; dMm: number }) {
+  // 3MF +Y runs to the BACK of the bed; SVG y grows downward. Every rect drawn
+  // here flips through the bed's depth, so the picture matches what the operator
+  // sees standing in front of the printer.
+  const y = dMm - at.yMm - at.hMm
+  const size = labelFit(at.wMm, at.hMm, at.label)
+  const upright = at.wMm >= at.hMm
+  const cx = at.xMm + at.wMm / 2
+  const cy = y + at.hMm / 2
+  return (
+    <g data-element="kit-plate-module" data-module-kind={at.kind} data-rotated={at.rotated}>
+      <title>{`${at.label} — ${at.wMm.toFixed(1)} × ${at.hMm.toFixed(1)} mm${
+        at.rotated ? ', turned 90°' : ''
+      }`}</title>
+      <rect
+        x={at.xMm}
+        y={y}
+        width={at.wMm}
+        height={at.hMm}
+        rx={1.5}
+        fill={MODULE_FILL}
+        stroke={MODULE_STROKE}
+        strokeWidth={0.6}
+      />
+      {size > 0 && (
+        <text
+          x={cx}
+          y={cy}
+          fontSize={size}
+          fill={MODULE_TEXT}
+          textAnchor="middle"
+          dominantBaseline="central"
+          transform={upright ? undefined : `rotate(-90 ${cx} ${cy})`}
+          style={{ pointerEvents: 'none', userSelect: 'none' }}
+        >
+          {at.label}
+        </text>
+      )}
+    </g>
+  )
+}
+
+export function KitPlatePreview({
+  layout,
+  refusal = null,
+  pending = false,
+  printerName,
+  filaments,
+}: KitPlatePreviewProps) {
+  const hatchId = useId()
+
+  if (refusal) {
+    return (
+      <div
+        data-component="kit-plate-preview"
+        data-state="refused"
+        style={{
+          padding: '10px 12px',
+          borderRadius: 8,
+          background: 'rgba(127,29,29,0.32)',
+          border: '1px solid rgba(248,113,113,0.5)',
+          color: 'rgba(254,226,226,0.96)',
+          lineHeight: 1.45,
+          fontSize: 13,
+        }}
+      >
+        <div style={{ fontWeight: 600 }}>{refusal.headline}</div>
+        <div style={{ color: 'rgba(254,226,226,0.82)', marginTop: 3 }}>{refusal.remediation}</div>
+        {refusal.modules.length > 0 && (
+          <div style={{ color: 'rgba(254,226,226,0.7)', marginTop: 4, fontSize: 12 }}>
+            {refusal.modules.join(', ')}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  if (!layout) {
+    return (
+      <div
+        data-component="kit-plate-preview"
+        data-state={pending ? 'pending' : 'idle'}
+        style={{
+          padding: '10px 12px',
+          borderRadius: 8,
+          border: `1px dashed ${BED_STROKE}`,
+          color: 'rgba(203,213,225,0.72)',
+          fontSize: 12,
+        }}
+      >
+        {pending ? 'Laying the kit out on the bed…' : 'No plate to show yet.'}
+      </div>
+    )
+  }
+
+  const { bed, tower, placements } = layout
+  const towerY = bed.dMm - tower.yMm - tower.dMm
+  const caption = [
+    printerName ?? `${Math.round(bed.wMm)} × ${Math.round(bed.dMm)} mm bed`,
+    `${placements.length} module${placements.length === 1 ? '' : 's'}`,
+    filaments ? `${filaments} filament${filaments === 1 ? '' : 's'}` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div data-component="kit-plate-preview" data-state="packed">
+      <svg
+        viewBox={`0 0 ${bed.wMm} ${bed.dMm}`}
+        role="img"
+        aria-label={`Build plate layout: ${caption}`}
+        style={{ width: '100%', height: 'auto', display: 'block', borderRadius: 8 }}
+      >
+        <defs>
+          {/* Diagonal hatch for the printer's keep-out. Pattern units are the
+              same millimetres as everything else, so the hatch reads at the same
+              density whatever size the SVG is displayed at. */}
+          <pattern
+            id={hatchId}
+            width={4}
+            height={4}
+            patternUnits="userSpaceOnUse"
+            patternTransform="rotate(45)"
+          >
+            <line x1={0} y1={0} x2={0} y2={4} stroke={KEEPOUT_STROKE} strokeWidth={1} />
+          </pattern>
+        </defs>
+
+        <rect
+          x={0}
+          y={0}
+          width={bed.wMm}
+          height={bed.dMm}
+          rx={3}
+          fill={BED_FILL}
+          stroke={BED_STROKE}
+          strokeWidth={0.8}
+        />
+
+        {(bed.exclude ?? []).map((zone) => (
+          <g
+            key={`keepout-${zone.xMm}-${zone.yMm}-${zone.wMm}-${zone.dMm}`}
+            data-element="kit-plate-keepout"
+          >
+            <title>
+              {`Printer keep-out — ${Math.round(zone.wMm)} × ${Math.round(
+                zone.dMm
+              )} mm. Nothing may overlap it, and the slicer refuses the whole plate if anything does.`}
+            </title>
+            <rect
+              x={zone.xMm}
+              y={bed.dMm - zone.yMm - zone.dMm}
+              width={zone.wMm}
+              height={zone.dMm}
+              fill={`url(#${hatchId})`}
+              stroke={KEEPOUT_STROKE}
+              strokeWidth={0.6}
+            />
+          </g>
+        ))}
+
+        <g data-element="kit-plate-tower">
+          <title>
+            {`Purge tower — ${Math.round(tower.wMm)} × ${Math.round(
+              tower.dMm
+            )} mm reserved before packing, so the modules lay out around it instead of under it.`}
+          </title>
+          <rect
+            x={tower.xMm}
+            y={towerY}
+            width={tower.wMm}
+            height={tower.dMm}
+            rx={1.5}
+            fill="none"
+            stroke={TOWER_STROKE}
+            strokeWidth={0.7}
+            strokeDasharray="3 2.5"
+          />
+          {labelFit(tower.wMm, tower.dMm, 'purge') > 0 && (
+            <text
+              x={tower.xMm + tower.wMm / 2}
+              y={towerY + tower.dMm / 2}
+              fontSize={labelFit(tower.wMm, tower.dMm, 'purge')}
+              fill={TOWER_STROKE}
+              textAnchor="middle"
+              dominantBaseline="central"
+              style={{ pointerEvents: 'none', userSelect: 'none' }}
+            >
+              purge
+            </text>
+          )}
+        </g>
+
+        {placements.map((at) => (
+          <ModuleRect key={at.id} at={at} dMm={bed.dMm} />
+        ))}
+      </svg>
+      <div
+        data-element="kit-plate-caption"
+        style={{ marginTop: 6, fontSize: 12, color: 'rgba(203,213,225,0.72)' }}
+      >
+        {caption}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/create/abacus/PrintPanel.tsx
+++ b/apps/web/src/components/create/abacus/PrintPanel.tsx
@@ -35,6 +35,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { persistAbacusDesign } from '@/hooks/useAbacusDesignSnapshot'
 import { useAbacusPrintJobs, useCancelPrintJob, useStartPrintJob } from '@/hooks/useAbacusPrintJobs'
 import { useAbacusPrintSettings, useSaveAbacusPrintSettings } from '@/hooks/useAbacusPrintSettings'
+import { useKitPlateLayout } from '@/hooks/useKitPlateLayout'
 import { usePrintJobRing } from '@/hooks/usePrintJobRing'
 import { useUserId } from '@/hooks/useUserId'
 import { createAbacusPrintClient } from '@/lib/abacus/print/browser-transport'
@@ -59,6 +60,7 @@ import {
 } from './abacus-print-panel-state'
 import { buildAbacusAuthoring, buildAbacusTicket } from './abacus-ticket'
 import { JobNotices } from './JobNotices'
+import { KitPlatePreview } from './KitPlatePreview'
 import { ParkedJobCard } from './ParkedJobCard'
 import { PairPrinterPrompt } from './PrintConnectionsManager'
 import { PrintSubmitErrorNotice } from './PrintSubmitErrorNotice'
@@ -649,6 +651,22 @@ export function PrintPanel(props: PrintPanelProps) {
   // never a silent style injection (see feetSupportGate).
   const feetGate = feetSupportGate(params, style)
 
+  // The bed preview (Gitea #32). Runs the SAME plan the submit runs, so what's
+  // drawn is what ships — including the refusals, which is the point: "this kit
+  // needs two beds" belongs on screen while the column count is still in the
+  // user's hand, not after they press print. Mono prints get no preview; there's
+  // one object and the container centres it.
+  const kitPlate = useKitPlateLayout({
+    enabled: visible && serviceReady && !!kit,
+    requestExportModuleParts: kit?.requestExportModuleParts,
+    params,
+    filamentMap,
+    supportsAtSlice: supportsWanted,
+    bed: printerBed,
+    wipeTower,
+    extraFilaments: supportPick ? 1 : 0,
+  })
+
   const submitBlocked =
     exportBlocked ||
     !serviceReady ||
@@ -939,6 +957,22 @@ export function PrintPanel(props: PrintPanelProps) {
               </button>
             </div>
           )}
+          {/* Directly above the commit, because that's the question it answers:
+              this is the bed you're about to print. */}
+          {kit && (
+            <div
+              data-element="kit-plate-preview-slot"
+              style={{ opacity: kitPlate.pending && kitPlate.layout ? 0.55 : 1 }}
+            >
+              <KitPlatePreview
+                layout={kitPlate.layout}
+                refusal={kitPlate.refusal}
+                pending={kitPlate.pending}
+                filaments={kitPlate.filaments ?? undefined}
+              />
+            </div>
+          )}
+
           <button
             type="button"
             data-action="submit-print-job"

--- a/apps/web/src/components/create/abacus/__tests__/KitPlatePreview.test.tsx
+++ b/apps/web/src/components/create/abacus/__tests__/KitPlatePreview.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * KitPlatePreview (Gitea #32) — the build-plate picture.
+ *
+ * Pins the things a picture of a bed can get silently wrong: the Y-FLIP (3MF +Y
+ * is the back of the bed, SVG y grows down — get it backwards and the drawing is
+ * a mirror of the print, which looks perfectly plausible), the KEEP-OUT actually
+ * being drawn (eink's preview honours it invisibly; ours draws it because it's
+ * what the layout slides against), and a refusal rendering AS a refusal rather
+ * than as an empty bed.
+ *
+ * Presentational, so it renders from plain geometry — no packer, no export, no
+ * printer.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { KitPlateLayout, KitPlatePlacement } from '../abacus-kit-plate'
+import { KitPlatePreview, labelFit } from '../KitPlatePreview'
+
+const at = (over: Partial<KitPlatePlacement> = {}): KitPlatePlacement => ({
+  id: 'm1',
+  label: 'mid 1 of 11',
+  kind: 'mid',
+  column: 1,
+  file: 'module_mid.3mf',
+  xMm: 20,
+  yMm: 30,
+  rotated: false,
+  wMm: 16,
+  hMm: 100,
+  ...over,
+})
+
+const layout = (over: Partial<KitPlateLayout> = {}): KitPlateLayout => ({
+  placements: [at()],
+  tower: { xMm: 180, yMm: 200, wMm: 70, dMm: 42, pinXMm: 215, pinYMm: 221 },
+  bed: { wMm: 256, dMm: 256, exclude: [{ xMm: 0, yMm: 0, wMm: 18, dMm: 28 }] },
+  ...over,
+})
+
+const rectOf = (el: Element | null): DOMStringMap & Record<string, string | null> =>
+  ({
+    x: el?.getAttribute('x') ?? null,
+    y: el?.getAttribute('y') ?? null,
+    width: el?.getAttribute('width') ?? null,
+    height: el?.getAttribute('height') ?? null,
+  }) as never
+
+describe('KitPlatePreview', () => {
+  it('draws the bed at 1:1 in millimetres, so no scale factor exists to get wrong', () => {
+    const { container } = render(<KitPlatePreview layout={layout()} />)
+    expect(container.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 256 256')
+  })
+
+  it('flips Y, because +Y in the 3MF is the BACK of the bed', () => {
+    // A module at y=30 with depth 100 occupies 30..130 from the front. Drawn
+    // without the flip it would sit at SVG y=30 — visually near the back — and
+    // the whole picture would be a mirror of the print that still looked fine.
+    const { container } = render(<KitPlatePreview layout={layout()} />)
+    const rect = container.querySelector('[data-element="kit-plate-module"] rect')
+    expect(rectOf(rect)).toMatchObject({ x: '20', y: '126', width: '16', height: '100' })
+  })
+
+  it('draws the printer keep-out — the thing the layout is slid clear of', () => {
+    const { container } = render(<KitPlatePreview layout={layout()} />)
+    const zone = container.querySelector('[data-element="kit-plate-keepout"] rect')
+    // 18 × 28 at the bed origin ⇒ flipped to the bottom-left of the drawing.
+    expect(rectOf(zone)).toMatchObject({ x: '0', y: '228', width: '18', height: '28' })
+    expect(
+      container.querySelector('[data-element="kit-plate-keepout"] title')?.textContent
+    ).toMatch(/keep-out/i)
+  })
+
+  it('draws no keep-out when the printer declares none', () => {
+    const { container } = render(
+      <KitPlatePreview layout={layout({ bed: { wMm: 256, dMm: 256 } })} />
+    )
+    expect(container.querySelector('[data-element="kit-plate-keepout"]')).toBeNull()
+  })
+
+  it('draws the reserved purge tower', () => {
+    const { container } = render(<KitPlatePreview layout={layout()} />)
+    const tower = container.querySelector('[data-element="kit-plate-tower"] rect')
+    expect(rectOf(tower)).toMatchObject({ x: '180', y: '14', width: '70', height: '42' })
+    expect(tower?.getAttribute('stroke-dasharray')).toBeTruthy()
+    expect(screen.getByText('purge')).toBeInTheDocument()
+  })
+
+  it('captions the bed with what is on it', () => {
+    render(<KitPlatePreview layout={layout()} filaments={3} />)
+    expect(screen.getByText(/256 × 256 mm bed · 1 module · 3 filaments/)).toBeInTheDocument()
+  })
+
+  it('renders a refusal as a refusal, not as an empty bed', () => {
+    render(
+      <KitPlatePreview
+        layout={null}
+        refusal={{
+          headline: 'this kit needs 2 build plates',
+          remediation: 'Print fewer columns.',
+          modules: ['mid 11 of 11'],
+        }}
+      />
+    )
+    expect(screen.getByText('this kit needs 2 build plates')).toBeInTheDocument()
+    expect(screen.getByText('Print fewer columns.')).toBeInTheDocument()
+    expect(screen.getByText('mid 11 of 11')).toBeInTheDocument()
+    expect(document.querySelector('svg')).toBeNull()
+  })
+
+  it('says it is working rather than showing an empty bed while it packs', () => {
+    const { container } = render(<KitPlatePreview layout={null} pending />)
+    expect(container.querySelector('[data-state="pending"]')).toBeInTheDocument()
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('names each module in its title, since colour deliberately carries no identity', () => {
+    const { container } = render(
+      <KitPlatePreview
+        layout={layout({ placements: [at({ rotated: true, wMm: 100, hMm: 16 })] })}
+      />
+    )
+    const titles = [...container.querySelectorAll('[data-element="kit-plate-module"] title')]
+    expect(titles[0]?.textContent).toMatch(/mid 1 of 11 — 100.0 × 16.0 mm, turned 90°/)
+  })
+})
+
+describe('the stories stay stories', () => {
+  // The stories run the REAL packer, which means a packer change can quietly
+  // turn "the shipped 13-column kit" into a refusal — and a refusal renders as
+  // a perfectly tidy red card, so nobody looking at Storybook would notice the
+  // gallery had stopped showing a packed bed at all.
+  it('still packs the kits they claim to show', async () => {
+    const stories = await import('../KitPlatePreview.stories')
+    expect(stories.FullKit.args?.layout?.placements).toHaveLength(13)
+    expect(stories.SupportsOn.args?.layout?.placements).toHaveLength(13)
+    expect(stories.FourFilaments.args?.layout?.placements).toHaveLength(13)
+    expect(stories.SmallKit.args?.layout?.placements).toHaveLength(4)
+    expect(stories.NoKeepOut.args?.layout?.bed.exclude).toBeUndefined()
+    expect(stories.WontFit.args?.layout).toBeNull()
+    expect(stories.WontFit.args?.refusal?.headline).toBeTruthy()
+  })
+
+  it('shows a fourth filament costing more bed than three', async () => {
+    // The per-count envelope read (Gitea #34) is why a 3-filament kit fits a bed
+    // the 6-filament worst case would have taken away — and the gallery is where
+    // that becomes visible, so it should stay visible.
+    const stories = await import('../KitPlatePreview.stories')
+    const three = stories.FullKit.args?.layout?.tower
+    const four = stories.FourFilaments.args?.layout?.tower
+    expect(four?.dMm).toBeGreaterThan(three?.dMm ?? Infinity)
+  })
+})
+
+describe('labelFit', () => {
+  it('measures text along the LONG side — a kit module is a tall narrow strip', () => {
+    // 16 × 100 mm. Measured across the width, an 11-character label would score
+    // (16 × 1.5) / 11 = 2.2 and vanish; every label on the plate would.
+    expect(labelFit(16, 100, 'mid 1 of 11')).toBeGreaterThan(0)
+  })
+
+  it('gives up rather than drawing an illegible label', () => {
+    expect(labelFit(4, 6, 'mid 1 of 11')).toBe(0)
+  })
+
+  it('never exceeds the eink ceiling, however much room there is', () => {
+    expect(labelFit(400, 400, 'a')).toBe(11)
+  })
+})

--- a/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
@@ -26,6 +26,7 @@ import {
   moduleBasis,
   packKitPlate,
   placeModuleBodies,
+  planKitPlate,
 } from '../abacus-kit-plate'
 import { defaultParams, derived, type FilamentMap, type Params } from '../abacus-model'
 import { type ModuleExportParts, moduleSoups } from '../abacus-module-kit'
@@ -759,5 +760,39 @@ describe('buildKitPlateThreeMf (the whole kit as one plate)', () => {
 
   it('refuses an overfull bed rather than shipping a partial kit', () => {
     expect(() => plateOf({ bed: { wMm: 150, dMm: 150 } })).toThrow(KitPlateFitError)
+  })
+})
+
+describe('planKitPlate (what the bed preview draws)', () => {
+  const pp = p({ color_scheme: 'heaven-earth' })
+  const args = { parts: kitParts(pp), filamentMap: fmHeavenEarth }
+
+  it('is the same arrangement the submit ships', () => {
+    // The whole reason the preview runs the real planner. If these two ever
+    // came apart, the studio would draw one plate and print another — and the
+    // divergence would be invisible until someone compared a photo of the bed
+    // against the screen.
+    const previewed = planKitPlate(args)
+    const shipped = buildKitPlateThreeMf(args)
+    expect(previewed.layout.placements).toEqual(shipped.placements)
+    expect(previewed.layout.tower).toEqual(shipped.tower)
+    expect(previewed.layout.bed).toEqual(shipped.bed)
+  })
+
+  it('reports the filament count that sized the tower', () => {
+    expect(planKitPlate(args).filaments).toBe(3)
+    expect(planKitPlate({ ...args, extraFilaments: 1 }).filaments).toBe(4)
+  })
+
+  it('refuses exactly where the submit refuses', () => {
+    // A preview that quietly drew a partial kit while the submit refused would
+    // be worse than no preview: it would promise a print that can't happen.
+    expect(() => planKitPlate({ ...args, bed: { wMm: 150, dMm: 150 } })).toThrow(KitPlateFitError)
+  })
+
+  it('hands back the gated soups, so the emit pays for one gate pass not two', () => {
+    const plan = planKitPlate(args)
+    expect(plan.instances).toHaveLength(13)
+    expect(plan.soupsFor(plan.instances[0])).toBe(plan.soupsFor(plan.instances[0]))
   })
 })

--- a/apps/web/src/components/create/abacus/abacus-kit-plate.ts
+++ b/apps/web/src/components/create/abacus/abacus-kit-plate.ts
@@ -690,25 +690,30 @@ export interface KitPlate extends KitPlateLayout {
   readonly wipeTower: AbacusThreeMf['wipeTower']
 }
 
-/**
- * Build the whole kit as ONE plate: expand the plan into instances, gate and
- * classify each module exactly as its standalone 3MF would, pack the footprints
- * around a reserved purge tower, apply each placement rigidly to every body of
- * its module, and emit the lot through the shared bucket/emit tail.
- *
- * Classification happens BEFORE placement, and that ordering is load-bearing:
- * `analyzeModuleShells` reads bead centers at the module's known local x and
- * hard-errors on anything else, so a rotated or translated module would fail its
- * own gate. Placement is the last thing that touches geometry.
- *
- * @throws {KitPlateFitError} when the kit doesn't fit one plate — the caller
- * falls back to the kit zip.
- */
-export function buildKitPlateThreeMf(args: {
+/** Everything decided about a kit plate BEFORE any triangle moves — the shared
+ *  head of {@link planKitPlate} and {@link buildKitPlateThreeMf}. */
+export interface KitPlatePlan {
+  /** Where every module and the tower land. What a bed preview draws. */
+  readonly layout: KitPlateLayout
+  readonly instances: readonly KitPlateInstance[]
+  readonly bases: Record<ModuleKind, ModuleBasis>
+  /** This kit's gated soups, memoized per (kind, column). */
+  readonly soupsFor: (inst: KitPlateInstance) => ModuleSoups
+  /** Some module prints its own feet, so this plate slices with supports on
+   *  whatever the ticket style says — it widens the gaps and the tower ring. */
+  readonly feetPrinted: boolean
+  /** Filaments this plate resolves to, `extraFilaments` included. Picks the
+   *  tower's envelope row. */
+  readonly filaments: number
+}
+
+/** The inputs that decide a plate's ARRANGEMENT. `buildKitPlateThreeMf` takes
+ *  these plus the emit-only ones (`slotLabels`), so a preview and the submit it
+ *  previews are the same call with the same answer. */
+export interface KitPlatePlanArgs {
   /** The snapshot-once module renders — the same bundle the kit zip builds from. */
   parts: ModuleExportParts
   filamentMap: FilamentMap
-  slotLabels?: readonly string[]
   supportsAtSlice?: boolean
   bed?: BedSize
   wipeTower?: WipeTowerProfileGeometry
@@ -716,11 +721,27 @@ export function buildKitPlateThreeMf(args: {
   /** Filaments the ticket will add beyond the plate's own bodies — the
    *  support-interface spool. A download adds none. */
   extraFilaments?: number
-}): KitPlate {
+}
+
+/**
+ * Gate every module, measure its basis, and pack the plate — everything up to
+ * but not including the emit.
+ *
+ * Split out of {@link buildKitPlateThreeMf} so the bed preview and the submit
+ * can't disagree about where things land. The preview is only honest if it is
+ * the SAME arrangement that ships, including the refusals: a preview computed
+ * from a cheaper model of the geometry would eventually draw a plate that fits
+ * while the submit refuses, or worse, draw one that fits while a different one
+ * prints. So this returns the real layout off the real renders, and the caller
+ * that wants bytes pays only the emit on top.
+ *
+ * @throws {KitPlateFitError} when the kit doesn't fit one plate — which a
+ * preview renders as the refusal it is, rather than hiding until submit.
+ */
+export function planKitPlate(args: KitPlatePlanArgs): KitPlatePlan {
   const {
     parts,
     filamentMap,
-    slotLabels,
     supportsAtSlice,
     bed = BAMBU_256_BED,
     wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
@@ -791,6 +812,7 @@ export function buildKitPlateThreeMf(args: {
     for (const soup of soups.partSoups) plateSlots.add(soup.slot)
   }
 
+  const filaments = plateSlots.size + extraFilaments
   const layout = packKitPlate({
     instances,
     bases,
@@ -798,8 +820,36 @@ export function buildKitPlateThreeMf(args: {
     gapMm,
     wipeTower,
     supportsAtSlice: supportsAtSlice || feetPrinted,
-    filaments: plateSlots.size + extraFilaments,
+    filaments,
   })
+  return { layout, instances, bases, soupsFor, feetPrinted, filaments }
+}
+
+/**
+ * Build the whole kit as ONE plate: plan it ({@link planKitPlate}), then apply
+ * each placement rigidly to every body of its module and emit the lot through
+ * the shared bucket/emit tail.
+ *
+ * Classification happens BEFORE placement, and that ordering is load-bearing:
+ * `analyzeModuleShells` reads bead centers at the module's known local x and
+ * hard-errors on anything else, so a rotated or translated module would fail its
+ * own gate. Placement is the last thing that touches geometry.
+ *
+ * @throws {KitPlateFitError} when the kit doesn't fit one plate — the caller
+ * falls back to the kit zip.
+ */
+export function buildKitPlateThreeMf(
+  args: KitPlatePlanArgs & { slotLabels?: readonly string[] }
+): KitPlate {
+  const {
+    filamentMap,
+    slotLabels,
+    supportsAtSlice,
+    bed = BAMBU_256_BED,
+    wipeTower = DEFAULT_WIPE_TOWER_PROFILE,
+    extraFilaments = 0,
+  } = args
+  const { layout, instances, bases, soupsFor, feetPrinted } = planKitPlate(args)
   const placementOf = new Map(layout.placements.map((pl) => [pl.id, pl]))
 
   // Each instance contributes its classified body soup (placed, its shells

--- a/apps/web/src/hooks/useKitPlateLayout.ts
+++ b/apps/web/src/hooks/useKitPlateLayout.ts
@@ -1,0 +1,168 @@
+'use client'
+
+// The packed kit plate, computed for the PREVIEW rather than for a submit
+// (Gitea #32).
+//
+// The layout the studio draws has to be the layout that prints, so this runs the
+// real thing: the real module export, the real gate, the real packer, via
+// `planKitPlate` — the shared head of `buildKitPlateThreeMf`. It just stops
+// before the emit, which is the expensive half and the half a picture doesn't
+// need. A cheaper analytic model of the footprints would be a second source of
+// truth about where modules land, and the day the two disagreed the preview
+// would be lying at exactly the moment it mattered.
+//
+// Cost control is therefore a caching problem, not a fidelity one:
+//   • the query key is the layout's INPUTS, so an unchanged design never
+//     re-exports, and `staleTime: Infinity` means it never re-exports on a
+//     refocus either;
+//   • the inputs are debounced, so dragging a column slider costs one export at
+//     the end of the drag rather than one per frame;
+//   • `enabled` gates it on the panel actually being open.
+//
+// A refusal (`KitPlateFitError`) is DATA here, not an error: "this kit needs two
+// beds" is the most useful thing the preview can say, and it should say it while
+// the user still has the column count in their hand — not after they press
+// print. Anything else that throws is a real failure and surfaces as one.
+
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import { bedSizeFromThh } from '@/components/create/abacus/abacus-3mf'
+import {
+  KitPlateFitError,
+  type KitPlateLayout,
+  planKitPlate,
+} from '@/components/create/abacus/abacus-kit-plate'
+import type { FilamentMap, Params } from '@/components/create/abacus/abacus-model'
+import type { ModuleExportParts } from '@/components/create/abacus/abacus-module-kit'
+import type { ThhBedGeometry, ThhWipeTowerCapability } from '@/lib/abacus/print/filament-wire'
+import { abacusPrintKeys } from '@/lib/queryKeys'
+import { stableStringify } from '@/lib/stable-stringify'
+
+/** Long enough that a slider drag settles first, short enough that the picture
+ *  feels attached to the control that changed it. */
+const SETTLE_MS = 400
+
+export interface KitPlateRefusalView {
+  readonly headline: string
+  readonly remediation: string
+  readonly modules: readonly string[]
+}
+
+export interface KitPlateLayoutResult {
+  /** Where every module and the tower land, or null if there's no plate yet. */
+  readonly layout: KitPlateLayout | null
+  /** Filaments the plate resolves to — the tower's envelope row. */
+  readonly filaments: number | null
+  /** We won't ship this plate, and why. Not an error state. */
+  readonly refusal: KitPlateRefusalView | null
+  /** The export/pack is running. */
+  readonly pending: boolean
+  /** Something other than a refusal broke — a dead exporter, torn HMR state. */
+  readonly error: Error | null
+}
+
+export interface UseKitPlateLayoutArgs {
+  /** Only compute while the panel is on screen and the design is modular. */
+  enabled: boolean
+  /** The modular export bundle, one snapshot per call. */
+  requestExportModuleParts?: () => Promise<ModuleExportParts>
+  params: Params
+  filamentMap: FilamentMap
+  /** Supports will be on at slice — widens the module gaps and the tower ring,
+   *  so it changes the layout and belongs in the key. */
+  supportsAtSlice: boolean
+  bed?: ThhBedGeometry
+  wipeTower?: ThhWipeTowerCapability | null
+  /** Filaments the ticket adds that no body carries (the routed support
+   *  interface). Sizes the tower reserve, so it changes the layout too. */
+  extraFilaments: number
+}
+
+/** Hold `value` still until it has stopped changing for `ms`. */
+function useSettled<T>(value: T, ms: number): T {
+  const [settled, setSettled] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setSettled(value), ms)
+    return () => clearTimeout(id)
+  }, [value, ms])
+  return settled
+}
+
+export function useKitPlateLayout(args: UseKitPlateLayoutArgs): KitPlateLayoutResult {
+  const {
+    enabled,
+    requestExportModuleParts,
+    params,
+    filamentMap,
+    supportsAtSlice,
+    bed,
+    wipeTower,
+    extraFilaments,
+  } = args
+
+  // Everything the arrangement depends on and nothing else. Style keys the
+  // slicer clamps, the start policy, the printer's name — none of them move a
+  // module, so none of them should cost an export.
+  const signature = stableStringify({
+    params,
+    filamentMap,
+    supportsAtSlice,
+    bed,
+    wipeTower,
+    extraFilaments,
+  })
+  const settled = useSettled(signature, SETTLE_MS)
+  // Debouncing the KEY alone would leave the query showing a stale plate as
+  // settled truth during the drag. `isFetching` below covers that: the picture
+  // dims while the design has moved on from what's drawn.
+  const moving = settled !== signature
+
+  const query = useQuery({
+    queryKey: abacusPrintKeys.kitPlate(settled),
+    enabled: enabled && !!requestExportModuleParts,
+    // The inputs ARE the key, so a hit can never be stale — and a plate should
+    // not be recomputed because a window regained focus.
+    staleTime: Infinity,
+    retry: false,
+    queryFn: async (): Promise<{
+      layout: KitPlateLayout | null
+      filaments: number | null
+      refusal: KitPlateRefusalView | null
+    }> => {
+      if (!requestExportModuleParts) throw new Error('no module exporter registered')
+      const parts = await requestExportModuleParts()
+      try {
+        const plan = planKitPlate({
+          parts,
+          filamentMap,
+          supportsAtSlice,
+          bed: bedSizeFromThh(bed),
+          wipeTower: wipeTower ?? undefined,
+          extraFilaments,
+        })
+        return { layout: plan.layout, filaments: plan.filaments, refusal: null }
+      } catch (err) {
+        if (err instanceof KitPlateFitError) {
+          return {
+            layout: null,
+            filaments: null,
+            refusal: {
+              headline: err.headline,
+              remediation: err.remediation,
+              modules: err.modules,
+            },
+          }
+        }
+        throw err
+      }
+    },
+  })
+
+  return {
+    layout: query.data?.layout ?? null,
+    filaments: query.data?.filaments ?? null,
+    refusal: query.data?.refusal ?? null,
+    pending: enabled && (query.isFetching || moving),
+    error: query.error instanceof Error ? query.error : null,
+  }
+}

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -284,6 +284,11 @@ export const abacusPrintKeys = {
       connectionId ?? 'sole',
     ] as const,
   settings: () => [...abacusPrintKeys.all, 'settings'] as const,
+  // The packed kit plate behind the bed preview (Gitea #32). Local work, not a
+  // fetch — it lives here because it caches like one: the key IS the layout's
+  // inputs (design + bed + tower + supports), so a hit is exact by construction
+  // and an unchanged design never pays for the module export again.
+  kitPlate: (signature: string) => [...abacusPrintKeys.all, 'kit-plate', signature] as const,
 }
 
 // Attachment query keys (for practice photos and worksheet parsing)


### PR DESCRIPTION
The kit had no bed preview: the plate was packed inside the submit mutation, so the first thing a user learned about the arrangement was a job appearing — and the first thing they learned about a **refusal** ("this kit needs 2 build plates") was a red card *after* pressing print, long after the column count that caused it left their hand.

This is Frame Studio's plate preview, for a kit.

## It runs the real planner, not a model of it

`planKitPlate` is `buildKitPlateThreeMf` split at the emit — same export, same gate, same basis, same packer, same keep-out slide, same `KitPlateFitError`. The caller who wants bytes pays the emit on top; the caller who wants a picture stops. A cheaper analytic footprint would have been a second source of truth about where modules land, and the day the two disagreed the picture would be lying at exactly the moment it mattered. A test asserts both paths return identical placements, tower and bed.

Cost is therefore a caching problem, not a fidelity one:

- the React Query key **is** the layout's inputs (design, bed, tower capability, supports, extra filaments), so an unchanged design never re-exports
- `staleTime: Infinity`, so a refocus doesn't either
- inputs are debounced 400 ms, so dragging the column slider costs one export at the end of the drag rather than one per frame — and the picture dims while the design has moved on from what's drawn

## Two deliberate divergences from eink

**It draws the keep-out.** eink's packer honours `bed.exclude` but its preview never draws it, so parts just mysteriously avoid a corner. For us that corner is the story: the X1C's 18 × 28 mm filament-cutter zone is what killed the first live kit submit with exit 192, and `clearOfKeepOuts` now slides the whole layout — modules and tower together — to clear it. Hiding what we slide against would hide the interesting part.

**It's read-only.** eink's is editable because a frame job spans plates and the user owns *membership* while the packer owns *positions*. Phase A ships one plate or an honest refusal, so there's nothing to drag. Phase B (#33) is where eink's tap-tap-plus-drag model gets copied.

## Kept from eink

A `viewBox` in millimetres, so the drawing is the bed at 1:1 and no scale factor exists to get wrong. Labels that hide themselves rather than render illegibly. And colour carrying **no identity** — every module is the same fill whatever its kind, because a legend keyed on hue is a legend some readers can't use. Which module a rectangle is lives in its label and its `<title>`.

One addition to eink's label formula: it measures against the rect's *width*, and a kit module is a tall narrow strip (15.5 × 100.5 mm at scale 1), so every label on the plate would score ~2.2 and vanish. Text is measured along whichever side is longer and turned to match.

## Verification

- `tsc` clean, biome clean on every touched file
- 1159 abacus + hooks tests pass (14 new for the preview, 4 new for the planner split)
- the Y-flip is pinned by test — 3MF +Y is the **back** of the bed and SVG y grows down, and getting that backwards draws a mirror of the print that looks perfectly plausible
- the stories run the **actual packer** over the actual module dimensions (`packKitPlate` needs footprint numbers, not triangles), so the gallery shows real arrangements and real refusal copy — and a test asserts they still pack what they claim to, because a packer change would otherwise turn "the shipped 13-column kit" into a tidy red card nobody would notice

Not verified: how it looks on a real screen. `AbacusStudio/KitPlatePreview` in Storybook is the fastest way to judge that.

Gitea #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKx8T1Y3skF8G83atrxmG4