### PR TITLE
Add slow first-layer adhesion control

### DIFF
--- a/apps/web/src/components/create/abacus/PrintPanel.tsx
+++ b/apps/web/src/components/create/abacus/PrintPanel.tsx
@@ -53,7 +53,11 @@ import {
   designSlotIds,
   FEET_SUPPORT_PROCESS,
   feetSupportGate,
+  SLOW_FIRST_LAYER_PROCESS,
+  slowFirstLayerEnabled,
   supportsEnabled,
+  supportsSlowFirstLayer,
+  withSlowFirstLayer,
 } from './abacus-print-panel-state'
 import { buildAbacusAuthoring, buildAbacusTicket } from './abacus-ticket'
 import { JobNotices } from './JobNotices'
@@ -145,6 +149,8 @@ const COMMON_KEYS = [
   // prints on supports, and off, Orca is free to grow them on the beads. See
   // FEET_SUPPORT_PROCESS.
   'support_on_build_plate_only',
+  'initial_layer_speed',
+  'initial_layer_acceleration',
   'brim_type',
 ] as const
 
@@ -245,6 +251,8 @@ export function PrintPanel(props: PrintPanelProps) {
     return preset ? { basePreset: preset, process: {} } : null
   }, [caps.data])
   const style = styleEdits ?? savedSettings.data ?? seededStyle
+  const slowFirstLayerSupported = supportsSlowFirstLayer(caps.data)
+  const slowFirstLayerActive = slowFirstLayerEnabled(style)
 
   // ---- support-interface negotiation (Gitea #23, THH#367) -------------------
   // Active only when the style EXPLICITLY enables supports (the client owns
@@ -854,6 +862,59 @@ export function PrintPanel(props: PrintPanelProps) {
                 }}
               >
                 {feetGate.blocked ? 'Enable supports' : 'Keep supports off the model'}
+              </button>
+            </div>
+          )}
+          {slowFirstLayerSupported && (
+            <div
+              data-element="slow-first-layer-choice"
+              data-active={slowFirstLayerActive || undefined}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 10,
+                padding: '8px 10px',
+                borderRadius: 8,
+                background: slowFirstLayerActive ? 'rgba(8,145,178,0.22)' : 'rgba(30,41,59,0.48)',
+                border: slowFirstLayerActive
+                  ? '1px solid rgba(34,211,238,0.5)'
+                  : '1px solid rgba(148,163,184,0.3)',
+              }}
+            >
+              <span style={{ display: 'flex', flexDirection: 'column', gap: 2, lineHeight: 1.35 }}>
+                <strong style={{ color: 'rgba(226,232,240,0.98)' }}>Slow first layer</strong>
+                <span style={{ color: 'rgba(148,163,184,0.95)', fontSize: 11 }}>
+                  {SLOW_FIRST_LAYER_PROCESS.initial_layer_speed} mm/s ·{' '}
+                  {SLOW_FIRST_LAYER_PROCESS.initial_layer_acceleration} mm/s². Try this before
+                  adding a brim.
+                </span>
+              </span>
+              <button
+                type="button"
+                data-action="toggle-slow-first-layer"
+                aria-pressed={slowFirstLayerActive}
+                disabled={!style}
+                onClick={() =>
+                  style && handleStyleChange(withSlowFirstLayer(style, !slowFirstLayerActive))
+                }
+                style={{
+                  flex: '0 0 auto',
+                  padding: '5px 10px',
+                  borderRadius: 6,
+                  border: slowFirstLayerActive
+                    ? '1px solid rgba(34,211,238,0.7)'
+                    : '1px solid rgba(148,163,184,0.45)',
+                  background: slowFirstLayerActive
+                    ? 'rgba(34,211,238,0.16)'
+                    : 'rgba(255,255,255,0.06)',
+                  color: slowFirstLayerActive ? 'rgba(207,250,254,0.98)' : 'rgba(226,232,240,0.95)',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  cursor: style ? 'pointer' : 'not-allowed',
+                }}
+              >
+                {slowFirstLayerActive ? 'Use preset speed' : 'Slow it down'}
               </button>
             </div>
           )}

--- a/apps/web/src/components/create/abacus/__tests__/abacus-print-panel-state.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-print-panel-state.test.ts
@@ -7,7 +7,7 @@
  * leaves a row), the `?? not ||` AMS tri-state (a live `false` never falls back to the
  * static capability), and that the monochrome note is scoped to a single EXTERNAL spool.
  */
