### PR TITLE
Search tower corners instead of taking the first one

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -148,6 +148,7 @@
   "devDependencies": {
     "@auth/core": "0.40.0",
     "@eink/frames-engine": "1.1159.1",
+    "@eink/plate-packing": "1.0.0",
     "@next/bundle-analyzer": "^16.1.1",
     "@pandacss/dev": "^1.8.1",
     "@playwright/test": "^1.55.1",

--- a/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/kit-plate.test.ts
@@ -459,6 +459,14 @@ describe('packKitPlate (tower first, then the modules around it)', () => {
     // Most of that was skirt — a loop `skirt_loops = 0` means this printer never draws,
     // and which would ring the plate rather than run between two modules if it did.
     // At the honest 10.9 the thirteenth module fits beside a six-filament tower.
+    //
+    // THIS IS ALSO THE GUARD ON THE TOWER-CORNER SEARCH. It is the only case in
+    // the suite where the tower's corner decides whether the kit ships: pinning
+    // the tower to the single most corner-hugging spot (i.e. replacing
+    // packKitPlate's candidate loop with `placeTowerReserve`) packs these 13
+    // modules 239.3 mm wide on a 256 bed, and the keep-out slide then needs
+    // 18 mm of slack where 16.7 is left — a `keep-out` refusal, right here.
+    // Verified by doing exactly that, on @eink/plate-packing 1.0.0.
     const plate = packKitPlate({ instances, bases, supportsAtSlice: true })
     expect(plate.placements).toHaveLength(instances.length)
   })

--- a/apps/web/src/components/create/abacus/abacus-kit-plate.ts
+++ b/apps/web/src/components/create/abacus/abacus-kit-plate.ts
@@ -38,24 +38,26 @@
  * all raise {@link KitPlateFitError} naming what didn't fit and which knob moves
  * it. Never silently drop a module: a kit missing a column is not a kit.
  *
- * IMPORT NOTE. `packPlates`, `meshBounds` and the tower reserve come from
- * `@eink/frames-engine` today. They move to `@eink/plate-packing` (eink PR #569)
- * once it publishes — a pure extraction with identical signatures, so that
- * switch is an import-line edit.
+ * IMPORT NOTE. The packer and the tower reserve come from `@eink/plate-packing`
+ * (eink PR #569 lifted them out of `@eink/frames-engine`). `meshBounds`
+ * deliberately stays behind: it reads triangles, and the point of the
+ * extraction is that the packing package is geometry over numbers — no STL, no
+ * 3MF, no DOM. `BedSize`/`BedRect` are declared identically in both packages
+ * and structurally interchangeable, which is why the four other abacus files
+ * that only name the TYPE can keep importing it beside the function they feed
+ * it to. The swap was NOT a no-op — see `packKitPlate` on tower candidates.
  */
+import { meshBounds } from '@eink/frames-engine/print-bundle'
 import {
   type BedRect,
   type BedSize,
-  meshBounds,
   type PackItem,
-  packPlates,
-} from '@eink/frames-engine/print-bundle'
-import {
   type PlacedTower,
-  placeTowerReserve,
+  packPlates,
   type TowerReserve,
   towerMargin,
-} from '@eink/frames-engine/wipe-tower'
+  towerPlacementCandidates,
+} from '@eink/plate-packing'
 import { type AbacusThreeMf, emitThreeMfBodies, type SpoolBodySummary } from './abacus-3mf'
 import {
   BAMBU_256_BED,
@@ -538,9 +540,29 @@ function bedFreeRects(bed: BedSize, margin: number): BedRect[] {
  * turn a one-filament plate into a real two-filament slice. Bed area is the
  * cheaper thing to spend.
  *
+ * WHICH CORNER THE TOWER TAKES IS PART OF THE SEARCH, NOT AN INPUT TO IT. The
+ * tower is placed by hugging a corner of the bed's free space, and for a full
+ * plate the corner it picks decides whether the kit fits at all: the reserve is
+ * a ~98 × 91 mm hole, and 13 modules pack differently around a hole in the back
+ * left than one in the front right. That is not a preference, it is the
+ * difference between a plate and a refusal — and worse, between a plate that can
+ * be slid clear of the printer's keep-out and one that cannot (see
+ * `clearOfKeepOuts`; the slide needs slack in a bed dimension, and the losing
+ * arrangement leaves 16.7 mm where it needs 18).
+ *
+ * So every viable spot is tried, best corner-hugger first, and the first that
+ * yields a complete single-plate layout WITH a clear slide wins. Unconstrained
+ * plates therefore cost exactly one pack, as before — the loop only spins for
+ * kits that are actually tight. `towerPlacementCandidates` returns the list for
+ * precisely this reason; taking `[0]` (which is what `placeTowerReserve` is)
+ * made the flagship 13-column printed-feet kit's fit depend on how the upstream
+ * packer happened to break a scoring tie, and a tie-break moving in
+ * `@eink/plate-packing` 1.0.0 is what surfaced it.
+ *
  * @throws {KitPlateFitError} when the kit needs more than one plate, when a
- * module exceeds the bed alone, or when no rectangle is left for the tower.
- * Phase A ships one plate or nothing.
+ * module exceeds the bed alone, when no rectangle is left for the tower, or when
+ * no tower spot leaves a layout that clears the keep-outs. Phase A ships one
+ * plate or nothing.
  */
 export function packKitPlate(args: {
   instances: readonly KitPlateInstance[]
@@ -574,8 +596,8 @@ export function packKitPlate(args: {
   const gapMm = args.gapMm ?? moduleGapMm(supportsAtSlice)
 
   const reserve = plateTowerReserve(wipeTower, supportsAtSlice, filaments)
-  const tower = placeTowerReserve(bed, reserve, bedFreeRects(bed, towerMargin(bed)))
-  if (!tower) {
+  const towerSpots = towerPlacementCandidates(bed, reserve, bedFreeRects(bed, towerMargin(bed)))
+  if (towerSpots.length === 0) {
     throw new KitPlateFitError(
       'no-tower-room',
       [],
@@ -587,6 +609,36 @@ export function packKitPlate(args: {
       'Select a printer with a bigger bed, or print the kit module by module from the zip.'
     )
   }
+
+  // Report the FIRST spot's refusal when none works. It is the corner the tower
+  // would have taken on its own, so the diagnosis a user reads is the one that
+  // describes the plate they asked for, not whichever of a dozen fallbacks
+  // happened to fail last.
+  let firstRefusal: KitPlateFitError | null = null
+  for (const tower of towerSpots) {
+    try {
+      return layoutAroundTower({ instances, bases, bed, gapMm, tower })
+    } catch (err) {
+      if (!(err instanceof KitPlateFitError)) throw err
+      firstRefusal ??= err
+    }
+  }
+  // Unreachable-by-construction guard: the loop either returns or records a
+  // refusal, and towerSpots is non-empty above.
+  throw firstRefusal ?? new Error('packKitPlate: no tower spot tried')
+}
+
+/** One tower spot, fully evaluated: pack the modules around it and slide the
+ *  result clear of the printer's keep-outs, or refuse. Split out of {@link
+ *  packKitPlate} so the spot search reads as a search. */
+function layoutAroundTower(args: {
+  instances: readonly KitPlateInstance[]
+  bases: Record<ModuleKind, ModuleBasis>
+  bed: BedSize
+  gapMm: number
+  tower: PlacedTower
+}): KitPlateLayout {
+  const { instances, bases, bed, gapMm, tower } = args
 
   const items: PackItem[] = instances.map((inst) => ({
     id: inst.id,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
       '@eink/frames-engine':
         specifier: 1.1159.1
         version: 1.1159.1
+      '@eink/plate-packing':
+        specifier: 1.0.0
+        version: 1.0.0
       '@next/bundle-analyzer':
         specifier: ^16.1.1
         version: 16.1.1
@@ -1564,6 +1567,9 @@ packages:
 
   '@eink/frames-engine@1.1159.1':
     resolution: {integrity: sha512-FKqNiQKsbDOy807s27cvUR9rvEPist/bSflWZLN1VaLQQAM2ovofWDXYYq0nb740DXSm5s40ijoTmW+dnxqexA==, tarball: https://git.dev.abaci.one/api/packages/antialias/npm/%40eink%2Fframes-engine/-/1.1159.1/frames-engine-1.1159.1.tgz}
+
+  '@eink/plate-packing@1.0.0':
+    resolution: {integrity: sha512-6leh4Tnp04RIqCLqhYMTbRoQsPJBT7P1RNI8+85Nsk0RaWUfqZUpLe6SznnpEGedUtLr6CUz0gvmDVfRKgGwag==, tarball: https://git.dev.abaci.one/api/packages/antialias/npm/%40eink%2Fplate-packing/-/1.0.0/plate-packing-1.0.0.tgz}
 
   '@eink/print-dialog@1.1153.1':
     resolution: {integrity: sha512-3WJ6QwSv1qRBz9wnyOM24TsJAQUTcp08CFYvZWrBtJLXPJrK1oOv9IDbJ75DLRYkiH1K/7yeGdAYMvphLkff6w==, tarball: https://git.dev.abaci.one/api/packages/antialias/npm/%40eink%2Fprint-dialog/-/1.1153.1/print-dialog-1.1153.1.tgz}
@@ -14698,6 +14704,8 @@ snapshots:
     dependencies:
       fflate: 0.8.3
       qrcode: 1.5.4
+
+  '@eink/plate-packing@1.0.0': {}
 
   '@eink/print-dialog@1.1153.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
Moves the packer and the tower reserve onto **`@eink/plate-packing` 1.0.0**, which eink extracted out of `@eink/frames-engine` (PR #569) and published today. `meshBounds` stays behind — it reads triangles, and the point of the extraction is that the packing package is geometry over numbers.

The swap was not the import-line edit the file predicted.

### What broke

Six tests went red, all keep-out refusals, including the flagship one: the 13-column printed-feet kit that physically printed on the X1C last week.

The cause was not the packer. It was **where the tower went**. Both libraries place the ~98 × 91 mm reserve by hugging a corner of the bed's free space and scoring the corners; two corners score close enough that a tie-break decides, and the tie-break moved.

| | tower spot | plate box |
|---|---|---|
| `@eink/frames-engine` 1.1159.1 | (142, 16) front-right | 240 × 221.3 |
| `@eink/plate-packing` 1.0.0 | (16, 149) back-left | 239.3 × 240 |

That second box is a refusal. `clearOfKeepOuts` slides the whole plate off the X1C's 18 × 28 mm cutter corner, and a slide needs slack — 18 mm in x or 28 in y. The 240-wide arrangement leaves 34.7 mm in y and slides clean; the 239.3 × 240 one leaves 16.7 and 16, and nothing clears.

So the kit that printed was fitting on a coin flip in a dependency.

### The fix

`towerPlacementCandidates` exists for exactly this, and says so in its own doc: the list is a list because which corner is cheapest depends on what else must fit, and eink's own plate packer scores every candidate by the pack it produces. This does the same — every viable spot is tried, best corner-hugger first, and the first that yields a complete single-plate layout **with a clear slide** wins.

An unconstrained plate still costs exactly one pack (candidate 0 succeeds and the loop stops), so only kits that need the search pay for it. When no spot works the error reported is the **first** spot's, because that is the corner the tower would have taken on its own.

### No new test

The guard already existed. `fits a printed-feet 13-column kit on a 256 even at the worst-case tower` is the one case in the suite where the tower's corner decides whether the kit ships, and it fails within seconds of anyone collapsing this loop back to `placeTowerReserve` — verified by doing exactly that. What it lacked was a comment saying so, which it now has, with the numbers.

### Verification

- `tsc --noEmit` clean
- biome clean on both changed source files
- **6387 tests passed**, 0 failed (full `apps/web` suite)

Gitea #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKx8T1Y3skF8G83atrxmG4