-import type { TicketStyle } from '@eink/print-dialog'
+import type { CapabilityDocument, CapabilityKeyEntry, TicketStyle } from '@eink/print-dialog'
 import { describe, expect, it } from 'vitest'
 import type { FilamentCatalog, FilamentSpool } from '../abacus-catalog'
 import {
@@ -15,7 +15,11 @@ import {
   abacusPrintPanelState,
   designSlotIds,
   feetSupportGate,
+  SLOW_FIRST_LAYER_PROCESS,
+  slowFirstLayerEnabled,
   supportsEnabled,
+  supportsSlowFirstLayer,
+  withSlowFirstLayer,
 } from '../abacus-print-panel-state'
 
 const spool = (over: Partial<FilamentSpool> = {}): FilamentSpool => ({
@@ -165,6 +169,107 @@ describe('supportsEnabled (Gitea #23)', () => {
     expect(supportsEnabled(withProcess({ enable_support: '0' }))).toBe(false)
     expect(supportsEnabled(withProcess({}))).toBe(false)
     expect(supportsEnabled(null)).toBe(false)
+  })
+})
+
+describe('slow first layer', () => {
+  const entry = (over: Partial<CapabilityKeyEntry> = {}): CapabilityKeyEntry => ({
+    class: 'process',
+    type: 'coFloat',
+    group: 'Speed',
+    tier: 'open',
+    audience: 'consumer',
+    ...over,
+  })
+  const capabilities = (
+    speed: CapabilityKeyEntry | null = entry({ min: 1 }),
+    acceleration: CapabilityKeyEntry | null = entry({ min: 0 })
+  ): Pick<CapabilityDocument, 'keys'> => ({
+    keys: {
+      ...(speed ? { initial_layer_speed: speed } : {}),
+      ...(acceleration ? { initial_layer_acceleration: acceleration } : {}),
+    },
+  })
+  const style = (process: TicketStyle['process']): TicketStyle => ({
+    basePreset: '0.20mm-standard',
+    process,
+  })
+
+  it('offers the recipe only when both numeric process keys can accept it', () => {
+    expect(supportsSlowFirstLayer(capabilities())).toBe(true)
+    expect(supportsSlowFirstLayer(capabilities(null, entry()))).toBe(false)
+    expect(supportsSlowFirstLayer(capabilities(entry(), null))).toBe(false)
+    expect(supportsSlowFirstLayer(capabilities(entry({ tier: 'blocked' }), entry()))).toBe(false)
+    expect(supportsSlowFirstLayer(capabilities(entry({ class: 'machine' }), entry()))).toBe(false)
+    expect(supportsSlowFirstLayer(capabilities(entry({ audience: 'never' }), entry()))).toBe(false)
+    expect(supportsSlowFirstLayer(capabilities(entry({ type: 'coFloats' }), entry()))).toBe(false)
+    expect(supportsSlowFirstLayer(capabilities(entry({ min: 13 }), entry()))).toBe(false)
+    expect(supportsSlowFirstLayer(capabilities(entry(), entry({ max: 299 })))).toBe(false)
+    expect(supportsSlowFirstLayer(null)).toBe(false)
+  })
+
+  it('is active only when both explicit overrides exactly match the recipe', () => {
+    expect(slowFirstLayerEnabled(style({ ...SLOW_FIRST_LAYER_PROCESS }))).toBe(true)
+    expect(slowFirstLayerEnabled(style({ initial_layer_speed: 12 }))).toBe(false)
+    expect(slowFirstLayerEnabled(style({ initial_layer_acceleration: 300 }))).toBe(false)
+    expect(
+      slowFirstLayerEnabled(style({ initial_layer_speed: 10, initial_layer_acceleration: 300 }))
+    ).toBe(false)
+    expect(slowFirstLayerEnabled(style({}))).toBe(false)
+    expect(slowFirstLayerEnabled(null)).toBe(false)
+  })
+
+  it('applies the recipe without mutating or discarding unrelated choices', () => {
+    const original = style({
+      initial_layer_speed: 9,
+      brim_type: 'outer_only',
+      enable_support: true,
+      wall_loops: 4,
+    })
+    const result = withSlowFirstLayer(original, true)
+
+    expect(result).toEqual({
+      basePreset: '0.20mm-standard',
+      process: {
+        initial_layer_speed: 12,
+        initial_layer_acceleration: 300,
+        brim_type: 'outer_only',
+        enable_support: true,
+        wall_loops: 4,
+      },
+    })
+    expect(original.process).toEqual({
+      initial_layer_speed: 9,
+      brim_type: 'outer_only',
+      enable_support: true,
+      wall_loops: 4,
+    })
+  })
+
+  it('resets only the recipe keys so the preset becomes effective again', () => {
+    const original = style({
+      ...SLOW_FIRST_LAYER_PROCESS,
+      brim_type: 'outer_only',
+      enable_support: true,
+      support_on_build_plate_only: true,
+    })
+    const result = withSlowFirstLayer(original, false)
+
+    expect(result).toEqual({
+      basePreset: '0.20mm-standard',
+      process: {
+        brim_type: 'outer_only',
+        enable_support: true,
+        support_on_build_plate_only: true,
+      },
+    })
+    expect(original.process).toEqual({
+      ...SLOW_FIRST_LAYER_PROCESS,
+      brim_type: 'outer_only',
+      enable_support: true,
+      support_on_build_plate_only: true,
+    })
+    expect(withSlowFirstLayer(style({ ...SLOW_FIRST_LAYER_PROCESS }), false).process).toEqual({})
   })
 })
 

--- a/apps/web/src/components/create/abacus/abacus-print-panel-state.ts
+++ b/apps/web/src/components/create/abacus/abacus-print-panel-state.ts
@@ -15,7 +15,7 @@
 // leaves a row in the roster (so `rosterEmpty` is false) yet something IS physically
 // loaded; checking emptiness first would falsely say "nothing loaded".
 
-import type { TicketStyle } from '@eink/print-dialog'
+import type { CapabilityDocument, CapabilityKeyEntry, TicketStyle } from '@eink/print-dialog'
 import type { PrintUnavailableReason } from '@/lib/abacus/print/filament-wire'
 import type { FilamentCatalog } from './abacus-catalog'
 import type { FilamentMap, Params } from './abacus-model'
@@ -140,6 +140,65 @@ function processTruthy(style: TicketStyle | null, key: string): boolean {
  */
 export function supportsEnabled(style: TicketStyle | null): boolean {
   return processTruthy(style, 'enable_support')
+}
+
+/**
+ * The first-line adhesion recipe for the actual bed-contact layer. THH's three
+ * current quality presets resolve to 50 mm/s and 500 mm/s²; this deliberately
+ * slows only the initial layer while leaving model brim as an independent,
+ * last-resort setting. Like the printed-feet support recipe below, these values
+ * must ride the visible ticket style because THH's loaded preset overrides 3MF
+ * project settings.
+ */
+export const SLOW_FIRST_LAYER_PROCESS = {
+  initial_layer_speed: 12,
+  initial_layer_acceleration: 300,
+} as const
+
+export type SlowFirstLayerKey = keyof typeof SLOW_FIRST_LAYER_PROCESS
+
+const SLOW_FIRST_LAYER_KEYS = Object.keys(SLOW_FIRST_LAYER_PROCESS) as SlowFirstLayerKey[]
+
+function acceptsSlowFirstLayerValue(entry: CapabilityKeyEntry | undefined, value: number): boolean {
+  if (
+    entry?.class !== 'process' ||
+    entry.tier !== 'open' ||
+    entry.audience !== 'consumer' ||
+    (entry.type !== 'coFloat' && entry.type !== 'coInt')
+  ) {
+    return false
+  }
+  return (
+    (entry.min === undefined || value >= entry.min) &&
+    (entry.max === undefined || value <= entry.max)
+  )
+}
+
+/** The quick recipe is shown only when THH can accept the whole job-level pair. */
+export function supportsSlowFirstLayer(
+  capabilities: Pick<CapabilityDocument, 'keys'> | null | undefined
+): boolean {
+  return SLOW_FIRST_LAYER_KEYS.every((key) =>
+    acceptsSlowFirstLayerValue(capabilities?.keys[key], SLOW_FIRST_LAYER_PROCESS[key])
+  )
+}
+
+/** Active means these exact sparse overrides are present, not merely inherited. */
+export function slowFirstLayerEnabled(style: TicketStyle | null): boolean {
+  return SLOW_FIRST_LAYER_KEYS.every(
+    (key) => style?.process?.[key] === SLOW_FIRST_LAYER_PROCESS[key]
+  )
+}
+
+/** Apply or selectively reset the recipe without disturbing any other print choice. */
+export function withSlowFirstLayer(style: TicketStyle, enabled: boolean): TicketStyle {
+  const process = { ...style.process }
+  if (enabled) {
+    Object.assign(process, SLOW_FIRST_LAYER_PROCESS)
+  } else {
+    for (const key of SLOW_FIRST_LAYER_KEYS) delete process[key]
+  }
+  return { ...style, process }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a capability-gated 12 mm/s / 300 mm/s² first-layer recipe
- keep brim selection independent as a fallback
- preserve the existing printed-feet transition modifier
- expose native first-layer settings and test sparse apply/reset behavior

## Validation
- TypeScript passed
- 72 focused tests passed
- scoped Biome check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)