### PR TITLE
Finish the rear-entry sliding dovetail — deep anchor, detent, 45° graduations

### DIFF
--- a/apps/web/public/scad/abacus.scad
+++ b/apps/web/public/scad/abacus.scad
@@ -154,21 +154,35 @@ joint_ridge   = 0.2;   // click ridge proud height (0 = no click, friction only)
    into three uniform rail segments — a discretized tapered sliding dovetail.
    Every section clears every female station it passes by ≥ slide_step/2 per
    side until the final berth-length of travel: loose the whole way in, home
-   in the last centimeter. The rear segment is the DEEP ANCHOR: slide_deep_depth
-   into the neighbor, top flank the only hook (~1.75× the shallow hook, ~3.5×
-   the flank bearing area), a 45° skirt running to the BED below it and a
-   bottom-open female pocket — the seated anchor block fills the opening flush
-   with both bottoms. Deep is possible only there because the anchor's whole
-   travel stays inside the solid back strip; everywhere else the 2.5 mm channel
-   webs cap the rail at slide_depth. Retention is the seat itself: each berth's front
+   in the last centimeter. EVERY profile is centered on slide_center_z and
+   nothing in this topology reaches the bed: a rail rooted on the plate would
+   print as a ~100 mm blade over a 1.2 mm female sliver, so the slab keeps a
+   lip under the joint as well as over it. The rear segment is the DEEP ANCHOR:
+   slide_deep_depth into the neighbor, both flanks leaving the neck at
+   slide_angle and then CLAMPED FLAT at slide_deep_floor and its mirror — one
+   symmetric block that lands on a solid berth floor, hooks on both lips with
+   the same per-side undercut the full-length teeth carry (slide_depth·tan),
+   and spends its extra depth on bearing area rather than on lip. Deep is
+   possible only there because the anchor's whole travel stays inside the solid
+   back strip; everywhere else the channel webs (widened by slide_edge_allow)
+   cap the rail at slide_depth. Retention is the seat itself: each berth's front
    slide_pinch over slide_pinch_l is a ~1.9° travel-direction taper, far under
    PLA's atan(µ≈0.25)≈14° self-holding limit — it seats with a firm push and
-   releases with a firm rearward tug. No flexures: nothing to crack, and the
-   insertion sweep is provably collision-free at every offset (female depth is
-   monotone non-decreasing toward the mouth, and the rail only ever sits
-   rearward of its seat, so depth clearance can only grow with offset). */
+   releases with a firm rearward tug, and a detent ridge (below) makes that seat
+   positive instead of frictional. ONE flexure, and it is not an added finger:
+   the leaf is the groove's own channel wall. The insertion sweep is collision-
+   free at every offset EXCEPT that one designed interference, which is checked
+   as a deflection rather than as a collision (female depth is monotone
+   non-decreasing toward the mouth, and the rail only ever sits rearward of its
+   seat, so depth clearance can only grow with offset). */
 slide_angle        = 14;    // flank from +X rail-depth axis
-slide_depth        = 1.0;   // male X depth (shallow rail — capped by channel webs)
+slide_depth        = 2.0;   // male X depth (full-length rail — capped by the
+                            // channel webs, which slide_edge_allow widens)
+slide_edge_allow   = 1.0;   // extra solid on EACH sliding module seam edge, so
+                            // an assembled seam costs 2 mm of column spacing
+                            // beyond the modular web. It is spent entirely on
+                            // tooth engagement: the groove keeps the SAME 1.25
+                            // backing wall a 1.0-deep rail had
 slide_neck         = 2.8;   // MID segment Z neck; sizes are slide_neck ± slide_step
 slide_step         = 0.6;   // Z graduation between adjacent rail sizes
 slide_min_backing  = 1.2;
@@ -179,19 +193,148 @@ slide_pinch        = 0.05;  // final-seat X squeeze across the berth's front …
 slide_pinch_l      = 1.5;   // … this much travel (atan(.05/1.5)≈1.9°, self-holding)
 slide_relief       = 0.15;  // runway floor relief past groove depth (loose travel)
 slide_datum_relief = 0.2;   // non-datum berth fronts stand off — ONE Y stop
+slide_lead_out     = 0.6;   // ramp AHEAD of a berth's front, out to the runway.
+                            // slide_funnel does this at a berth's REAR, where the
+                            // rail arrives; nothing did it at the front, and the
+                            // two voids there are not the same size — the runway
+                            // ahead is slide_relief deeper and the berth's front
+                            // is slide_pinch tighter, so butting them left a
+                            // rearward-facing ledge slide_relief + slide_pinch
+                            // proud, standing the full height of the berth. That
+                            // is a wall across the groove that nothing asks for:
+                            // the rail leaves the berth into a LARGER void, so no
+                            // sweep can see it, and it is a stress riser and a
+                            // print artifact where the seat wedge starts. Ramp
+                            // instead — the deep taper needs no length for this,
+                            // it just ends on the berth's own front profile
 slide_seat_clear   = 0.02;  // CAD gap at the front stop (print swell closes it)
 slide_mouth_flare  = 0.6;   // rear-mouth Z flare beyond the pass-through size
-slide_deep_depth   = 3.5;   // rear anchor X depth — bounded by the top lip over
-                            // the anchor pocket ceiling (s_fh − slide_min_lip),
-                            // NOT by the channel webs: the anchor never leaves
-                            // the solid back strip
-slide_deep_floor   = 0.5;   // thinnest printable female floor; where the closed
-                            // floor would be thinner the anchor pocket opens
-                            // through the bottom face and the male skirt runs to
-                            // the bed (at default s_fh=8 both sides take the
-                            // OPEN branch; the seated male block fills the
-                            // opening flush with both bottoms)
+slide_deep_depth   = 9.0;   // rear anchor X depth — bounded by the NEIGHBOUR's
+                            // rear foot pocket (mf_sock + mf_wall), NOT by the
+                            // channel webs: the anchor never leaves the solid
+                            // back strip. Half the module's underside, so the
+                            // catch shelf runs under the whole bite
+slide_deep_floor   = 1.8;   // female berth floor under the anchor AND, mirrored
+                            // about slide_center_z, the ceiling lip over it —
+                            // ONE knob for both, which is what keeps the anchor
+                            // symmetric. Nothing on the male sits below it (no
+                            // knife edge at the bed) and the berth never opens
+                            // through the underside. Its flat underside floats
+                            // this far over the plate, so the male module wants
+                            // a sliver of support there — free when printed feet
+                            // already put the bottom face on a support interface
 slide_mouth_l      = 2.5;   // deep rear mouth flare length
+slide_corner       = 0.5;   // anchor edge break. Applied as an INSET in x/z hulled
+                            // over the same run in Y, so every broken face — the
+                            // underside included — is at exactly 45° and prints
+slide_anchor_lead  = 1.5;   // B→anchor graduation run. The jump from a 2 mm rail
+                            // to a 9 mm one is the largest single face on the part
+                            // — 7 mm of x by (s_fh − 2·slide_deep_floor) of z, a
+                            // cliff standing across the track — and at
+                            // slide_corner it was barely broken at all. This is
+                            // the same 45° inset break, just given enough run to
+                            // BE the graduation instead of decorating it, so the
+                            // rail steps up a ramp and there is no wall between
+                            // the anchor and the section ahead of it. It is not
+                            // the Y-blend the underside can't have: an inset
+                            // hulled over its own run is 45° everywhere, floor
+                            // included, which is the limit and not past it. Costs
+                            // exactly this much full-section anchor bearing (see
+                            // the deep-anchor gates), and is bounded above by the
+                            // z budget — the inset eats slide_deep_floor→cap from
+                            // both sides, so 2·lead must leave a tip land
+/* The click. The pinch wedge is friction against a blind stop; this makes the
+   seat positive. A ridge on the female MIDDLE berth's floor drops into a notch
+   in the male's MIDDLE (B) section, at the mid-length of the track — NOT out at
+   the module's front corner, where the tongue's free end is a lever a thumb can
+   reach and crack off, and not on the 9 mm anchor, where a spring would make the
+   anchor itself a lever every twist of a column would load.
+   Mid-track costs the kinematic exclusivity a front-berth ridge got for free
+   (rear entry means a female feature at f is swept by every male section ahead
+   of f, and mid-track that is most of the rail), so exclusivity is bought
+   geometrically instead: slide_ch_* is a shallow channel down the CENTRE of the
+   rail's tip face, from the nose to the tongue's tip. The ridge is
+   2·slide_detent_h wide and the channel clears it by slide_ch_clear per side and
+   slide_ch_air under the crest, so every section ahead of the tongue runs past
+   the ridge without touching it. The channel is a tip-face feature only — the
+   14° flanks, which are what actually grip, are never cut, so the small section
+   keeps its full undercut. Contact begins only when the ridge reaches the
+   tongue, ~2.7 mm before seat: the detent never meets its spring until the end
+   of the mating sequence, so the click still lands on the seat.
+   The spring is the MALE side: slide_spring_slot is a Z-through slot behind the
+   rail, so the B key and the slide_leaf_t of skin backing it become one
+   cantilever tongue — rooted at the solid BAR strip (slide_spring_y1 lands on
+   sc_b0, so unlike the front-corner version the root has no bead channel behind
+   it to bow into) and free at slide_spring_y0, where the slot turns and cuts out
+   through the seam face. That free end is buried mid-module: 48 mm from either
+   end, with a neighbour's groove around it, nothing can reach it to snap it off.
+   The female side stays rigid, which is what lets the ridge sit on a berth floor
+   rather than on relieved runway.
+   THE RETRACTION LIMIT, which is the non-obvious gate here. slide_groove_profile
+   builds the female by translating the male profile joint_fit in +X, so the rail
+   can back out of its groove EXACTLY joint_fit before its own 14° flanks bottom
+   on the groove's — refusing to come out radially is the whole job of a
+   dovetail. The tongue cannot deflect further than the rail it carries can
+   retract; past that the flanks wedge and the seat force stops being the
+   flexure's. An insertion sweep cannot see this — it is a rigid-overlap check
+   measuring the ridge's volume, not whether the rail has anywhere to go — so it
+   is gated here instead. slide_detent_relief opens the middle berth's NECK (not
+   its floor, not its angle) over the run the deflected tongue occupies, which
+   buys the room back. It is the MIDDLE berth deliberately: the front and anchor
+   berths are what locate the module, so this is the one berth that can afford to
+   give up a sliver of Z grip — which is itself an argument for mid-track.
+   The bending member is the tongue's WHOLE section — the skin AND the rail's own
+   trapezoid, which is most of the stiffness; see slide_leaf_I. */
+slide_detent       = 0.15;  // ridge engagement — how far the crest stands INSIDE
+                            // the male rail's tip face at seat (the number that
+                            // matters; the deflection the tongue takes to pass
+                            // it). Bounded by TWO gates, not one: the flexure's
+                            // strain, and the retraction limit above — the rail
+                            // has joint_fit + slide_detent_relief·... of room to
+                            // back out of its groove, and the tongue's free tip
+                            // overswings the notch, so the tip is what binds
+slide_detent_relief = 0.07; // middle berth NECK opened over the detent window,
+                            // TOTAL across both flanks (so half of it per side).
+                            // Converts to flank-normal room at 1/tan(slide_angle)
+                            // — 0.07 of neck is 0.14 of extra X retraction. Floor
+                            // depth and flank angle untouched, so nothing about
+                            // the seat or the undercut changes; it is purely the
+                            // sideways slack the deflecting tongue needs
+slide_ch_clear     = 0.2;   // relief channel half-width past the ridge, per side
+slide_ch_air       = 0.25;  // gap between the ridge crest and the channel floor —
+                            // the margin the un-sprung sections pass the ridge on
+slide_detent_l     = 0.6;   // crest land in Y
+slide_detent_h     = 0.9;   // ridge half-height in Z — the notch grown from it
+                            // has to stay off the A rail's flanks at EVERY
+                            // coupon fit, and 1.0 misses that gate at 0.12
+slide_detent_out   = 55;    // front flank — the retention wall (male pulls out
+                            // over it); 55° is well past self-holding
+slide_detent_in    = 18;    // rear flank — the insertion cam
+slide_detent_slop  = 0.04;  // flank-normal gap between ridge and notch at seat.
+                            // NOT joint_fit: joint_fit is running clearance for a
+                            // sliding fit, and a detent does not run — it is
+                            // parked. Whatever is here is pure Y backlash before
+                            // the retention flank bites (slop/sin(out)), so it is
+                            // held to the seat's own tolerance rather than the
+                            // rail's, and it is still a real gap, so the click
+                            // can never hold the seam off its blind front stop
+slide_spring_slot  = 0.8;   // Z-THROUGH slot behind the rail that frees the
+                            // tongue, and — turned 90° at slide_spring_y0 and
+                            // driven out through the seam face — the gap that
+                            // frees its TIP. Both ends are inside the module now,
+                            // so the slot is an L in plan with a rounded blind
+                            // root; it cannot move in X or Y to dodge anything
+slide_leaf_t       = 1.2;   // seam skin kept in front of the slot: the rail's
+                            // backing, and the tongue's root section with it
+slide_spring_a     = 11.25; // notch → root. The cantilever length, so the strain
+                            // knob: ε goes as 1/a², k as 1/a³. Set so the root
+                            // lands ON sc_b0 — the bar strip is the only solid
+                            // the tongue can grow out of without a bead channel
+                            // behind it, and the gate below holds it there
+slide_modulus      = 2500;  // wood PLA tensile modulus, MPa. Strain does not need
+                            // it; the hand-assembly force gate does
+slide_mu           = 0.25;  // conservative PLA-on-PLA static friction, the same
+                            // bound the seat taper is judged against
 slide_head          = slide_neck + 2 * slide_depth * tan(slide_angle);
 slide_groove_depth  = slide_depth + joint_fit;                 // berth floor
 slide_running_clear = joint_fit * sin(slide_angle);            // flank-normal
@@ -935,12 +1078,16 @@ module frame() {   // two children = implicit union (keeps the no-bar CSG tree
    strip, reckoning bar, back strip. Their edges are derived below from the
    SAME travel stack the channels came from, so a joint cannot collide with a
    bead channel by construction: joints and channels live in disjoint Y. */
-sc_wall = web * S;             // module edge wall = a FULL web. A monolithic
-                               // mid-web cut would leave web/2 = 1.25 per side
-                               // — too flimsy to capture beads — so modular
-                               // pitch is s_cp + web·S: the honest +2.5 mm/col
-                               // cost of modularity, stated once, here.
-sc_w    = s_bd + 2 * clearance + 2 * sc_wall;    // coupon width (15.5 @ defaults)
+/* Module edge wall = a FULL web. A monolithic mid-web cut would leave
+   web/2 = 1.25 per side — too flimsy to capture beads — so modular pitch is
+   s_cp + web·S: the honest +2.5 mm/col cost of modularity, stated once, here.
+   The sliding rail buys its depth with a further slide_edge_allow per edge
+   (+2 mm per assembled seam), which is why it is an edge-wall term and not a
+   pitch term: bead channels and every mono dimension stay exactly where the
+   monolith puts them. */
+sc_wall = web * S + (joint_type == "sliding_dovetail" ? slide_edge_allow : 0);
+sc_w    = s_bd + 2 * clearance + 2 * sc_wall;    // coupon width (15.5 snap /
+                                                 // 17.5 sliding @ defaults)
 sc_f1   = s_bw + s_elo - s_bl / 2 - clearance;   // front band  [0, 13.0]
 sc_b0   = s_bw + s_ehi + s_bl / 2 + clearance;   // bar band    [61.5,
 sc_b1   = s_bw + s_hlo - s_bl / 2 - clearance;   //              69.0]
@@ -982,6 +1129,76 @@ slide_anchor0 = slide_taper0 + slide_funnel + slide_datum_relief;
                                // prints clean, and the rail is fully
                                // runway-guided long before the anchor enters
 slide_mouth0  = outer_d - slide_mouth_l;            // deep mouth flare start
+/* Detent stations. The crest sits at the MID-LENGTH of the MIDDLE berth — the
+   middle of the track, and the middle of the middle tooth's engaged length — so
+   the ridge stands on a solid berth floor (slide_groove_depth) rather than on
+   relieved runway, and the wedge is worked outwards from there. The berth's own
+   stations are hoisted here because three separate things now speak in them: the
+   ridge, the tongue's tip, and the neck relief. Everything is absolute, because
+   every term is. */
+slide_mid_y0    = slide_k0_m - slide_datum_relief;              // middle berth front
+slide_mid_y1    = slide_k0_m + slide_key_l + 0.3;               // … and rear
+slide_detent_yc = slide_k0_m + slide_key_l / 2;                 // crest center
+slide_detent_y0 = slide_detent_yc - slide_detent_l / 2;         // crest land [y0, y1]
+slide_detent_y1 = slide_detent_yc + slide_detent_l / 2;
+slide_detent_proud = joint_fit + slide_detent;                  // over the BERTH floor
+slide_detent0   = slide_detent_y0 - slide_detent_proud / tan(slide_detent_out);  // front toe
+slide_detent_yr = slide_detent_y1 + slide_detent_proud / tan(slide_detent_in);
+slide_berth_y1  = slide_mid_y1;                                 // the berth the ridge lives in
+slide_spring_y1 = slide_detent_yc + slide_spring_a;             // slot's blind root
+/* The tongue's free tip, and with it the relief channel's rear end. It sits one
+   slot width behind the middle berth's seat pinch, which is the forward-most it
+   can go without the tip gap landing IN that pinch: the pinch is the berth's
+   retention, and a gap through it is a gap through the seat. That placement also
+   makes the split exact — everything ahead of slide_ch_y1 is un-sprung rail that
+   must pass the ridge on air, everything behind slide_spring_y0 is tongue. */
+slide_ch_y1     = slide_mid_y0 + slide_pinch_l;                 // channel end = gap front
+slide_spring_y0 = slide_ch_y1 + slide_spring_slot;              // tongue's free tip
+slide_ch_d      = slide_detent + slide_ch_air;                  // channel depth into the tip face
+slide_ch_w      = 2 * (slide_detent_h + slide_ch_clear);        // … and its Z width
+/* Retraction budget. The tongue is loaded at the notch but runs on past it to
+   its free tip, and beyond the load a cantilever is straight: the tip therefore
+   overswings the notch by the tip's distance times the slope there, 3δ/2a. The
+   tip is the binding station, not the notch. Against it, the room the groove
+   actually leaves: joint_fit of X play, plus whatever slide_detent_relief opens
+   the neck by, converted back to X at the flank angle. */
+slide_tip_over  = slide_detent_yc - slide_spring_y0;            // load → free tip
+slide_tip_defl  = slide_detent * (1 + 1.5 * slide_tip_over / slide_spring_a);
+slide_retract_room = joint_fit + slide_detent_relief / (2 * tan(slide_angle));
+/* The tongue's SECTION, which is the part of this that is easy to get wrong. It
+   is NOT the slide_leaf_t of skin on its own: the B key is welded to that skin
+   along the whole free length, so the rail's trapezoid bends with it and carries
+   most of the second moment (I is ~11× the skin's alone here). Taken in the seam's
+   own x measured from the slot's inner face: the skin is a rectangle at full slab
+   height, and the rail is the B trapezoid, neck at the seam face widening to the
+   head at the tip — B, not A, because the tongue moved to mid-track with the
+   notch, and B is the fatter section, which is part of why the shorter lever
+   still clears the strain gate. First and second moments are accumulated about
+   x = 0 and shifted to the centroid once, so no piece needs its own
+   parallel-axis term. */
+slide_neck_b  = slide_neck;                                     // B section neck —
+slide_head_b  = slide_neck_b + 2 * slide_depth * tan(slide_angle);  // the tongue
+slide_rail_A  = slide_depth * (slide_neck_b + slide_head_b) / 2;    // carries B now
+slide_leaf_A  = slide_leaf_t * s_fh + slide_rail_A;
+slide_leaf_Q  = s_fh * pow(slide_leaf_t, 2) / 2
+              + slide_leaf_t * slide_rail_A
+              + pow(slide_depth, 2) * (slide_neck_b / 6 + slide_head_b / 3);
+slide_leaf_J  = s_fh * pow(slide_leaf_t, 3) / 3
+              + pow(slide_leaf_t, 2) * slide_rail_A
+              + 2 * slide_leaf_t * pow(slide_depth, 2) * (slide_neck_b / 6 + slide_head_b / 3)
+              + pow(slide_depth, 3) * (slide_neck_b / 12 + slide_head_b / 4);
+slide_leaf_x  = slide_leaf_Q / slide_leaf_A;                    // centroid depth
+slide_leaf_I  = slide_leaf_J - slide_leaf_A * pow(slide_leaf_x, 2);
+slide_leaf_c  = max(slide_leaf_x, slide_leaf_t + slide_depth - slide_leaf_x);
+/* Cantilever, loaded at the notch: δ = F·a³/(3EI) ⇒ F = 3EIδ/a³. The gate is
+   deliberately the RIGID-ROOT model — the wall the tongue roots into does rotate,
+   which makes the real spring ~14% softer than this — because a gate that
+   overstates stiffness and strain is the conservative direction for both. */
+slide_detent_k = 3 * slide_modulus * slide_leaf_I / pow(slide_spring_a, 3);   // N/mm
+slide_detent_F = slide_detent_k * slide_detent;                              // N at crest
+slide_detent_push = slide_detent_F * (tan(slide_detent_in) + slide_mu)
+                  / (1 - slide_mu * tan(slide_detent_in));       // N along the seam
+slide_backing   = sc_wall - (slide_groove_depth + slide_relief); // female post-groove wall
 /* wood-PLA flexure gate — the eink dfm-checks screen (#367 "PLA flexures don't
    flex"), applied here at authoring time: peak outer-fibre strain ε% =
    150·t·Y/L² at the worst INTENDED engagement (ridge fully proud + 0.05 of
@@ -1016,7 +1233,7 @@ assert(!sc_active || joint_type != "vertical_snap" ||
        (sc_seat >= 0.6 && sc_seat + joint_tab + 1 <= s_fh),
        "bottom seat + 45° chamfer leave <1mm of straight dovetail wall — raise scale_factor or shrink sc_seat/joint_tab");
 assert(!sc_active || joint_type != "sliding_dovetail" ||
-       sc_wall - (slide_groove_depth + slide_relief) >= slide_min_backing,
+       slide_backing >= slide_min_backing,
        "sliding groove leaves <1.2mm backing wall — raise scale_factor");
 assert(!sc_active || joint_type != "sliding_dovetail" ||
        (s_fh - (slide_neck + slide_step
@@ -1024,24 +1241,136 @@ assert(!sc_active || joint_type != "sliding_dovetail" ||
          >= slide_min_lip,
        "sliding runway leaves insufficient top/bottom lips — raise scale_factor");
 assert(!sc_active || joint_type != "sliding_dovetail" ||
-       (slide_k0_s + slide_key_l + 0.3 + slide_funnel + 1
+       (slide_k0_s + slide_key_l + 0.3 + slide_funnel + slide_lead_out + 1
           <= slide_k0_m - slide_datum_relief
         && slide_k0_m + slide_key_l + 0.3 + slide_funnel + 1 <= slide_taper0
         && slide_taper0 + slide_funnel + slide_pinch_l + 2 <= slide_mouth0),
        "graduated rail berths + deep anchor don't fit along the module — raise scale_factor");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_lead_out < slide_funnel,
+       "berth lead-out is longer than the funnel feeding the runway it ramps out of — shrink slide_lead_out");
 /* Deep-anchor gates: the anchor never undercuts the receiving module's own
-   rail root, and the pocket's TIGHT ceiling leaves a real top lip (the mouth's
-   Z-flare is derived from whatever lip budget remains, so it can't overdraw).
-   The floor needs no gate — where a closed floor would print too thin, both
-   profiles branch to the bottom-open form instead. */
+   rail root, and the clamped profile has to be a real shape at this scale. The
+   berth floor and the ceiling lip are the SAME absolute knob mirrored, so the
+   lip gate is scale-free — but the flank run from the neck down to that
+   absolute floor grows with the slab, which is what the last gate bounds (it
+   is the only one in this cluster that fails from scale_factor being too
+   LARGE: past it the flanks would reach the floor plane behind the anchor tip
+   and the profile would fold on itself). */
 assert(!sc_active || joint_type != "sliding_dovetail" ||
        sc_w - (slide_deep_depth + 0.12 + slide_relief) >= 2,
        "deep anchor pocket cuts too close to the module's own rail — raise scale_factor");
 assert(!sc_active || joint_type != "sliding_dovetail" ||
-       s_fh - (slide_center_z + (slide_neck + slide_step) / 2
-               + (slide_deep_depth + 2 * 0.12 + slide_relief) * tan(slide_angle))
-         >= slide_min_lip,
-       "deep anchor pocket ceiling leaves insufficient top lip — raise scale_factor");
+       slide_deep_floor - joint_fit >= slide_min_lip,
+       "anchor ceiling lip (= the mirrored berth floor) below minimum — raise slide_deep_floor");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_center_z - (slide_neck + slide_step) / 2 - slide_deep_floor >= 0.3,
+       "anchor flanks have no room between neck and berth floor — raise scale_factor");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_deep_depth
+         >= (slide_center_z - (slide_neck + slide_step) / 2 - slide_deep_floor)
+              / tan(slide_angle) + 1,
+       "anchor flanks reach the berth floor too close to the tip — lower scale_factor");
+/* The B→anchor graduation is the 45° inset break run out to slide_anchor_lead,
+   and it is spent out of two budgets at once. In z the inset closes the anchor
+   from BOTH the floor and its mirrored ceiling, so twice the lead has to leave a
+   tip land — at zero the ramp's front section is a knife edge and the hull's
+   45° stops being well defined. In y the ramp is inset for its whole run, so it
+   bears on nothing: every millimetre of it is a millimetre the full anchor
+   section is NOT engaged, and the second gate is what keeps the graduation from
+   eating the anchor it is there to introduce. */
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       s_fh - 2 * (slide_deep_floor + slide_anchor_lead) >= 0.4,
+       "anchor lead-in closes to a knife edge — lower slide_anchor_lead");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       outer_d - slide_corner - (slide_anchor0 + slide_anchor_lead) >= 6,
+       "anchor lead-in leaves too little full-section bearing — lower slide_anchor_lead");
+/* The rear mouth flares all four sides now that the anchor has a floor to flare
+   INTO, and both flares are spent out of the same budget: whatever the berth
+   floor keeps over slide_min_lip. The zf clamp in slide_pockets is a min, so it
+   silently gives up the flare rather than the lip — this gate says the budget
+   has to exist at all. */
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_deep_floor - joint_fit - slide_min_lip >= 0,
+       "deep mouth has no flare budget left over the berth floor lip — raise slide_deep_floor");
+/* Detent gates. The notch is a void in the B rail's tip face, so it may not
+   reach a flank (the dovetail's grip is the one thing it must not touch) and it
+   must leave real rail behind it. The ridge has to live wholly inside the MIDDLE
+   berth: past the berth's front pinch ramp, so it stands on the flat berth floor
+   the proud height assumes, and short of the berth's rear station. What keeps it
+   unreachable by the sections AHEAD of the tongue is no longer the berth — it is
+   the relief channel, which gets its own two gates below.
+   Then the flexure gate the snap clip has, on the tongue. Cantilever, loaded at
+   the notch: δ = F·a³/(3·E·I) ⇒ F = 3·E·I·δ/a³, peak moment M = F·a at the root,
+   so ε = M·c/(E·I) drops both E and I and the gate is 300·δ·c/a² in percent —
+   against the same wood-PLA line the clip uses (~1.5% break, 1.5× safety).
+   In-plane bend ⇒ no layer derate. The c is the WHOLE tongue's, skin plus rail
+   (see slide_leaf_c). Force does NOT cancel, which is why E and I are carried at
+   all: a click nobody can push home is as dead as one that cracks, so the
+   assembly gate holds the insertion cam to what a hand gives a small part.
+   Then the backlash — the notch clears the ridge by slide_detent_slop along each
+   flank normal, which is slop/sin(flank) of free Y travel before the retention
+   flank bites, and that has to stay inside the seat's own tolerance.
+   Last the slot, which is a Z-THROUGH cut and therefore everybody's neighbour:
+   it has to leave the rail its backing, leave the bead channel its wall, stop
+   before the bar strip, and clear the front foot pocket it opens beside. */
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_detent_h + joint_fit + 0.3
+         <= slide_neck / 2
+            + (slide_depth - slide_detent - joint_fit) * tan(slide_angle),
+       "detent notch would cut the rail flanks — shrink slide_detent_h/slide_detent");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_depth - slide_detent - joint_fit >= 1.2,
+       "detent notch leaves too little rail depth behind it — shrink slide_detent");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_detent0 >= slide_mid_y0 + slide_pinch_l,
+       "detent ridge starts on the berth's seat pinch, not on its floor — move slide_detent_yc rearward");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_detent_yr <= slide_mid_y1,
+       "detent ridge reaches past the middle berth: it would stand on relieved runway");
+/* The retraction gate — the one an insertion sweep is blind to. Peak deflection
+   is the TIP's, not the notch's, and it has to fit inside the room the dovetail
+   leaves. The relief that buys that room may not eat the seat pinch, so the tip
+   gap has to start at or behind the pinch's end; and the relief window is the
+   berth run the deflected tongue occupies, which is the same station. */
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_tip_defl <= slide_retract_room,
+       "tongue would deflect further than the rail can retract — the 14° flanks bottom out and the click stops being a flexure; raise slide_detent_relief or shrink slide_detent");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_ch_y1 >= slide_mid_y0 + slide_pinch_l,
+       "tongue's tip gap cuts through the middle berth's seat pinch — move slide_spring_y0 rearward");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_spring_y0 < slide_detent0,
+       "tongue's tip gap reaches the detent ridge — the notch would have no land in front of it");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_ch_d + 1.2 <= slide_depth,
+       "relief channel leaves under 1.2mm of rail behind it — shrink slide_ch_air");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_ch_w / 2 + 0.3
+         <= (slide_neck - slide_step) / 2
+            + (slide_depth - slide_ch_d) * tan(slide_angle),
+       "relief channel would cut the SMALL section's flanks — shrink slide_ch_clear/slide_detent_h");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       300 * slide_detent * slide_leaf_c / pow(slide_spring_a, 2) <= 1.0,
+       "detent strain would crack wood PLA — shrink slide_detent or lengthen slide_spring_a");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_detent_push <= 15,
+       "detent needs more than a hand to push home — shrink slide_detent or flatten slide_detent_in");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_detent_slop / sin(slide_detent_out) <= 0.05,
+       "detent backlash exceeds the seat's own tolerance — shrink slide_detent_slop");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_leaf_t >= slide_min_backing,
+       "spring slot leaves the rail under 1.2mm of backing skin — raise slide_leaf_t");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_leaf_t + slide_spring_slot <= sc_wall - slide_min_backing,
+       "spring slot leaves <1.2mm of wall in front of the bead channel — raise scale_factor");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_spring_y1 <= sc_b0,
+       "spring slot runs THROUGH the bar strip — shrink slide_spring_a. It is meant to stop ON sc_b0: the tongue roots in solid, not in a channel wall");
+assert(!sc_active || joint_type != "sliding_dovetail" ||
+       slide_spring_y1 >= sc_f1,
+       "spring slot's root is still in the front strip — the tongue is not rooted where it thinks it is");
 
 /* ----- module family (CP3): real per-column modules -----
    mid    = the coupon geometry grown up: rim-chamfered slab (never on the seam
@@ -1054,11 +1383,15 @@ assert(!sc_active || joint_type != "sliding_dovetail" ||
             marker/feet corner positions are all the same solid mono ships),
             carrying column 0 / cols−1, two corner feet and two ArUco pockets
             (engraved only in phase 1 — plugs are a follow-up).
-   Widths: 2·mod_we + (cols−2)·sc_w == frame_w + (cols−1)·web·S exactly — the
-   modular assembly reproduces the mono footprint plus one full web per seam. */
+   Widths: 2·mod_we + (cols−2)·sc_w == frame_w + (cols−1)·(2·sc_wall − web·S)
+   exactly — the modular assembly reproduces the mono footprint plus whatever
+   the two edge walls cost over the one web a mono column boundary already had
+   (a full web per seam on the snap; that plus 2·slide_edge_allow sliding). */
 mod_we = s_bw + s_em + s_bd / 2 + clearance + sc_wall;  // end-module width (26.0
-                               // @ defaults): border + field margin + half of
-                               // its column's channel + a full edge web
+                               // snap / 27.0 sliding @ defaults): border + field
+                               // margin + half of its column's channel + a full
+                               // edge wall — so every seam face lands at the
+                               // same offset from its column as a mid module's
 /* mid-module feet: the monolith's foot Y-centers are CONCENTRIC with the
    dovetails (same solid bands), and the socket eats x∈[0, mf_sock] at full
    height — so the mid foot moves BESIDE the socket on X, in the band mf_band
@@ -1084,17 +1417,34 @@ mf_band  = sc_w - mf_sock - 2 * mf_wall - 2 * feet_undercut_eff - 2 * feet_fit_e
 mf_w     = feet_printed ? min(feet_w, 6.35, mf_band) : feet_w;
 mf_mouth = mf_w + 2 * feet_fit_eff;
 mf_seat  = mf_mouth + 2 * feet_undercut_eff;
-mf_x     = (mf_sock + sc_w) / 2;             // centered in the band beside the socket
-MF_Y     = [feet_c, outer_d - feet_c];       // front + back solid strips, same
+mf_x     = (mf_sock + sc_w) / 2;             // REAR foot: centered in the band
+                                             // beside the socket
+/* The front foot shares the rear's X again. It did not when the tongue was a
+   front-corner cantilever: the spring slot ran out through the module's FRONT
+   face, straight past this pocket, so the front foot had to be squeezed into its
+   own band between the groove's deepest cut and the slot's inner face. The
+   tongue is mid-track now (slide_spring_y0 ≈ 48, forty millimetres behind the
+   front foot), so the front strip's only obstruction is the groove again and the
+   band is no longer needed. mf_x_lo/mf_x_hi stay because the gate below still
+   reads them — a scale that could not fit that band could not fit this pocket
+   either. */
+mf_x_lo  = slide_groove_depth + slide_relief + mf_wall + mf_seat / 2;
+mf_x_hi  = sc_w - slide_leaf_t - slide_spring_slot - mf_wall - mf_seat / 2;
+mf_x_front = mf_x;
+MF_XY    = [[mf_x_front, feet_c], [mf_x, outer_d - feet_c]];
+                                             // front + back solid strips, same
                                              // edge inset as the mono corners
 assert(!(mod_active && feet) || mf_w >= 4,
        "module feet don't fit beside the seam socket — raise scale_factor (or feet_mode=none)");
 assert(!(mod_active && feet && !feet_printed) || feet_w <= mf_band,
        "stick-on bumper doesn't fit beside the seam socket — pick a narrower bumper or raise scale_factor");
 assert(!(mod_active && feet) || (mf_x - mf_seat / 2 - mf_sock >= 1.5 && sc_w - mf_x - mf_seat / 2 >= 1.5),
-       "module foot pocket too close to the seam socket or the seam face");
+       "rear module foot pocket too close to the seam socket or the seam face");
 assert(!(mod_active && feet && feet_crossbar) || feet_c + mf_seat / 2 + xbar_embed + 0.8 <= sc_f1,
        "module foot crossbar would break into the bead channel — shrink feet_w or raise scale_factor");
+assert(!(mod_active && feet) || joint_type != "sliding_dovetail" ||
+       mf_x_hi - mf_x_lo >= 1.5,
+       "front module foot has no band left between the sliding groove and the spring slot — raise scale_factor");
 
 /* 2D plan profiles. Both are CONVEX — the top-taper hulls below depend on it. */
 module sc_dove_2d(g = 0)       // dovetail plan: base on x=0, pointing +x
@@ -1196,45 +1546,65 @@ function slide_groove_profile(neck, fit, xr = 0) =
    [d, slide_center_z - neck / 2 - (d + fit) * t],
    [d, slide_center_z + neck / 2 + (d + fit) * t],
    [-0.01, slide_center_z + neck / 2 + (fit - 0.01) * t]];
-/* Deep anchor male: the top 14° flank is the only hook; below, a 45° skirt
-   drops from the root toward the bed so the underside prints support-free
-   (bottom-down orientation — X/Z surfaces are the only overhang risk). Where
-   the skirt reaches the bed before the tip (default s_fh), the profile runs
-   flat ON the bed to full depth — a solid block, trivially printable. */
-function slide_deep_profile(neck) =
+/* Deep anchor male: the graduated trapezoid every other section uses, CLAMPED
+   the moment each flank reaches slide_deep_floor or its mirror. The undercut is
+   therefore (slide_center_z − neck/2 − slide_deep_floor) per side — tuned to
+   match the full-length teeth's slide_depth·tan — no matter how deep the bite
+   is. Symmetric about slide_center_z: both lips hook, the bite buys bearing
+   area, and the block lands on the berth floor rather than the bed. That the
+   flats exist at all is an assert (see the deep-anchor gates).
+   `corner` breaks the two long tip edges — two extra vertices, no depth given
+   up. `inset` shrinks floor, cap and tip by the same amount while the seam root
+   stays put, so hulling an inset section `slide_corner` behind a full one breaks
+   that whole end at 45°, underside included. The flanks follow the floor rather
+   than being offset along their own normals, which puts them at ~44° in that
+   break: still printable, and it costs one formula instead of two. */
+function slide_deep_profile(neck, inset = 0, corner = slide_corner) =
   let(rb = slide_center_z - neck / 2, rt = slide_center_z + neck / 2,
-      ht = rt + slide_deep_depth * tan(slide_angle),
-      tb = rb - slide_deep_depth)
-  tb >= 0
-    ? [[0, rb], [slide_deep_depth, tb], [slide_deep_depth, ht], [0, rt]]
-    : [[0, rb], [rb, 0], [slide_deep_depth, 0], [slide_deep_depth, ht], [0, rt]];
-/* Deep anchor female: top flank grown like the shallow groove. Below, either
-   a fit-dropped skirt over a printable ≥slide_deep_floor floor (large scales)
-   or — default s_fh — the pocket opens THROUGH the bottom face: the seated
-   male block fills the opening flush with both bottoms, Z-registration stays
-   with the front/mid berths' two-flank profiles. zflare raises only the
-   ceiling (a symmetric flare would pierce the bottom face). */
+      fl = slide_deep_floor + inset, cap = s_fh - slide_deep_floor - inset,
+      xb = max(0, (rb - fl) / tan(slide_angle)),   // bottom flank meets the floor
+      xt = max(0, (cap - rt) / tan(slide_angle)),  // top flank meets the cap
+      d  = slide_deep_depth - inset,
+      c  = min(corner, (d - max(xb, xt)) / 2, (cap - fl) / 2))
+  concat([[0, rb]],
+         xb > 0 ? [[xb, fl]] : [],          // an inset deep enough to reach the
+         [[d - c, fl], [d, fl + c],         // neck leaves no flank to state
+          [d, cap - c], [d - c, cap]],
+         xt > 0 ? [[xt, cap]] : [],
+         [[0, rt]]);
+/* Deep anchor female: the same shape grown the file's way — flanks offset fit
+   along +x (the uniform fit·sin(angle) flank-normal gap), floor and ceiling
+   offset fit along ∓z. The berth therefore keeps slide_deep_floor − fit of
+   solid PLA underneath, and the wedge that lip leaves at the seam face is what
+   hooks the male's bottom flank: the underside stays a closed face. zflare
+   opens ceiling and floor — and each root corner with them, so neither corner
+   moves — by the same amount: the mouth eases all four sides, which is only
+   possible now that the anchor lands on a floor instead of on the bed. */
 function slide_deep_groove_profile(neck, fit, xr = 0, zflare = 0) =
   let(t = tan(slide_angle), d = slide_deep_depth + fit + xr,
-      rb = slide_center_z - neck / 2, rt = slide_center_z + neck / 2 + zflare,
-      fb = rb - slide_deep_depth - 2 * fit)
-  fb >= slide_deep_floor
-    ? [[-0.01, rb + 0.01 - fit],
-       [slide_deep_depth + fit, fb], [d, fb],
-       [d, rt + (d + fit) * t],
-       [-0.01, rt + (fit - 0.01) * t]]
-    : [[-0.01, -0.01], [d, -0.01],
-       [d, rt + (d + fit) * t],
-       [-0.01, rt + (fit - 0.01) * t]];
+      rb = slide_center_z - neck / 2 - zflare, rt = slide_center_z + neck / 2 + zflare,
+      fl = slide_deep_floor - fit - zflare, cap = s_fh - slide_deep_floor + fit + zflare,
+      xb = (rb - fl) / t - fit, xt = (cap - rt) / t - fit)
+  [[-0.01, rb - (fit - 0.01) * t],
+   [xb, fl], [d, fl],
+   [d, cap], [xt, cap],
+   [-0.01, rt + (fit - 0.01) * t]];
 
 module slide_xz(pts, y0, y1)
   translate([0, (y0 + y1) / 2, 0]) prism_xz(pts, 0, y1 - y0);
-module slide_zone(neck, y0, y1, fit) { // tight berth; graduated seat pinch at the
-  hull() {                             // front: fit−pinch → fit over pinch_l, a
-    slide_xz(slide_groove_profile(neck, fit - slide_pinch), y0, y0 + 0.01);   // self-
+module slide_zone(neck, y0, y1, fit, neck_r = 0) { // tight berth; graduated seat
+  nr = neck + neck_r;                  // pinch at the front: fit−pinch → fit over
+  hull() {                             // pinch_l, a self-holding ~1.9° wedge that
+    slide_xz(slide_groove_profile(neck, fit - slide_pinch), y0, y0 + 0.01);  // is
     slide_xz(slide_groove_profile(neck, fit), y0 + slide_pinch_l, y0 + slide_pinch_l + 0.01);
-  }                                    // holding ~1.9° wedge that is the retention
-  slide_xz(slide_groove_profile(neck, fit), y0 + slide_pinch_l, y1);
+  }                                    // the retention. neck_r then opens the neck
+  hull() {                             // BEHIND that pinch — never through it (see
+    slide_xz(slide_groove_profile(neck, fit),   // slide_detent_relief), and eased
+             y0 + slide_pinch_l, y0 + slide_pinch_l + 0.01);   // over its own 0.4 so
+    slide_xz(slide_groove_profile(nr, fit),     // the groove ceiling steps by a ramp
+             y0 + slide_pinch_l + 0.4, y0 + slide_pinch_l + 0.41);   // and not a shelf
+  }
+  slide_xz(slide_groove_profile(nr, fit), y0 + slide_pinch_l + 0.4, y1);
 }
 module slide_deep_zone(neck, y0, y1, fit) { // deep berth, same pinch-wedge seat
   hull() {
@@ -1250,57 +1620,176 @@ module slide_funnel(neck_tight, neck_run, y0, fit) // berth mouth → relieved r
              y0 + slide_funnel - 0.01, y0 + slide_funnel);
   }
 
+/* The click, in two halves that are the same wedge.
+   RIDGE (female): a wedge standing off the FRONT BERTH's floor, at its
+   mid-length — crossed by the A key and nothing else, since rear entry means B
+   and the anchor never reach a station this far forward. The berth floor is the
+   one place in the groove that is flat and known (the runway behind it is
+   relieved, and the berth's own front is a pinch ramp), which is what makes the
+   proud height a constant. The crest land is pinned for every sample; only the
+   toes move with fit, because the floor they run down to does.
+   NOTCH (male): the same two flank LINES, each stepped back slide_detent_slop
+   along its own normal, plus a fit of depth at the floor and of half-height in Z.
+   The flanks are stated where the ridge's flanks cross the rail's TIP face, which
+   is the surface the notch is cut into — read them off the ridge's toes instead
+   and every flank gains (floor − tip)·cos(flank) of slack it never asked for,
+   which is backlash: the seam still seats on its blind front stop, but the click
+   is loose against a pull by that much before it bites. The notch stays a void in
+   the tip face only: the flanks the dovetail grips are untouched, with
+   slide_depth − detent − fit of rail left behind it. */
+module slide_detent_ridge(fit = joint_fit) {
+  xf = slide_depth + fit;                   // the berth floor it grows from —
+  xc = slide_depth - slide_detent;          // per-sample, so a coupon plate's
+  pr = xf - xc;                             // other fits can't leave it floating
+  translate([0, 0, slide_center_z - slide_detent_h])
+    linear_extrude(2 * slide_detent_h)
+      polygon([[xf, slide_detent_y0 - pr / tan(slide_detent_out)], [xc, slide_detent_y0],
+               [xc, slide_detent_y1], [xf, slide_detent_y1 + pr / tan(slide_detent_in)]]);
+}
+module slide_detent_notch(fit = joint_fit) {
+  xt = slide_depth + 0.01;                       // break the rail's tip face
+  xc = slide_depth - slide_detent - fit;
+  yf = slide_detent_y0 - slide_detent / tan(slide_detent_out)   // ridge flanks AT the
+     - slide_detent_slop / sin(slide_detent_out);               // tip face, stepped
+  yb = slide_detent_y1 + slide_detent / tan(slide_detent_in)    // off along their
+     + slide_detent_slop / sin(slide_detent_in);                // own normals
+  translate([0, 0, slide_center_z - slide_detent_h - fit])
+    linear_extrude(2 * (slide_detent_h + fit))
+      polygon([[xt, yf - (xt - slide_depth) / tan(slide_detent_out)],
+               [xc, yf - (xc - slide_depth) / tan(slide_detent_out)],
+               [xc, yb + (xc - slide_depth) / tan(slide_detent_in)],
+               [xt, yb + (xt - slide_depth) / tan(slide_detent_in)]]);
+}
+/* The slot that makes the tongue. An L in plan, Z-through on both legs (each
+   cuts the top face as well as the bottom):
+     the LONG leg runs in Y behind the rail, from the tip gap back to a half-round
+       blind root on sc_b0 — a half-round and not a square corner because this is
+       the root of a part that flexes every time a module is fitted, and a square
+       corner there is a crack waiting for a cycle count;
+     the SHORT leg is the tip gap: the same slide_spring_slot of Y, turned 90° and
+       driven out through the seam face so it severs the leaf AND the rail. That
+       is what makes the tongue a cantilever instead of a fixed-fixed leaf — with
+       both ends built in, a 13 mm span at this engagement is ~4× over the strain
+       gate. Nothing about the gap is free to move: its front edge is the middle
+       berth's pinch end (any further forward and it cuts the seat), and its width
+       is the slot's, because it is the slot.
+   The rail it severs at that station is the A→B shoulder, which is a transition
+   the berth does not grip anyway — the middle berth's full-neck grip starts
+   behind the gap, and the small berth is 38 mm ahead of it. */
+module slide_spring_slot_cut() {
+  x0 = sc_w - slide_leaf_t - slide_spring_slot;
+  hull() {                                          // long leg, blind at the root
+    translate([x0, slide_ch_y1, -1]) cube([slide_spring_slot, 0.01, s_fh + 2]);
+    translate([x0 + slide_spring_slot / 2, slide_spring_y1 - slide_spring_slot / 2, -1])
+      cylinder(h = s_fh + 2, d = slide_spring_slot, $fn = 24);
+  }
+  translate([x0, slide_ch_y1, -1])                  // tip gap, out through the face
+    cube([slide_leaf_t + slide_spring_slot + slide_depth + 1, slide_spring_slot, s_fh + 2]);
+}
+/* The relief channel: a flat-bottomed groove down the CENTRE of the rail's tip
+   face, nose → tongue tip. It is what buys back the kinematic exclusivity the
+   front-berth ridge had for free — every male section ahead of the tongue runs
+   the ridge down this channel on slide_ch_air of nothing. Tip face only: it stops
+   slide_ch_d short of the flanks' own depth, so the 14° grip surfaces are
+   untouched and the small section keeps its full undercut. */
+module slide_relief_channel()
+  translate([slide_depth - slide_ch_d, slide_k0_s - 0.5, slide_center_z - slide_ch_w / 2])
+    cube([slide_ch_d + 0.01, slide_spring_y0 - slide_k0_s + 0.5, slide_ch_w]);
+
 module slide_tabs()              // on RIGHT face after caller translates to seam
   translate([sc_w, 0, 0]) {
     n_s = slide_neck - slide_step; n_m = slide_neck; n_l = slide_neck + slide_step;
-    hull() {  // front nose: sliver → full small profile, eases the blind-stop
-      slide_xz(slide_profile(n_s - 1.2, 0.3), slide_k0_s, slide_k0_s + 0.01);
-      slide_xz(slide_profile(n_s), slide_k0_s + 0.8, slide_k0_s + 0.81);
+    difference() {
+      union() {
+        hull() {  // front nose: sliver → full small profile, eases the blind-stop
+          slide_xz(slide_profile(n_s - 1.2, 0.3), slide_k0_s, slide_k0_s + 0.01);
+          slide_xz(slide_profile(n_s), slide_k0_s + 0.8, slide_k0_s + 0.81);
+        }
+        slide_xz(slide_profile(n_s), slide_k0_s + 0.8, slide_k0_m + 0.01);
+        hull() {  // A→B graduation shoulder, eased like a nose for mid-berth entry
+          slide_xz(slide_profile(n_s), slide_k0_m, slide_k0_m + 0.01);
+          slide_xz(slide_profile(n_m), slide_k0_m + 0.8, slide_k0_m + 0.81);
+        }
+        slide_xz(slide_profile(n_m), slide_k0_m + 0.8, slide_anchor0 + 0.01);
+        // B→anchor graduation. NOT a Y-blend of the underside — that would be a
+        // near-horizontal droop. This is the same 45° inset break the rear face
+        // gets, run out to slide_anchor_lead so the step becomes a ramp: the
+        // inset shrinks floor, cap and tip together, so hulling it over its own
+        // run puts every face — underside included — at exactly 45°.
+        hull() {  // front lead-in
+          slide_xz(slide_deep_profile(n_l, slide_anchor_lead),
+                   slide_anchor0, slide_anchor0 + 0.01);
+          slide_xz(slide_deep_profile(n_l),
+                   slide_anchor0 + slide_anchor_lead,
+                   slide_anchor0 + slide_anchor_lead + 0.01);
+        }
+        slide_xz(slide_deep_profile(n_l),
+                 slide_anchor0 + slide_anchor_lead, outer_d - slide_corner + 0.01);
+        hull() {  // rear face break — the edge a hand actually reaches
+          slide_xz(slide_deep_profile(n_l),
+                   outer_d - slide_corner, outer_d - slide_corner + 0.01);
+          slide_xz(slide_deep_profile(n_l, slide_corner), outer_d - 0.01, outer_d);
+        }
+      }
+      slide_detent_notch();
+      slide_relief_channel();
     }
-    slide_xz(slide_profile(n_s), slide_k0_s + 0.8, slide_k0_m + 0.01);
-    hull() {  // A→B graduation shoulder, eased like a nose for mid-berth entry
-      slide_xz(slide_profile(n_s), slide_k0_m, slide_k0_m + 0.01);
-      slide_xz(slide_profile(n_m), slide_k0_m + 0.8, slide_k0_m + 0.81);
-    }
-    slide_xz(slide_profile(n_m), slide_k0_m + 0.8, slide_anchor0 + 0.01);
-    // B→anchor is a HARD step (vertical −Y wall — see slide_anchor0). The B
-    // profile is strictly inside the anchor profile, so the union is clean.
-    slide_xz(slide_deep_profile(n_l), slide_anchor0, outer_d);  // flush rear
   }
 module slide_pockets(fit = joint_fit) { // into LEFT face; front berth wall = Y datum
   n_s = slide_neck - slide_step; n_m = slide_neck; n_l = slide_neck + slide_step;
   y0_s = slide_k0_s - slide_seat_clear;
   y1_s = slide_k0_s + slide_key_l + 0.3;
-  y0_m = slide_k0_m - slide_datum_relief;   // non-datum fronts stand off 0.2 —
-  y1_m = slide_k0_m + slide_key_l + 0.3;    // only the rail nose touches a Y stop
-  slide_zone(n_s, y0_s, y1_s, fit);
-  slide_funnel(n_s, n_m, y1_s, fit);        // runway sizes: one graduation step
-  slide_xz(slide_groove_profile(n_m, fit, slide_relief),   // above the largest
-           y1_s + slide_funnel - 0.01, y0_m + 0.01);       // section that sweeps it
-  slide_zone(n_m, y0_m, y1_m, fit);
-  slide_funnel(n_m, n_l, y1_m, fit);
-  slide_xz(slide_groove_profile(n_l, fit, slide_relief),
-           y1_m + slide_funnel - 0.01, slide_taper0 + 0.01);
-  hull() {  // shallow→deep taper: doubles as B's funnel out of the deep void
-            // into the runway. A sloped void ceiling prints fine — it bridges
-            // the pocket width layer by layer, unlike a male underside.
-    slide_xz(slide_groove_profile(n_l, fit, slide_relief), slide_taper0, slide_taper0 + 0.01);
-    slide_xz(slide_deep_groove_profile(n_l, fit, slide_relief),
-             slide_taper0 + slide_funnel - 0.01, slide_taper0 + slide_funnel);
-  }
-  slide_deep_zone(n_l, slide_taper0 + slide_funnel, slide_mouth0, fit);
-  // deep rear mouth: the ceiling takes whatever Z-flare the top lip budget
-  // allows (0.14 at defaults — bottom-registration on the table does the real
-  // aligning), capped at the shallow mouth's step+flare; breaks the rear rim
-  // chamfer exactly like the shallow mouth did.
+  y0_m = slide_mid_y0;                      // non-datum fronts stand off 0.2 —
+  y1_m = slide_mid_y1;                      // only the rail nose touches a Y stop
+  // deep rear mouth: floor and ceiling each take whatever Z-flare the lip budget
+  // allows (0.5 at defaults — the flat floor/cap planes, not a flank, are what
+  // the lips are measured from now), capped at the shallow mouth's step+flare;
+  // breaks the rear rim chamfer exactly like the shallow mouth did.
   zf = min(slide_step + slide_mouth_flare,
-           max(0, s_fh - slide_min_lip
-                  - (slide_center_z + n_l / 2
-                     + (slide_deep_depth + 2 * fit + slide_relief) * tan(slide_angle))));
-  hull() {
-    slide_xz(slide_deep_groove_profile(n_l, fit), slide_mouth0 - 0.01, slide_mouth0);
-    slide_xz(slide_deep_groove_profile(n_l, fit, slide_relief, zf),
-             outer_d, outer_d + 0.01);
+           max(0, slide_deep_floor - fit - slide_min_lip));
+  difference() {
+    union() {
+      slide_zone(n_s, y0_s, y1_s, fit);
+      slide_funnel(n_s, n_m, y1_s, fit);        // runway sizes: one graduation step
+      slide_xz(slide_groove_profile(n_m, fit, slide_relief),   // above the largest
+               y1_s + slide_funnel - 0.01,                     // section that sweeps it
+               y0_m - slide_lead_out + 0.01);
+      hull() {   // …and the runway lands ON the berth's front profile, not beside
+                 // it: see slide_lead_out. Only the A section is ever at these
+        slide_xz(slide_groove_profile(n_m, fit, slide_relief),   // stations, so the
+                 y0_m - slide_lead_out, y0_m - slide_lead_out + 0.01);   // ramp
+        slide_xz(slide_groove_profile(n_m, fit - slide_pinch),   // costs no travel
+                 y0_m, y0_m + 0.01);
+      }
+      slide_zone(n_m, y0_m, y1_m, fit, slide_detent_relief);
+      slide_funnel(n_m + slide_detent_relief, n_l, y1_m, fit);
+      slide_xz(slide_groove_profile(n_l, fit, slide_relief),
+               y1_m + slide_funnel - 0.01, slide_taper0 + 0.01);
+      hull() {  // shallow→deep taper: doubles as B's funnel out of the deep void
+                // into the runway. A sloped void ceiling prints fine — it bridges
+                // the pocket width layer by layer, unlike a male underside. Its
+                // rear end IS the anchor berth's front profile (slide_lead_out's
+                // job, for free here — the taper already has 3 mm of run), so the
+                // ramp meets the seat pinch instead of stepping over it.
+                // The rear slab sits PAST slide_taper0 + slide_funnel, not short
+                // of it: every other piece of this pocket overlaps its neighbour
+                // by 0.01 and this one used to abut the deep berth exactly. CGAL
+                // welds an exact abutment; Manifold — which is what the browser
+                // renders with — keeps the shared face, and a coincident face
+                // inside a void reads as a zero-width wall standing between the
+                // anchor berth and the runway ahead of it. Overlap, always.
+        slide_xz(slide_groove_profile(n_l, fit, slide_relief), slide_taper0, slide_taper0 + 0.01);
+        slide_xz(slide_deep_groove_profile(n_l, fit - slide_pinch),
+                 slide_taper0 + slide_funnel, slide_taper0 + slide_funnel + 0.01);
+      }
+      slide_deep_zone(n_l, slide_taper0 + slide_funnel, slide_mouth0, fit);
+      hull() {
+        slide_xz(slide_deep_groove_profile(n_l, fit), slide_mouth0 - 0.01, slide_mouth0);
+        slide_xz(slide_deep_groove_profile(n_l, fit, slide_relief, zf),
+                 outer_d, outer_d + 0.01);
+      }
+    }
+    slide_detent_ridge(fit);
   }
 }
 
@@ -1323,6 +1812,12 @@ module sc_pockets(fit = joint_fit) {   // fit is only meaningful for sliding: th
   if (joint_type == "sliding_dovetail") slide_pockets(fit);   // coupon plate
   else sc_vertical_pockets();          // threads its per-sample compensation here
 }
+/* Cut on the TAB side, not the pocket side: the sliding spring is the male
+   tongue, so it belongs wherever sc_tabs() does and at the same translate. The
+   vertical topology has no spring, so this is empty there. */
+module sc_tab_relief() {
+  if (joint_type == "sliding_dovetail") slide_spring_slot_cut();
+}
 
 /* The coupon: a real single column — live captive beads, real strip positions,
    full outer_d depth — with the seam features on its faces. No markers, feet,
@@ -1338,6 +1833,7 @@ module seam_coupon_one(fit = joint_fit) {
       channel(sc_w / 2, s_hlo, s_hhi);
     }
     sc_pockets(fit);
+    sc_tab_relief();
   }
   translate([0, s_bw, 0]) {   // the ones column, per place_value(cols−1)
     for (j = [0 : earth - 1]) color(bead_color(cols - 1, false)) bead(sc_w / 2, earthy(j));
@@ -1392,12 +1888,13 @@ module module_mid() {          // any interior column: sockets left, tabs right
       channel(sc_w / 2, s_hlo, s_hhi);
     }
     sc_pockets();
-    if (feet) for (y = MF_Y) feet_pocket_xy(mf_x, y, mf_mouth, mf_seat);
+    sc_tab_relief();
+    if (feet) for (xy = MF_XY) feet_pocket_xy(xy[0], xy[1], mf_mouth, mf_seat);
   }
   if (feet_crossbar)           // Y-run bars (an X-run would hit both seam faces)
     color(frame_color) intersection() {
       mod_slab(sc_w);
-      for (y = MF_Y) xbar_xy(mf_x, y, false, mf_seat);
+      for (xy = MF_XY) xbar_xy(xy[0], xy[1], false, mf_seat);
     }
   translate([0, s_bw, 0]) {    // captive beads; place-value color of a generic
                                // interior column (3MF slotting is per-column)
@@ -1423,6 +1920,7 @@ module module_end(left) {      // left: border + column 0, tabs on the right fac
         channel(colx(ci), s_hlo, s_hhi);
       }
       if (!left) translate([x0, 0, 0]) sc_pockets();
+      if (left) translate([mod_we - sc_w, 0, 0]) sc_tab_relief();
       if (show_markers) for (k = left ? [0, 3] : [1, 2]) marker_pocket(k);
       // This side's rail + end wall ride the module (both sit ≥14 mm inboard of
       // the seam plane); the seam-crossing slots are unrepresentable here — the
@@ -1447,7 +1945,7 @@ module module_end(left) {      // left: border + column 0, tabs on the right fac
 module module_feet(kind) {     // the TPU pass per module kind (renders empty
   if (feet) {                  // when feet are off — the exporter treats an
     if (kind == "mid")         // empty feet render as an error, same as mono)
-      for (y = MF_Y) color("#1f2937") foot_xy(mf_x, y, false, mf_mouth, mf_seat);
+      for (xy = MF_XY) color("#1f2937") foot_xy(xy[0], xy[1], false, mf_mouth, mf_seat);
     else {
       x0 = kind == "left" ? 0 : frame_w - mod_we;
       translate([-x0, 0, 0])
@@ -1506,14 +2004,13 @@ else if (only == "bead_exposed")
 else if (only == "channel")      color(frame_color) channel(0, -(s_ehi - s_elo) / 2, (s_ehi - s_elo) / 2);
 else if (only == "frame")        color(frame_color) frame();
 /* The modular-seam coupon (SPIKE, Gitea #30). `seam_coupon` is the printable
-   part — print it TWICE and the two copies snap into a chain. The pair pass
-   shows the assembled seam for inspection; it is also the disjointness proof
-   the harness leans on: at joint_fit > 0 the pair's volume must equal exactly
-   2× the single coupon's, or a tab is fused into its socket. */
+   part: the three-fit calibration PLATE, one coupon per candidate joint_fit.
+   `seam_coupon_pair` is two seated copies of ONE of them, for inspection. The
+   two passes are therefore NOT a volume pair — 2× the plate is three plates'
+   worth of coupons — and a harness that compares them reads a fusion that is not
+   there. The disjointness proof is module_mid vs module_pair. */
 else if (only == "seam_coupon")      seam_coupon();
 else if (only == "seam_coupon_pair") {
-  /* Inspection remains one selected-fit seated pair; the printable coupon pass
-     above is the three-fit calibration plate. Pass vocabulary stays unchanged. */
   seam_coupon_one(); translate([sc_w, 0, 0]) seam_coupon_one();
 }
 /* Module columns (Gitea #30 CP3): the six per-module passes the kit exporter

--- a/apps/web/scripts/scad/README.md
+++ b/apps/web/scripts/scad/README.md
@@ -34,6 +34,167 @@ Exits non-zero on failure, so it can gate a pipeline. Sensitivity is proven:
 at `joint_fit = −0.05` (deliberate interference) the pair check detects a
 ~17 mm³ deficit; at the shipped fit the rel diff is ~1e-7.
 
+## insertion-sweep.mjs
+
+Rigid-path proof for the rear-entry graduated sliding rail: render one
+`module_mid` STL, then import it twice at 181 relative-Y offsets and require
+zero positive-volume intersection at every one of them — everywhere except the
+one place the seam is *designed* to interfere (the detent, below).
+
+```bash
+openscad -Dseam_mode='"modular"' -Djoint_type='"sliding_dovetail"' \
+  -Djoint_fit=0.10 -Donly='"module_mid"' \
+  -o /tmp/slide-mid-010.stl public/scad/abacus.scad
+node scripts/scad/insertion-sweep.mjs /tmp/slide-mid-010.stl
+
+# a bounded diagnosis, and any non-default render (pitch = sc_w)
+node scripts/scad/insertion-sweep.mjs /tmp/slide-mid-010.stl \
+  --offsets 0,0.5,1 --pitch 17.5
+```
+
+The sliding module pitch is **17.5** at stock scale, not the vertical-snap
+15.5: each sliding seam edge carries `slide_edge_allow` on top of its web.
+Sweeping at the wrong pitch measures nothing, so `--pitch` exists — and the
+sweep's own threshold stays at 1e-6 mm³, because seated modules touch on
+coincident planes only, which contributes no volume.
+
+What the sweep confirms is that female cross-sections are NESTED toward the
+mouth, not merely deeper in X: every station a section passes contains its
+whole XZ profile. That includes the deep anchor berth, whose flanks are the
+same 14° lines as the shallow runway's until they clamp flat at the berth
+floor — outside the reach of any section that sweeps through it.
+
+Every graduation on the rail is a ramp, and each is ramped by whichever side
+has the room. On the female, `slide_lead_out` ramps the relieved runway down
+onto the next berth's front profile (`slide_funnel` already did this at a
+berth's rear; without the lead-out the runway — cut `slide_relief` deeper — butted
+the berth's pinched front and left a `slide_relief + slide_pinch` ledge facing
+the incoming rail). On the male, `slide_anchor_lead` is the B→anchor
+graduation: the jump from a 2 mm rail to a 9 mm one is the largest single face
+on the part, and running the existing 45° inset break out to 1.5 mm trades
+about half of that face for a ramp. Both are free of travel cost — only a
+smaller section is ever at those stations — and the sweep is what says so.
+
+The one graduation that CANNOT be ramped further is the female shallow→deep
+taper at `slide_taper0`: it has to gain 6.8 mm of depth in the 3 mm between the
+back strip's start (`sc_k0`, where the bead-channel webs end and a 9 mm cut
+first becomes legal) and the anchor berth's front. Its ~66° face is the front
+wall of the anchor pocket, and it is load-bearing on the layout, not a defect.
+
+### The detent (the one designed interference)
+
+The seam carries a snap detent: a wedge on the floor of the female MIDDLE BERTH
+that drops into a notch in the male rail's middle (B) section, at the mid-length
+of the track. It is an elastic interference, so a rigid sweep would report it as
+a collision — the script instead derives the ridge's own bounding box from the
+scad's knobs (`--fit` picks the render's compensation; the crest station comes
+from the mesh's own Y span, because `slide_detent_yc` lands on `outer_d / 2`
+exactly), accounts every triangle inside it separately, and checks it as a
+*deflection*:
+
+- the seated pair (r = 0) must be empty inside the box — the notch receives the
+  ridge, or the seam does not close;
+- peak deflection must equal `slide_detent`, and peak volume the wedge's own —
+  the tongue is never asked for more than the engagement;
+- the ride must start no earlier than the TONGUE'S TIP reaching the ridge's rear
+  toe, and full deflection no earlier than the tip reaching the crest. On the
+  front-berth version those bounds were the rail nose's and they held for free
+  (rear entry means a female feature at Y is met only by male sections seated at
+  or ahead of it). Mid-track that exclusivity is gone — A and B both sweep the
+  crest station — so these two bounds are now *measurements of the relief
+  channel*, and they are the only thing that proves it works.
+
+The crest sits at the berth's mid-length rather than out on the runway, so the
+floor under it is flat and known and the proud height is `joint_fit +
+slide_detent` — a constant, not something that rides `slide_relief`.
+
+**The relief channel** is what buys back the exclusivity: `slide_ch_*` cuts a
+shallow groove down the CENTRE of the rail's TIP FACE, from the nose to the
+tongue's tip, clearing the ridge by `slide_ch_clear` per side in Z and
+`slide_ch_air` under the crest. Every section ahead of the tongue runs past the
+ridge on air; contact begins only when the ridge reaches the tongue, ~2.7 mm
+before seat. It is a tip-face feature only — the 14° flanks, which are what
+actually grip, are never cut — so the small section keeps its full undercut.
+
+The spring is not a printed finger, and it is not the female: `slide_spring_slot`
+is an L-shaped Z-through slot behind the male rail, so the B key plus the
+`slide_leaf_t` of seam skin behind it become one cantilever tongue — rooted at
+the blind end on the solid bar strip (`slide_spring_y1` lands on `sc_b0`), free
+at the short leg that cuts out through the seam face at `slide_spring_y0`. Both
+ends are inside the module, ~48 mm from either face, which is the point: the
+earlier front-corner version put the tongue's free end at the module's front
+corner, where a thumb could reach it and snap it off.
+
+**The retraction limit — the gate this harness is structurally blind to.**
+`slide_groove_profile` builds the female by translating the male profile
+`joint_fit` in +X, so the rail can back out of its groove exactly `joint_fit`
+before its own 14° flanks bottom on the groove's, and the tongue cannot deflect
+further than the rail it carries can retract. A sweep measures the ridge's
+*volume*, not whether the rail has anywhere to go, so it will happily pass a
+design whose flanks wedge solid. That gate lives in the scad
+(`slide_tip_defl <= slide_retract_room`) and in `seamFit`'s `detent_retract`
+verdict. Two things it accounts for that are easy to miss: peak deflection is the
+free TIP's, not the notch's (past its load a cantilever is straight, so the tip
+overswings by `1.5·b/a`), and the room is bought by `slide_detent_relief`, which
+opens the middle berth's NECK — not its floor, not its angle — over the run the
+deflected tongue occupies.
+
+The strain gate on the cantilever is a scad assert too (see the detent cluster),
+so a knob change that would over-strain it aborts the render rather than
+printing. What that gate does **not** model: it assumes a rigid root. The seam
+wall the tongue grows out of rotates under the same moment, which makes the real
+spring roughly 14% softer than the assert's number — the conservative direction
+for strain and for the 15 N push gate alike. It also ignores the slot's rounded
+blind end, which spreads the root over a few millimetres instead of a plane.
+Nothing in this harness measures the real deflection; only a printed coupon does.
+
+The rear mouth flare is symmetric now that the anchor lands on a berth floor:
+it eases the floor and the ceiling as well as the two flanks, all four out of
+the same lip budget.
+
+Four independent negative controls. The first two MUST report overlap (otherwise
+the sweep is blind and its pass means nothing):
+
+```bash
+# runway: sinks the female floors below the male rail depth. The berths — and
+# so the detent — are untouched by slide_relief, so the shipped detent knobs
+# stand and this control is purely about the runway.
+openscad -Dseam_mode='"modular"' -Djoint_type='"sliding_dovetail"' \
+  -Djoint_fit=0.10 -Dslide_relief=-0.3 -Donly='"module_mid"' \
+  -o /tmp/slide-mid-neg-runway.stl public/scad/abacus.scad
+node scripts/scad/insertion-sweep.mjs /tmp/slide-mid-neg-runway.stl --expect-overlap
+
+# seated berths incl. the deep anchor: over-squeezes the seat pinch
+openscad -Dseam_mode='"modular"' -Djoint_type='"sliding_dovetail"' \
+  -Djoint_fit=0.10 -Dslide_pinch=0.35 -Donly='"module_mid"' \
+  -o /tmp/slide-mid-neg-seat.stl public/scad/abacus.scad
+node scripts/scad/insertion-sweep.mjs /tmp/slide-mid-neg-seat.stl --expect-overlap
+```
+
+The other two prove the relief channel is load-bearing — starve it and the
+un-sprung sections start hitting the ridge tens of millimetres too early. These
+land in the DETENT bucket, not the rigid one, so run them as a **plain sweep**:
+`--expect-overlap` is the wrong harness and will report the run as a failure of
+the wrong check. Each should fail with "the relief channel is not clearing it",
+at a ride start ~47–48 against a bound of 2.97.
+
+```bash
+# crest clearance: the ridge now scrapes the channel floor
+openscad -Dseam_mode='"modular"' -Djoint_type='"sliding_dovetail"' \
+  -Djoint_fit=0.10 -Dslide_ch_air=-0.05 -Donly='"module_mid"' \
+  -o /tmp/slide-mid-neg-chair.stl public/scad/abacus.scad
+node scripts/scad/insertion-sweep.mjs /tmp/slide-mid-neg-chair.stl
+
+# Z clearance: the channel is narrower than the ridge
+openscad -Dseam_mode='"modular"' -Djoint_type='"sliding_dovetail"' \
+  -Djoint_fit=0.10 -Dslide_ch_clear=-0.15 -Donly='"module_mid"' \
+  -o /tmp/slide-mid-neg-chclear.stl public/scad/abacus.scad
+node scripts/scad/insertion-sweep.mjs /tmp/slide-mid-neg-chclear.stl
+```
+
+`joint_fit` itself is assert-gated to the coupon values on module passes, so a
+negative fit is not a usable control here.
+
 **Additivity at large coordinates is quantization-limited.** OpenSCAD's ASCII
 STL prints 6 significant digits, so x≈200 mm vertices carry ~0.001 mm of
 quantization vs ~1e-5 mm near the origin. Measured 2026-08-04: the identical
@@ -44,6 +205,46 @@ assembly (222.5 mm wide) therefore misses parts-sum additivity by ~1.6 mm³
 check pairs/small assemblies rendered near the origin (each seam type is
 additive at ~1e-7; a cols=3 assembly at ~2e-7) — do not chase the whole-row
 deficit, and do not loosen the 1e-6 threshold to make it "pass".
+
+## The CLI is not the engine that ships — always overlap, never abut
+
+**This harness renders with a different CSG engine than the app does.** The `openscad`
+CLI here is 2021.01, CGAL only. `public/openscad/` is a 2025.03.25 WASM build and
+`scad-worker.js` runs it with `--backend=Manifold`. Every guarantee below is a
+CGAL guarantee; the geometry a user actually looks at is Manifold's.
+
+The two disagree on **exactly abutting solids**. Two pieces of a `union()` that
+share a face plane with zero overlap are welded by CGAL's Nef representation and
+vanish; Manifold keeps the shared face. Inside a *void* — a pocket built as a
+union and then subtracted — that surviving face is a coincident triangle pair
+standing across the cavity: a wall of literally zero width, invisible to a slicer,
+plainly visible in the viewer. This shipped once (2026-08-13): the shallow→deep
+taper ended at `slide_taper0 + slide_funnel` and `slide_deep_zone` began at the
+same station, and the studio drew a partition between the anchor berth and the
+runway ahead of it. CGAL-rendered STLs of the same source were spotless.
+
+So: **every piece of a pocket or a rail overlaps its neighbour by 0.01**, which is
+why the `± 0.01` litter the seam modules. It is not decoration, and a junction
+that "looks cleaner" without one is the bug.
+
+To check, render through the shipped engine and audit the mesh — a closed,
+manifold solid has no coincident pairs, no boundary edges and no flipped faces:
+
+```js
+// node: same loader insertion-sweep.mjs uses
+const { default: OpenSCAD } = await import('public/openscad/openscad.js')
+const inst = await OpenSCAD({ wasmBinary, noInitialRun: true })
+inst.callMain(['/abacus.scad', '-o', '/out.stl', '--export-format=asciistl',
+               '--backend=Manifold', '-Donly="module_mid"', /* … */])
+```
+
+then group the triangles by sorted-rounded vertex key (a key with two triangles
+is a zero-width sheet) and by undirected edge (an edge with one triangle is a
+boundary; with more than two, non-manifold). At the shipped knobs `module_mid`
+scores 0/0/0 at every coupon fit, as does the assembled row.
+
+Note also that Manifold emits **no degenerate triangles** where CGAL leaves
+hundreds, so a sliver census on a CGAL export tells you nothing about the render.
 
 ## Render recipes (OpenSCAD 2021.01 quirks)
 
@@ -57,7 +258,10 @@ deficit, and do not loosen the 1e-6 threshold to make it "pass".
 - **Assert gating needs STL export.** A failed top-level `assert` exits 1 on STL
   export but exits **0** on `.csg` export (which writes a 1-byte file) — so
   negative-control runs must export STL, and fast `.csg` eval runs must grep the
-  log for `ERROR:` instead of trusting the exit code.
+  log for `ERROR:` instead of trusting the exit code. An aborted render also
+  leaves any existing `-o` file untouched, so a sweep run straight after one
+  silently measures the PREVIOUS geometry: delete the target (or stop on a
+  nonzero exit) before believing a control's verdict.
 - Any top-level scad variable can be forced with `-D` for negative controls
   (e.g. `-Dsc_seat=5` to trip the bottom-seat assert at default scale).
 - **Boolean ops on imported STLs crash CGAL** (`SNC_FM_decorator.h` assertion) —

--- a/apps/web/scripts/scad/insertion-sweep.mjs
+++ b/apps/web/scripts/scad/insertion-sweep.mjs
@@ -5,10 +5,14 @@
  * The claim under test: two seated modules have a continuous rigid insertion
  * path — at EVERY relative Y offset from fully seated (r = 0) to fully apart
  * (r > outer_d), the male module translated +r must not interpenetrate the
- * female module. The v3 graduation invariant makes this true by construction
- * (every station a key passes after leaving its own berth is one graduation
- * step larger, and female depth is monotone non-decreasing toward the mouth),
- * and this script is the check that the rendered solids agree.
+ * female module, EXCEPT at the one designed elastic interference (the detent
+ * ridge), which is measured as a deflection instead. The v3 graduation
+ * invariant makes the rigid half true by construction (every station a key
+ * passes after leaving its own berth is one graduation step larger, and female
+ * depth is monotone non-decreasing toward the mouth — including the deep anchor
+ * berth, whose flanks are the same 14° lines as the shallow runway's until they
+ * clamp flat outside any smaller section's reach), and this script is the check
+ * that the rendered solids agree.
  *
  * Method: ONE native render of `module_mid` (done outside this script), then
  * ONE WASM OpenSCAD run that imports that STL twice per offset and intersects
@@ -18,14 +22,25 @@
  * here and signed volume is accumulated per bin (divergence theorem — the
  * same inversion-proof metric as signed-volume.mjs).
  *
+ * The detent: every triangle whose centroid falls inside the ridge's own
+ * bounding box (derived below from the scad's knobs, in the STATIONARY female's
+ * frame — the ridge cannot move) is accounted separately. That volume is the
+ * spring's designed interference, and the deepest such triangle gives the
+ * deflection the male tongue takes. Nothing else lives in that box, and it is
+ * the only masked region: a runway or berth collision reports as rigid
+ * interference exactly as before.
+ *
  * Pass:            node scripts/scad/insertion-sweep.mjs <mid.stl>
  * Negative control (a deliberately interfering render MUST collide — proves
- * the sweep can see): render module_mid with -Dslide_relief=-0.3 (sinks the
- * runway floors 0.2 mm above the male rail depth; note joint_fit itself is
- * assert-gated to the coupon values on module passes, so negative fit is NOT
- * a usable control here), then:
+ * the sweep can see): render module_mid with `-Dslide_relief=-0.3` (sinks the
+ * runway floors 0.2 mm above the male rail depth, leaving the berths — and so
+ * the detent — exactly where they are; joint_fit itself is assert-gated to the
+ * coupon values on module passes, so negative fit is NOT a usable control
+ * here), then:
  *                  node scripts/scad/insertion-sweep.mjs <mid-neg.stl> --expect-overlap
  * Custom offsets:  --offsets 0,0.5,1
+ * Custom pitch:    --pitch 17.5   (sc_w of the render under test)
+ * Custom fit:      --fit 0.11     (joint_fit of the render under test)
  *
  * The default grid is fine where the joint is tight (0–2 mm @ 0.05 for the
  * seating pinch, 2–14 mm @ 0.25 for berth-length travel) and coarse where
@@ -38,14 +53,124 @@ import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const OPENSCAD_DIR = join(here, '..', '..', 'public', 'openscad')
+const SCAD_FILE = join(here, '..', '..', 'public', 'scad', 'abacus.scad')
 
-// Must match the scad: sc_w (module pitch) at scale 1 defaults.
-const PITCH = 15.5
+// Must match the scad's sc_w for the render under test — the SLIDING module
+// pitch at scale 1 defaults, which carries slide_edge_allow on each seam edge
+// (the vertical-snap 15.5 does not apply here; that topology has no sweep).
+// Exposed as --pitch so a non-default render cannot be swept at the wrong X.
+const DEFAULT_PITCH = 17.5
+// The detent's proud height is fit-dependent, so the keep-out box is too. The
+// module passes are assert-gated to the coupon fits; 0.10 is the shipped one.
+const DEFAULT_FIT = 0.1
 // X spacing between bins. A displaced pair spans ~31 mm in X plus the male
 // protrusion, so 60 keeps bins unambiguous for centroid binning.
 const SPACING = 60
 const SENTINEL_X = -300 // sentinel cube bin ≈ -5; also the parse sanity check
 const VOL_EPS = 1e-6 // mm³; real interference is mm³-scale, mesh noise ~1e-9
+// Margin on the detent keep-out box. Big enough to catch the interference
+// solid's own facets whatever the mesh does with them, far too small to reach
+// any other feature (the wedge sits mid-berth: the seat pinch ends 2 mm ahead
+// of the front toe, the berth's rear station is 3 mm behind the rear one).
+const DETENT_PAD = 0.05
+// How close to slide_detent a reading has to be to count as "fully deflected".
+// It is also a Y tolerance: on an 18° cam, being this shallow means being
+// DEPTH_TOL·cot(in) of travel short of the crest, and the full-deflection bound
+// below has to allow exactly that much or it fails a correct geometry.
+const DEPTH_TOL = 0.02
+
+/** The Y extent of one module — outer_d. Derived in the scad through a chain
+ *  (s_fd ← s_hhi ← …) that is not worth restating here, and the module is a slab
+ *  spanning exactly [0, outer_d], so the mesh is the honest source.
+ *  Handles both STL flavours: the module renders ASCII (OpenSCAD 2021.01's
+ *  default), while the sweep's own intersection pass comes back binary. The
+ *  length test is the only reliable discriminator — a binary STL may also open
+ *  with the word "solid". */
+function meshYSpan(stl) {
+  let lo = Number.POSITIVE_INFINITY
+  let hi = Number.NEGATIVE_INFINITY
+  const seen = (y) => {
+    if (y < lo) lo = y
+    if (y > hi) hi = y
+  }
+  if (stl.byteLength >= 84) {
+    const dv = new DataView(stl.buffer, stl.byteOffset, stl.byteLength)
+    const n = dv.getUint32(80, true)
+    if (stl.byteLength === 84 + 50 * n) {
+      for (let t = 0; t < n; t++) {
+        const o = 84 + t * 50 + 12
+        for (const k of [4, 16, 28]) seen(dv.getFloat32(o + k, true))
+      }
+      return hi - lo
+    }
+  }
+  for (const m of stl.toString('latin1').matchAll(/^\s*vertex\s+\S+\s+(\S+)/gm)) seen(Number(m[1]))
+  if (!Number.isFinite(lo)) throw new Error('could not read any vertices from the module STL')
+  return hi - lo
+}
+
+/** The detent's geometry, read out of the scad rather than restated here — the
+ *  ridge is a fixed feature of the STATIONARY module, so its box is the same at
+ *  every offset. Mirrors slide_detent_ridge() and the stations above the assert
+ *  cluster. */
+function detentModel(fit, outerD) {
+  const src = readFileSync(SCAD_FILE, 'utf8')
+  const knob = (name) => {
+    const m = src.match(new RegExp(`^${name}\\s*=\\s*(-?[\\d.]+)\\s*;`, 'm'))
+    if (!m) throw new Error(`knob ${name} not found in abacus.scad`)
+    return Number(m[1])
+  }
+  const cot = (deg) => 1 / Math.tan((deg * Math.PI) / 180)
+  const sFh = knob('frame_h') * knob('scale_factor')
+  const chamf = Math.min(knob('top_chamfer'), sFh * 0.4)
+  const k0s = chamf + 1 + knob('slide_seat_clear')
+  const depth = knob('slide_depth')
+  const detent = knob('slide_detent')
+  const outCot = cot(knob('slide_detent_out'))
+  const inCot = cot(knob('slide_detent_in'))
+  // The crest sits at the MIDDLE berth's mid-length, where the floor is flat and
+  // known; the toes are worked back from it down each flank. slide_k0_m is
+  // outer_d/2 − key/2, so the crest lands on outer_d/2 exactly — the middle of
+  // the track, which is the whole point of the mid-track detent.
+  const land = knob('slide_detent_l')
+  const keyL = knob('slide_key_l')
+  const yc = outerD / 2
+  // The tongue's free tip, and with it the rear end of the relief channel: one
+  // slot width behind the middle berth's seat pinch. Everything AHEAD of this
+  // station passes the ridge inside the channel, on air — which is the claim the
+  // ride bound below actually tests.
+  const springY0 =
+    yc - keyL / 2 - knob('slide_datum_relief') + knob('slide_pinch_l') + knob('slide_spring_slot')
+  const y0 = yc - land / 2
+  const y1 = yc + land / 2
+  const proud = fit + detent // over the berth floor — no runway relief here
+  const y00 = y0 - proud * outCot // front toe
+  const yr = y1 + proud * inCot
+  const h = knob('slide_detent_h')
+  const crestX = depth - detent
+  const floorX = depth + fit
+  // The engaged wedge is everything between the crest and the rail's tip face:
+  // widest at the berth floor, closing at cot(out) + cot(in) per mm toward the
+  // crest. Width is linear in x, so the midpoint width times the engagement is
+  // the area exactly — and the midpoint is stated as the floor width less what
+  // has closed by there.
+  const peakArea = detent * (yr - y00 - (floorX - (crestX + depth) / 2) * (outCot + inCot))
+  return {
+    k0s,
+    springY0,
+    detent,
+    inCot,
+    y0: y00,
+    y1, // crest land's rear edge — the first station that can be fully deflected
+    yr,
+    yc,
+    crestX,
+    floorX,
+    zLo: sFh / 2 - h,
+    zHi: sFh / 2 + h,
+    peakVol: peakArea * 2 * h,
+  }
+}
 
 function defaultOffsets() {
   const rs = []
@@ -56,23 +181,37 @@ function defaultOffsets() {
 }
 
 function parseArgs(argv) {
-  const args = { mid: null, expectOverlap: false, offsets: null }
+  const args = {
+    mid: null,
+    expectOverlap: false,
+    offsets: null,
+    pitch: DEFAULT_PITCH,
+    fit: DEFAULT_FIT,
+  }
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--expect-overlap') args.expectOverlap = true
     else if (a === '--offsets') args.offsets = argv[++i].split(',').map(Number)
+    else if (a === '--pitch') args.pitch = Number(argv[++i])
+    else if (a === '--fit') args.fit = Number(argv[++i])
     else if (!args.mid) args.mid = resolve(a)
     else throw new Error(`unexpected argument: ${a}`)
   }
   if (!args.mid)
     throw new Error(
-      'usage: insertion-sweep.mjs <module_mid.stl> [--expect-overlap] [--offsets a,b,c]'
+      'usage: insertion-sweep.mjs <module_mid.stl> [--expect-overlap] [--offsets a,b,c] [--pitch mm] [--fit mm]'
     )
+  if (!(args.pitch > 0)) throw new Error('--pitch must be a positive number')
+  if (!(args.fit >= 0)) throw new Error('--fit must be a non-negative number')
+  if (args.offsets?.some((r) => !Number.isFinite(r)))
+    throw new Error('--offsets must be comma-separated numbers')
   return args
 }
 
-/** Signed volume per X bin from a binary STL (80-byte header, u32 count, 50 B/tri). */
-function binVolumes(stl) {
+/** Signed volume per X bin from a binary STL (80-byte header, u32 count, 50 B/tri),
+ *  split into the rigid part and the detent's designed interference. `box` is in
+ *  bin-local coordinates (the female module sits at local x = pitch). */
+function binVolumes(stl, box) {
   const dv = new DataView(stl.buffer, stl.byteOffset, stl.byteLength)
   const n = dv.getUint32(80, true)
   const bins = new Map()
@@ -90,7 +229,29 @@ function binVolumes(stl) {
     // a · (b × c) / 6
     const v = (ax * (by * cz - bz * cy) + ay * (bz * cx - bx * cz) + az * (bx * cy - by * cx)) / 6
     const bin = Math.round((ax + bx + cx) / 3 / SPACING)
-    bins.set(bin, (bins.get(bin) ?? 0) + v)
+    const rec = bins.get(bin) ?? {
+      v: 0,
+      detent: 0,
+      minX: Number.POSITIVE_INFINITY,
+      maxX: Number.NEGATIVE_INFINITY,
+    }
+    const lx = (ax + bx + cx) / 3 - bin * SPACING
+    const ly = (ay + by + cy) / 3
+    const lz = (az + bz + cz) / 3
+    const inDetent =
+      box &&
+      lx >= box.x0 &&
+      lx <= box.x1 &&
+      ly >= box.y0 &&
+      ly <= box.y1 &&
+      lz >= box.z0 &&
+      lz <= box.z1
+    if (inDetent) {
+      rec.detent += v
+      rec.minX = Math.min(rec.minX, ax - bin * SPACING, bx - bin * SPACING, cx - bin * SPACING)
+      rec.maxX = Math.max(rec.maxX, ax - bin * SPACING, bx - bin * SPACING, cx - bin * SPACING)
+    } else rec.v += v
+    bins.set(bin, rec)
   }
   return { bins, facets: n }
 }
@@ -99,6 +260,17 @@ async function main() {
   const args = parseArgs(process.argv)
   const offsets = args.offsets ?? defaultOffsets()
   const mid = readFileSync(args.mid)
+  const d = detentModel(args.fit, meshYSpan(mid))
+  // The ridge belongs to the module that does NOT move, so its box is fixed in
+  // the bin's own frame — at the female's seam face, which sits at x = pitch.
+  const box = {
+    x0: args.pitch + d.crestX - DETENT_PAD,
+    x1: args.pitch + d.floorX + DETENT_PAD,
+    y0: d.y0 - DETENT_PAD,
+    y1: d.yr + DETENT_PAD,
+    z0: d.zLo - DETENT_PAD,
+    z1: d.zHi + DETENT_PAD,
+  }
 
   const scad = [
     `rs = [${offsets.join(', ')}];`,
@@ -106,7 +278,7 @@ async function main() {
     `  translate([${SPACING} * i, 0, 0])`,
     `    intersection() {`,
     `      translate([0, rs[i], 0]) import("/mid.stl");`,
-    `      translate([${PITCH}, 0, 0]) import("/mid.stl");`,
+    `      translate([${args.pitch}, 0, 0]) import("/mid.stl");`,
     `    }`,
     `translate([${SENTINEL_X}, 0, 0]) cube(1);`,
   ].join('\n')
@@ -138,22 +310,29 @@ async function main() {
     }
   }
   const out = inst.FS.readFile('/out.stl')
-  const { bins, facets } = binVolumes(out)
+  const { bins, facets } = binVolumes(out, box)
   console.log(
     `sweep: ${offsets.length} offsets, ${facets} facets, ${((Date.now() - t0) / 1000).toFixed(1)}s`
   )
 
   const sentinelBin = Math.round(SENTINEL_X / SPACING)
-  const sentinel = bins.get(sentinelBin) ?? 0
+  const sentinel = bins.get(sentinelBin)?.v ?? 0
   if (Math.abs(sentinel - 1) > 1e-3) {
     console.error(`FAIL sentinel cube missing or misparsed (V=${sentinel}) — sweep did not render`)
     process.exit(2)
   }
 
   const hits = []
+  const detent = []
   for (let i = 0; i < offsets.length; i++) {
-    const v = bins.get(i) ?? 0
-    if (Math.abs(v) > VOL_EPS) hits.push({ r: offsets[i], v })
+    const rec = bins.get(i) ?? { v: 0, detent: 0 }
+    if (Math.abs(rec.v) > VOL_EPS) hits.push({ r: offsets[i], v: rec.v })
+    // The tongue is pushed by however thick the wedge is where it is engaged: the
+    // solid runs from the ridge surface out to the rail's tip face, so its own
+    // X extent IS the deflection (and an upper bound on it before the crest is
+    // covered, where the deepest point and the widest are not the same station).
+    if (Math.abs(rec.detent) > VOL_EPS)
+      detent.push({ r: offsets[i], v: rec.detent, depth: rec.maxX - rec.minX })
   }
 
   if (args.expectOverlap) {
@@ -175,7 +354,63 @@ async function main() {
     console.error(`FAIL ${hits.length}/${offsets.length} offsets interpenetrate`)
     process.exit(1)
   }
-  console.log(`PASS all ${offsets.length} offsets rigid-clear (|V| ≤ ${VOL_EPS} mm³)`)
+  console.log(
+    `PASS all ${offsets.length} offsets rigid-clear (|V| ≤ ${VOL_EPS} mm³), detent excluded`
+  )
+  detentReport(d, detent, offsets)
+}
+
+/** The detent is the one place the modules are MEANT to interfere. Three claims:
+ *  it is empty at the seat (the notch receives the ridge), it never asks the
+ *  tongue for more than slide_detent of deflection, and it is reachable only by
+ *  the TONGUE.
+ *  That last one used to come free from rear entry — a ridge parked in the front
+ *  berth is behind every section but A. Mid-track it is bought by the relief
+ *  channel instead, so it has to be measured rather than assumed, and this is
+ *  where: the ride may not begin before the tongue's own tip reaches the ridge's
+ *  rear toe. Everything ahead of that tip is running the ridge down the channel,
+ *  and if the channel were shallow or narrow by so much as a facet, interference
+ *  would show up ~40 mm earlier in the stroke and this bound would catch it. A
+ *  too-shallow channel does not even reach here: contact below the crest lands
+ *  outside the keep-out box and reports as a RIGID collision, which is the
+ *  louder failure and the right one. */
+function detentReport(d, detent, offsets) {
+  const fail = (msg) => {
+    console.error(`FAIL detent: ${msg}`)
+    process.exit(1)
+  }
+  if (detent.length === 0) fail('no interference at ANY offset — the ridge is missing')
+  const seated = detent.find((h) => h.r === 0)
+  if (seated) fail(`the seated pair interferes (${seated.v.toFixed(4)} mm³) — the notch misses`)
+  const deepest = detent.reduce((a, b) => (b.depth > a.depth ? b : a))
+  const biggest = detent.reduce((a, b) => (b.v > a.v ? b : a))
+  if (Math.abs(deepest.depth - d.detent) > 0.02)
+    fail(`peak deflection ${deepest.depth.toFixed(3)} mm ≠ slide_detent ${d.detent}`)
+  if (Math.abs(biggest.v - d.peakVol) > 0.05)
+    fail(`peak interference ${biggest.v.toFixed(3)} mm³ ≠ the wedge's ${d.peakVol.toFixed(3)} mm³`)
+  const rideStart = Math.max(...detent.map((h) => h.r))
+  const tipAtToe = d.yr - d.springY0
+  if (rideStart > tipAtToe)
+    fail(
+      `interference at r=${rideStart} — the tongue's tip is still behind the ridge's rear toe ` +
+        `(${tipAtToe.toFixed(3)}), so something ahead of the tongue is touching the ridge: ` +
+        `the relief channel is not clearing it`
+    )
+  const fullAt = Math.max(...detent.filter((h) => h.depth > d.detent - DEPTH_TOL).map((h) => h.r))
+  // The earliest the tongue can read as fully deflected: its tip at the crest
+  // land's rear edge, plus the travel a DEPTH_TOL-shallow reading is worth.
+  const tipAtCrest = d.y1 - d.springY0 + DEPTH_TOL * d.inCot
+  if (fullAt > tipAtCrest)
+    fail(
+      `full deflection at r=${fullAt} — before the tongue's tip reaches the crest ` +
+        `(${tipAtCrest.toFixed(3)})`
+    )
+  const firstBite = Math.min(...detent.map((h) => h.r))
+  console.log(
+    `PASS detent: ${detent.length} offsets ride the ridge, r ${rideStart} → ${firstBite}` +
+      ` (bound ${tipAtToe.toFixed(3)}), peak ${deepest.depth.toFixed(3)} mm /` +
+      ` ${biggest.v.toFixed(3)} mm³ at r ≤ ${fullAt} (bound ${tipAtCrest.toFixed(3)})`
+  )
 }
 
 main().catch((e) => {

--- a/apps/web/src/components/create/abacus/ModularSeamPanel.tsx
+++ b/apps/web/src/components/create/abacus/ModularSeamPanel.tsx
@@ -179,7 +179,7 @@ export function ModularSeamPanel() {
           style={{ fontSize: 11, lineHeight: 1.5, color: 'rgba(226,232,240,0.75)' }}
         >
           {sliding
-            ? 'One continuous graduated dovetail rail slides in through the rear entry mouth — loose the whole way, engaging only over the last centimeter. Its rear end is a deep anchor that reaches 3.5 mm into the neighbor and hooks the pull-apart direction; the table registers both bottoms flush. Push firmly until the module stops against the blind front seat; the tapered seat is self-holding. Remove with a firm rearward tug.'
+            ? 'One continuous graduated dovetail rail slides in through the rear entry mouth — loose the whole way, engaging only over the last centimeter. Its rear end is a deep anchor that bites 9 mm into the neighbor and hooks the pull-apart direction on both lips; it rides on a solid berth floor, so no seam surface opens through the underside. Push firmly until the module stops against the blind front seat: over the last few millimetres the rail rides up a ridge on the berth floor and drops into a notch with a click. The rail is its own spring — a slot behind its middle stretch makes that part of the seam edge a tongue, buried where nothing can catch it — so nothing on the socket side has to flex. The taper is self-holding and the ridge makes the seat positive; removal takes a firm rearward tug over the same ridge.'
             : 'Vertical dovetails carry the seam while the crossbar clip clicks at full depth. Modules press straight down and any middle module can lift straight out.'}
         </div>
 
@@ -197,8 +197,11 @@ export function ModularSeamPanel() {
           </strong>
           <div style={{ marginTop: 3, color: 'rgba(148,163,184,0.85)' }}>
             Each seam keeps a full wall on both sides — every column carries its own web — so the
-            row grows by one web per seam. Every module also carries its own feet, so any subset
-            stands.
+            row grows by one web per seam.{' '}
+            {sliding
+              ? 'The sliding rail buys its depth with 1 mm more on each mating edge, adding a further 2 mm per seam without touching the bead channels. '
+              : ''}
+            Every module also carries its own feet, so any subset stands.
           </div>
         </div>
 
@@ -211,7 +214,7 @@ export function ModularSeamPanel() {
             style={{ fontSize: 11, color: 'rgba(134,239,172,0.9)', lineHeight: 1.5 }}
           >
             {sliding
-              ? 'Sliding joint fit OK — no flexures; the ~1.9° seat taper is self-holding.'
+              ? `Sliding joint fit OK — detent strain ${fit.strainPct.toFixed(2)}% (wood-PLA gate 1.0%); the ~1.9° seat taper is self-holding.`
               : `Vertical snap joint fit OK — snap-clip strain ${fit.strainPct.toFixed(2)}% (wood-PLA gate 1.0%).`}
           </div>
         ) : (

--- a/apps/web/src/components/create/abacus/__tests__/ModularSeamPanel.test.tsx
+++ b/apps/web/src/components/create/abacus/__tests__/ModularSeamPanel.test.tsx
@@ -204,10 +204,11 @@ describe('ModularSeamPanel', () => {
       container.querySelector('[data-element="modular-joint-explanation"]')?.textContent
     ).toContain('rear entry mouth')
     expect(screen.getByText(/bounded plate contains 0\.10, 0\.11, and 0\.12/)).toBeInTheDocument()
-    // no flexures in this topology: the ok line reports self-holding taper, not strain %
+    // one flexure in this topology — the detent's male tongue — so the ok line
+    // carries its strain alongside the self-holding taper
     const ok = container.querySelector('[data-element="modular-seam-verdict-ok"]')
     expect(ok?.textContent).toContain('self-holding')
-    expect(ok?.textContent).not.toMatch(/strain/)
+    expect(ok?.textContent).toMatch(/detent strain 0\.69%/)
     fireEvent.change(select!, { target: { value: 'vertical_snap' } })
     expect(set).toHaveBeenCalledWith('joint_type', 'vertical_snap')
   })

--- a/apps/web/src/components/create/abacus/__tests__/module-kit.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/module-kit.test.ts
@@ -591,11 +591,28 @@ describe('buildModuleKit', () => {
     expect(slidingReadme).toContain('rear-entry graduated sliding dovetail')
     expect(slidingReadme).toMatch(/ONE continuous\s+graduated dovetail rail/)
     expect(slidingReadme).toMatch(/enters through the REAR face/)
-    expect(slidingReadme).toMatch(/deep anchor block/)
-    expect(slidingReadme).toMatch(/the table is the height datum/)
+    expect(slidingReadme).toMatch(/deep anchor block that bites\s+9 mm into the neighbor/)
+    // the anchor's two load-bearing claims: symmetric hook, and a closed underside
+    expect(slidingReadme).toMatch(/hooks the pull-apart direction on BOTH lips/)
+    expect(slidingReadme).toMatch(/solid 1\.7 mm berth floor/)
+    expect(slidingReadme).toMatch(/no seam surface opens through the bottom\s+face/)
+    // the price of the deeper rail, stated where the builder measures the row
+    expect(slidingReadme).toMatch(/adds 2 mm of assembled width/)
     expect(slidingReadme).toMatch(/blind front\s+seat/)
     expect(slidingReadme).toMatch(/firm rearward tug/)
     expect(slidingReadme).toContain('cannot lift straight out')
     expect(slidingReadme).toMatch(/0\.10, 0\.11,\s+and 0\.12 mm compensation samples/)
+    // the detent: the seated signal a builder can act on, and the warning that
+    // the firm last stretch is the ridge rather than a bad fit
+    expect(slidingReadme).toMatch(/climbs a ridge on the berth floor/)
+    expect(slidingReadme).toMatch(/with a click as\s+the seat is reached/)
+    expect(slidingReadme).toMatch(/That click is the seated signal/)
+    expect(slidingReadme).toMatch(/lift the detent out of its notch/)
+    expect(slidingReadme).toMatch(/never clicks into the\s+notch/)
+    expect(slidingReadme).toMatch(/MEANT to be firm/)
+    // and it is still not a separate part — but the builder is told WHICH module
+    // flexes, because that decides which one to hold
+    expect(slidingReadme).toMatch(/makes that stretch of rail its own spring/)
+    expect(slidingReadme).toMatch(/not the one already in\s+the row/)
   })
 })

--- a/apps/web/src/components/create/abacus/__tests__/seam-fit.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/seam-fit.test.ts
@@ -19,9 +19,15 @@ import {
   type Params,
   previewDedupKey,
   SEAM,
+  type SeamProfile,
   SLIDING_DOVETAIL,
   SLIDING_FIT_VALUES,
   seamFit,
+  slideDeepGrooveProfile,
+  slideDeepProfile,
+  slideProfile,
+  slidingAnchorGeometry,
+  slidingDetentGeometry,
   slidingDovetailDerived,
 } from '../abacus-model'
 
@@ -87,6 +93,7 @@ describe('SEAM constants mirror the scad', () => {
     const pins: [keyof typeof SLIDING_DOVETAIL, string][] = [
       ['angleDeg', 'slide_angle'],
       ['maleDepth', 'slide_depth'],
+      ['edgeAllowance', 'slide_edge_allow'],
       ['neck', 'slide_neck'],
       ['step', 'slide_step'],
       ['minBackingWall', 'slide_min_backing'],
@@ -97,42 +104,684 @@ describe('SEAM constants mirror the scad', () => {
       ['pinchLength', 'slide_pinch_l'],
       ['floorRelief', 'slide_relief'],
       ['datumRelief', 'slide_datum_relief'],
+      ['leadOut', 'slide_lead_out'],
       ['seatClear', 'slide_seat_clear'],
       ['mouthFlare', 'slide_mouth_flare'],
       ['deepDepth', 'slide_deep_depth'],
       ['deepFloor', 'slide_deep_floor'],
       ['mouthLength', 'slide_mouth_l'],
+      ['corner', 'slide_corner'],
+      ['anchorLead', 'slide_anchor_lead'],
+      ['detent', 'slide_detent'],
+      ['detentRelief', 'slide_detent_relief'],
+      ['channelClear', 'slide_ch_clear'],
+      ['channelAir', 'slide_ch_air'],
+      ['detentLand', 'slide_detent_l'],
+      ['detentHalfHeight', 'slide_detent_h'],
+      ['detentOutDeg', 'slide_detent_out'],
+      ['detentInDeg', 'slide_detent_in'],
+      ['detentSlop', 'slide_detent_slop'],
+      ['springSlot', 'slide_spring_slot'],
+      ['leafT', 'slide_leaf_t'],
+      ['springA', 'slide_spring_a'],
+      ['modulusMPa', 'slide_modulus'],
+      ['selfHoldMu', 'slide_mu'],
     ]
     for (const [ts, scad] of pins) expect(SLIDING_DOVETAIL[ts]).toBe(knob(scad))
     const g = slidingDovetailDerived(0.1)
-    // graduated rail family: neck ± step, heads = neck + 2·depth·tan14° (+0.498656)
+    // graduated rail family: neck ± step, heads = neck + 2·depth·tan14° (+0.997312)
     expect(g.necks.s).toBeCloseTo(2.2, 12)
     expect(g.necks.m).toBe(2.8)
     expect(g.necks.l).toBeCloseTo(3.4, 12)
-    expect(g.head).toBeCloseTo(3.298656, 5)
-    expect(g.headL).toBeCloseTo(3.898656, 5)
-    // deepest SHALLOW female cut = depth + fit + floor relief = 1.25 at fit 0.10
-    expect(g.deepestCut).toBeCloseTo(1.25, 12)
-    // deep anchor pocket cut = deep depth + fit + floor relief = 3.75
-    expect(g.deepPocketCut).toBeCloseTo(3.75, 12)
+    expect(g.head).toBeCloseTo(3.797312, 5)
+    expect(g.headL).toBeCloseTo(4.397312, 5)
+    // deepest SHALLOW female cut = depth + fit + floor relief = 2.25 at fit 0.10
+    expect(g.deepestCut).toBeCloseTo(2.25, 12)
+    // deep anchor pocket cut = deep depth + fit + floor relief = 9.25
+    expect(g.deepPocketCut).toBeCloseTo(9.25, 12)
     // widest SHALLOW female Z opening = the large segment's relieved runway:
-    // 3.4 + 2·1.35·tan14° = 4.073186 (the deep mouth's Z-flare is lip-budget
+    // 3.4 + 2·2.35·tan14° = 4.571842 (the deep mouth's Z-flare is lip-budget
     // capped in the scad, so the runway is the honest z_lips driver)
-    expect(g.runwayOpening).toBeCloseTo(4.073186, 5)
+    expect(g.runwayOpening).toBeCloseTo(4.571842, 5)
     // the large rail head passes its own relieved runway with room to spare
     expect(g.runwayOpening).toBeGreaterThan(g.headL)
-    // deep anchor hook = 3.5·tan14° — exactly 1.75× the shallow TOTAL hook
-    // (2·depth·tan14°), the "one flank is the only hook" trade made explicit
-    expect(g.anchorHook).toBeCloseTo(0.872648, 5)
-    expect(g.anchorHook / (2 * SLIDING_DOVETAIL.maleDepth * Math.tan(g.angleRad))).toBeCloseTo(
-      1.75,
-      12
-    )
+    // the anchor berth's floor is the anchor's ceiling lip mirrored — 1.8 − fit,
+    // scale-free, and the mouth flare is what is left of it over the 1.2 minimum
+    expect(g.anchorFloor).toBeCloseTo(1.7, 12)
+    expect(g.anchorMouthFlare).toBeCloseTo(0.5, 12)
+    expect(slidingDovetailDerived(0.12).anchorMouthFlare).toBeCloseTo(0.48, 12)
     // any rail section passing a one-step-up station clears ≥ step/2 + fit·tan14° per side
     expect(g.passClearance).toBeCloseTo(0.324933, 5)
     // retention physics: 0.05/1.5 seat taper = 1.909° ≪ atan(µ 0.25) = 14.036°
     expect(g.seatTaperDeg).toBeCloseTo(1.90915, 4)
     expect(g.selfHoldLimitDeg).toBeCloseTo(14.03624, 4)
+  })
+})
+
+// ---- the deep anchor's cross-section ------------------------------------------
+// The rear anchor is the one section whose profile is NOT the graduated
+// trapezoid: both flanks clamp flat at the berth floor and its mirror. These
+// pins are the shape itself — hand-derived from the scad's slide_deep_profile /
+// slide_deep_groove_profile — plus the two properties the shape exists for
+// (a symmetric hook, and a berth every smaller section can still sweep through).
+
+const TAN14 = Math.tan((14 * Math.PI) / 180) // 0.249328…
+
+/** Vertical [zmin, zmax] span of a convex XZ profile at depth x, by clipping
+ *  every edge against the vertical line — the containment question these
+ *  profiles have to answer, asked directly of the polygons. */
+const spanAt = (poly: SeamProfile, x: number): [number, number] | null => {
+  const zs: number[] = []
+  for (let i = 0; i < poly.length; i++) {
+    const [x1, z1] = poly[i]
+    const [x2, z2] = poly[(i + 1) % poly.length]
+    if (x1 === x2) {
+      if (Math.abs(x1 - x) < 1e-12) zs.push(z1, z2)
+      continue
+    }
+    const t = (x - x1) / (x2 - x1)
+    if (t >= 0 && t <= 1) zs.push(z1 + t * (z2 - z1))
+  }
+  return zs.length ? [Math.min(...zs), Math.max(...zs)] : null
+}
+
+/** Worst top/bottom clearance of a male section inside a female berth, over the
+ *  whole depth the section occupies. Negative ⇒ the section would collide on
+ *  its way past that berth. */
+const passMargin = (section: SeamProfile, berth: SeamProfile, depth: number): number => {
+  let worst = Number.POSITIVE_INFINITY
+  for (let i = 0; i <= 200; i++) {
+    const x = (i / 200) * depth
+    const s = spanAt(section, x)
+    const b = spanAt(berth, x)
+    if (!s || !b) return Number.NaN
+    worst = Math.min(worst, s[0] - b[0], b[1] - s[1])
+  }
+  return worst
+}
+
+const shiftZ = (poly: SeamProfile, dz: number): SeamProfile => poly.map(([x, z]) => [x, z + dz])
+
+describe('deep anchor profile', () => {
+  const S_FH = 8 // frame_h × scale_factor at stock size
+  const N_L = SLIDING_DOVETAIL.neck + SLIDING_DOVETAIL.step // 3.4 — the anchor is always LARGE
+
+  it('is one symmetric block: 14° off the neck, then clamped at the floor and its mirror', () => {
+    // rb 2.3, rt 5.7 (neck centered in an 8 mm slab); floor 1.8, cap 8 − 1.8;
+    // each flank runs 0.5/tan14° = 2.005390 before it clamps; bite 9, whose two
+    // long tip edges are broken by slide_corner.
+    const male = slideDeepProfile(N_L, S_FH)
+    const k = SLIDING_DOVETAIL.corner
+    const xFlank = 0.5 / TAN14
+    expect(xFlank).toBeCloseTo(2.00539, 5)
+    expect(male).toHaveLength(8)
+    const expected: SeamProfile = [
+      [0, 2.3],
+      [xFlank, 1.8],
+      [9 - k, 1.8],
+      [9, 1.8 + k],
+      [9, 6.2 - k],
+      [9 - k, 6.2],
+      [xFlank, 6.2],
+      [0, 5.7],
+    ]
+    for (const [i, [x, z]] of expected.entries()) {
+      expect(male[i][0]).toBeCloseTo(x, 9)
+      expect(male[i][1]).toBeCloseTo(z, 9)
+    }
+    // symmetry is the whole design: floor + cap planes sum to the slab, and the
+    // two flanks clamp at the same depth, so both lips hook the same amount
+    const a = slidingAnchorGeometry(S_FH)
+    expect(a.floorPlane + a.capPlane).toBeCloseTo(S_FH, 12)
+    expect(male[1][0]).toBeCloseTo(male[6][0], 12)
+    expect(a.rootBottom - a.floorPlane).toBeCloseTo(a.capPlane - a.rootTop, 12)
+  })
+
+  it('the tip breaks at 45° in section, and an inset profile breaks each END at 45°', () => {
+    // Section: both long tip edges lose slide_corner in x and in z — equal runs,
+    // so the underside break is exactly 45°, not a shallower overhang.
+    const male = slideDeepProfile(N_L, S_FH)
+    const k = SLIDING_DOVETAIL.corner
+    expect(male[3][0] - male[2][0]).toBeCloseTo(k, 12)
+    expect(male[3][1] - male[2][1]).toBeCloseTo(k, 12)
+    expect(male[4][0] - male[5][0]).toBeCloseTo(k, 12)
+    expect(male[5][1] - male[4][1]).toBeCloseTo(k, 12)
+    // Ends: the scad hulls an inset section `corner` in Y ahead of a full one.
+    // The floor rises by the inset over that run and the tip pulls back by it,
+    // so every face the hull sweeps — underside included — is at 45° exactly.
+    const inset = slideDeepProfile(N_L, S_FH, k)
+    const floorOf = (poly: SeamProfile) => Math.min(...poly.map(([, z]) => z))
+    const tipOf = (poly: SeamProfile) => Math.max(...poly.map(([x]) => x))
+    expect(floorOf(inset) - floorOf(male)).toBeCloseTo(k, 12)
+    expect(tipOf(male) - tipOf(inset)).toBeCloseTo(k, 12)
+    // dz/dy on the swept underside is exactly 1 — the printability limit, which
+    // is why this is admissible where the anchor's front STEP could not be a
+    // blend at all
+    expect((floorOf(inset) - floorOf(male)) / k).toBeCloseTo(1, 12)
+    // the seam root never moves: only the floor, cap and tip are inset, so the
+    // hull cannot pull the profile off the neck it grows from
+    expect(inset[0]).toEqual(male[0])
+    expect(inset[inset.length - 1]).toEqual(male[male.length - 1])
+  })
+
+  it('keeps the full-length tooth’s undercut and spends the extra depth on bearing', () => {
+    const a = slidingAnchorGeometry(S_FH)
+    // 0.5 per side — the same hook a 2 mm-deep graduated tooth gets from its
+    // flank (2·tan14° = 0.498656), to a thousandth of a millimetre
+    expect(a.undercut).toBeCloseTo(0.5, 12)
+    expect(a.undercut).toBeCloseTo(SLIDING_DOVETAIL.maleDepth * TAN14, 2)
+    // …so the 9 mm bite is 7 mm of flat bearing, not 7 mm of deeper hook
+    expect(a.flankRun).toBeCloseTo(2.00539, 5)
+    expect(a.flatLength).toBeCloseTo(9 - 2.00539, 5)
+  })
+
+  it('the female berth grows the same shape and keeps a solid floor under it', () => {
+    const fit = 0.1
+    const berth = slideDeepGrooveProfile(N_L, fit, S_FH)
+    const xCorner = 0.6 / TAN14 - fit // 2.306469 — grown flank meets grown floor
+    const expected: SeamProfile = [
+      [-0.01, 2.3 - 0.09 * TAN14], // the seam-face lip trick, on the flank line
+      [xCorner, 1.7],
+      [9.1, 1.7],
+      [9.1, 6.3],
+      [xCorner, 6.3],
+      [-0.01, 5.7 + 0.09 * TAN14],
+    ]
+    for (const [i, [x, z]] of expected.entries()) {
+      expect(berth[i][0]).toBeCloseTo(x, 9)
+      expect(berth[i][1]).toBeCloseTo(z, 9)
+    }
+    // flanks: offset fit along +x ⇒ exactly fit·sin(angle) flank-normal running
+    // clearance, the file's convention. Floor/ceiling: offset fit along ∓z.
+    const male = slideDeepProfile(N_L, S_FH)
+    expect(spanAt(male, 1)![0] - spanAt(berth, 1)![0]).toBeCloseTo(fit * TAN14, 12)
+    expect(slidingDovetailDerived(fit).runningClearance).toBeCloseTo(
+      fit * Math.sin((14 * Math.PI) / 180),
+      12
+    )
+    expect(male[1][1] - berth[1][1]).toBeCloseTo(fit, 12) // floor
+    expect(berth[3][1] - male[5][1]).toBeCloseTo(fit, 12) // ceiling (past the corner break)
+    // the floor lip: at the seam face the berth's underside sits 0.575 mm ABOVE
+    // the floor flat, so the female keeps a wedge that hooks the male's bottom
+    // flank — the underside is a closed face, not an opening
+    expect(spanAt(berth, 0)![0]).toBeCloseTo(2.275067, 6)
+    expect(spanAt(berth, 0)![0] - 1.7).toBeCloseTo(0.575067, 6)
+    expect(spanAt(berth, 0)![0]).toBeLessThan(spanAt(male, 0)![0])
+    // and the berth ceiling clears the slab top by the mirrored floor
+    expect(S_FH - spanAt(berth, 5)![1]).toBeCloseTo(slidingDovetailDerived(fit).anchorFloor, 12)
+  })
+
+  it('the rear mouth flares all four sides, out of one lip budget', () => {
+    // The flare only became possible once the anchor landed on a floor: it opens
+    // the berth's floor and ceiling by the same amount it opens the two roots,
+    // and what it may spend is whatever the floor keeps over slide_min_lip.
+    const fit = 0.1
+    const g = slidingDovetailDerived(fit)
+    expect(g.anchorMouthFlare).toBeCloseTo(0.5, 12)
+    const mouth = slideDeepGrooveProfile(
+      N_L,
+      fit,
+      S_FH,
+      SLIDING_DOVETAIL.floorRelief,
+      g.anchorMouthFlare
+    )
+    const floor = Math.min(...mouth.map(([, z]) => z))
+    const ceiling = Math.max(...mouth.map(([, z]) => z))
+    expect(floor).toBeCloseTo(SLIDING_DOVETAIL.minLip, 12) // 1.2 — the budget spent exactly
+    expect(S_FH - ceiling).toBeCloseTo(SLIDING_DOVETAIL.minLip, 12)
+    expect(floor + ceiling).toBeCloseTo(S_FH, 12) // still symmetric about mid-slab
+    // both seam-face roots open too, by the same flare, so no corner is left square
+    const plain = slideDeepGrooveProfile(N_L, fit, S_FH, SLIDING_DOVETAIL.floorRelief)
+    expect(spanAt(plain, 0)![0] - spanAt(mouth, 0)![0]).toBeCloseTo(g.anchorMouthFlare, 9)
+    expect(spanAt(mouth, 0)![1] - spanAt(plain, 0)![1]).toBeCloseTo(g.anchorMouthFlare, 9)
+    // and the budget itself is asserted, not silently clamped to zero
+    expect(SLIDING_DOVETAIL.deepFloor - fit - SLIDING_DOVETAIL.minLip).toBeGreaterThanOrEqual(0)
+  })
+
+  it('every smaller section still sweeps through the anchor berth', () => {
+    // Rear entry: the A (2.2) and B (2.8) sections travel through the deep berth
+    // on their way to their own. The berth's flanks ARE the graduated flanks
+    // until they clamp — outside any 2 mm-deep section's reach — so the margin
+    // is the ordinary one-graduation pass clearance, top and bottom.
+    const g = slidingDovetailDerived(0.1)
+    const berth = slideDeepGrooveProfile(N_L, 0.1, S_FH)
+    const depth = SLIDING_DOVETAIL.maleDepth
+    const sectionA = slideProfile(g.necks.s, S_FH)
+    const sectionB = slideProfile(g.necks.m, S_FH)
+    expect(passMargin(sectionB, berth, depth)).toBeCloseTo(g.passClearance, 9)
+    // A is two graduations under the anchor's neck, so it clears by two halves
+    expect(passMargin(sectionA, berth, depth)).toBeCloseTo(
+      g.passClearance + SLIDING_DOVETAIL.step / 2,
+      9
+    )
+    // the tight seat squeezes the berth by the pinch and it still clears
+    const seated = slideDeepGrooveProfile(N_L, 0.1 - SLIDING_DOVETAIL.pinch, S_FH)
+    expect(passMargin(sectionB, seated, depth)).toBeGreaterThan(0.3)
+    // the anchor itself is contained by its own berth over the whole bite
+    expect(passMargin(slideDeepProfile(N_L, S_FH), berth, SLIDING_DOVETAIL.deepDepth)).toBeCloseTo(
+      0.1 * TAN14,
+      9
+    )
+  })
+
+  it('the clearance check can fail — a floor raised into the passing section collides', () => {
+    const berth = slideDeepGrooveProfile(N_L, 0.1, S_FH)
+    const sectionB = slideProfile(SLIDING_DOVETAIL.neck, S_FH)
+    // dropping the section 0.7 mm is the same geometry as a berth floor raised
+    // to 2.4: the check must go negative, or it is proving nothing above
+    expect(passMargin(shiftZ(sectionB, -0.7), berth, SLIDING_DOVETAIL.maleDepth)).toBeLessThan(0)
+    // and on real knobs: a 7 mm slab pulls the necks down onto the absolute
+    // floor. seamFit refuses that geometry (anchor_flanks) before the sweep
+    // would ever see it — the gate is upstream of the collision.
+    const squat = passMargin(
+      slideProfile(SLIDING_DOVETAIL.neck, 7),
+      slideDeepGrooveProfile(N_L, 0.1, 7),
+      SLIDING_DOVETAIL.maleDepth
+    )
+    expect(squat).toBeLessThan(0)
+    expect(slidingAnchorGeometry(7).undercut).toBeLessThan(0.3)
+  })
+})
+
+// ---- the detent: the click, and the only flexure in this topology --------------
+// A wedge on the female MIDDLE BERTH's floor drops into a notch in the male rail's
+// middle (B) section, at the mid-length of the track. The crest goes at the berth's
+// mid-length: that is the one stretch of groove with a flat, known floor, so the
+// proud height is a constant instead of something that rides the runway relief.
+// Mid-track gives up the kinematic exclusivity a front-berth ridge got free from
+// rear entry, so exclusivity is bought geometrically instead — the RELIEF CHANNEL
+// down the rail's tip face, which every un-sprung section passes the ridge inside.
+// The spring is the MALE side — an L-shaped Z-through slot behind the rail frees
+// the B key and the skin backing it into a cantilever tongue whose free tip is
+// buried mid-module — so the female stays rigid. The tongue's bending SECTION is
+// skin AND rail; the tests below integrate it rather than trusting the closed form,
+// because counting the skin alone understates it ~11×. And the gate an insertion
+// sweep is blind to gets its own test: the tongue cannot deflect further than the
+// rail it carries can RETRACT out of its own groove.
+
+describe('the detent', () => {
+  const sliding = p({ joint_type: 'sliding_dovetail' })
+  const dt = slidingDetentGeometry(sliding)
+  const c = SLIDING_DOVETAIL
+  const S_FH_1 = sliding.frame_h * sliding.scale_factor // 8 — the slab at stock size
+
+  it('stations: crest pinned to the middle berth’s mid-length, toes worked back', () => {
+    expect(dt.k0S).toBeCloseTo(2.02, 12)
+    expect(dt.k0M).toBeCloseTo(46.25, 12)
+    // the middle berth runs k0M − datumRelief → k0M + keyLength + 0.3 (its front
+    // stands off: one Y stop locates the seam, and it is the SMALL berth's), and
+    // the crest land straddles the key's own midpoint
+    expect(dt.midY0).toBeCloseTo(46.05, 12)
+    expect(dt.midY1).toBeCloseTo(54.55, 12)
+    expect(dt.berthY1).toBe(dt.midY1)
+    expect(dt.crestY).toBeCloseTo(50.25, 12)
+    expect(dt.crestY - dt.k0M).toBeCloseTo(c.keyLength / 2, 12)
+    // and that lands on outerD / 2 exactly — the literal middle of the track,
+    // which is the whole point of moving it off the module's front corner
+    expect(dt.crestY).toBeCloseTo(derived(sliding).outerD / 2, 12)
+    expect(dt.crest0).toBeCloseTo(49.95, 12)
+    expect(dt.crest1).toBeCloseTo(50.55, 12)
+    // proud = fit + detent = 0.25 over the BERTH floor (not the relieved runway —
+    // the ridge never leaves the berth), and each flank run is that height over
+    // the flank's own tangent
+    expect(dt.proud).toBeCloseTo(0.25, 12)
+    expect(dt.y0).toBeCloseTo(49.774948, 5)
+    expect(dt.rearToe).toBeCloseTo(51.319421, 5)
+    // both toes land inside the berth: past the seat pinch at the front, clear of
+    // the berth's rear station behind
+    expect(dt.y0).toBeGreaterThan(dt.midY0 + c.pinchLength)
+    expect(dt.rearToe).toBeLessThan(dt.berthY1)
+    // the tongue's root sits behind the wedge and lands ON the bar strip — the
+    // only solid it can grow out of with no bead channel behind it to bow into
+    expect(dt.springA).toBe(11.25)
+    expect(dt.springY1).toBeCloseTo(61.5, 12)
+    const dv0 = derived(sliding)
+    const scB0 =
+      sliding.border_w * sliding.scale_factor +
+      dv0.sEhi +
+      (sliding.bead_len * sliding.scale_factor) / 2 +
+      sliding.clearance
+    expect(dt.springY1).toBeCloseTo(scB0, 12)
+  })
+
+  it('mid-track is swept by A and B alike — the relief channel is what excludes them', () => {
+    // Rear entry: a male section starting at male-Y m sweeps female-Y ∈
+    // [m, outerD] and nothing ahead of m. At the FRONT berth that made the ridge
+    // A's alone; mid-track it does not, and pretending otherwise is the error this
+    // test exists to pin. A and B both reach the crest; only the anchor cannot.
+    const dv = derived(sliding)
+    const sBw = sliding.border_w * sliding.scale_factor
+    const sBl = sliding.bead_len * sliding.scale_factor
+    const taper0 = sBw + dv.sHhi + sBl / 2 + sliding.clearance + 0.3
+    const anchor0 = taper0 + c.funnel + c.datumRelief
+    const fronts: [string, number, boolean][] = [
+      ['A', dt.k0S, true],
+      ['B', dt.k0M, true],
+      ['anchor', anchor0, false],
+    ]
+    for (const [name, m, reaches] of fronts) {
+      const sweeps = (y: number) => y >= m
+      expect(sweeps(dt.y0), `${name} vs the ridge toe`).toBe(reaches)
+      expect(sweeps(dt.rearToe), `${name} vs the ridge's rear toe`).toBe(reaches)
+    }
+    expect(anchor0 - dt.rearToe).toBeGreaterThan(30)
+    // So exclusivity is geometric. The channel runs the rail's tip face from the
+    // nose to the tongue's tip, and every section ahead of that tip passes the
+    // ridge INSIDE it: channelAir under the crest, channelClear past each Z edge.
+    expect(dt.channel.y0).toBeCloseTo(dt.k0S, 12)
+    expect(dt.channel.y1).toBeCloseTo(dt.springY0, 12)
+    expect(dt.channel.x0).toBeCloseTo(c.maleDepth - dt.channelDepth, 12)
+    expect(dt.channelDepth).toBeCloseTo(c.detent + c.channelAir, 12)
+    expect(dt.channel.x0).toBeLessThan(dt.crestX) // crest sits inside the channel…
+    expect(dt.crestX - dt.channel.x0).toBeCloseTo(c.channelAir, 12) // …by this much
+    expect(dt.channel.z[0]).toBeLessThan(dt.ridgeZ[0])
+    expect(dt.ridgeZ[0] - dt.channel.z[0]).toBeCloseTo(c.channelClear, 12)
+    expect(dt.channel.z[1] - dt.ridgeZ[1]).toBeCloseTo(c.channelClear, 12)
+    // Tip face ONLY: it stops short of the flanks, so the small section — the one
+    // that has to run the whole track past this ridge — keeps its full undercut.
+    const smallHalfAtChannelFloor = (c.neck - c.step) / 2 + (c.maleDepth - dt.channelDepth) * TAN14
+    expect(smallHalfAtChannelFloor - dt.channelWidth / 2).toBeGreaterThanOrEqual(0.3)
+    // and the un-sprung run is nearly the whole track: contact starts only when
+    // the ridge reaches the tongue, a couple of millimetres before seat
+    expect(dt.channel.y1 - dt.channel.y0).toBeGreaterThan(46)
+    expect(dt.rearToe - dt.springY0).toBeCloseTo(2.969421, 5)
+  })
+
+  it('ridge and notch: the same wedge, the notch grown off the rail’s tip face', () => {
+    // ridge: berth floor 2.10 → crest 1.85 (0.15 inside the rail's 2.0 tip face).
+    // The floor it stands on is the BERTH's — depth + fit, with no runway relief,
+    // which is the whole reason the crest is inside the berth and not behind it.
+    expect(dt.floorX).toBeCloseTo(2.1, 12)
+    expect(dt.crestX).toBeCloseTo(1.85, 12)
+    const ridge = dt.ridge()
+    const flat: number[] = ridge.flat()
+    expect(flat).toHaveLength(8)
+    for (const [i, v] of [2.1, dt.y0, 1.85, dt.crest0, 1.85, dt.crest1, 2.1, dt.rearToe].entries())
+      expect(flat[i]).toBeCloseTo(v, 9)
+    // the crest land is the same at every coupon fit — only the toes ride the
+    // floor down, so no sample can drag the crest off the berth's mid-length
+    for (const fit of SLIDING_FIT_VALUES) {
+      const r = slidingDetentGeometry(p({ joint_type: 'sliding_dovetail', joint_fit: fit })).ridge(
+        fit
+      )
+      expect(r[1][1], `crest0 at fit ${fit}`).toBeCloseTo(49.95, 12)
+      expect(r[2][1], `crest1 at fit ${fit}`).toBeCloseTo(50.55, 12)
+      expect(r[0][0]).toBeCloseTo(c.maleDepth + fit, 12)
+    }
+    // notch: crest floor a fit deeper, Z half-height a fit taller, and each flank
+    // stated where the RIDGE's flank crosses the rail tip face — which the 0.01
+    // overshoot breaks — then stepped back detentSlop along its own normal
+    const notch = dt.notch()
+    expect(dt.notchFloorX).toBeCloseTo(1.75, 12)
+    expect(notch[0][0]).toBeCloseTo(2.01, 12)
+    expect(notch[0][1]).toBeCloseTo(49.789136, 5)
+    expect(notch[1][0]).toBeCloseTo(1.75, 12)
+    expect(notch[1][1]).toBeCloseTo(49.97119, 5)
+    expect(notch[2][0]).toBeCloseTo(1.75, 12)
+    expect(notch[2][1]).toBeCloseTo(50.371674, 5)
+    expect(notch[3][1]).toBeCloseTo(51.171872, 5)
+    // …and in Z the notch is a fit taller than the ridge, top and bottom
+    expect(dt.ridgeZ).toEqual([S_FH_1 / 2 - c.detentHalfHeight, S_FH_1 / 2 + c.detentHalfHeight])
+    expect(dt.notchZ[0]).toBeCloseTo(dt.ridgeZ[0] - sliding.joint_fit, 12)
+    expect(dt.notchZ[1]).toBeCloseTo(dt.ridgeZ[1] + sliding.joint_fit, 12)
+  })
+
+  it('the seated flank gaps are detentSlop exactly, at every coupon fit', () => {
+    // The notch's flanks are the RIDGE's flank lines stepped back along their own
+    // normals, so the gap is detentSlop and nothing else. State them off the
+    // ridge's toes on the runway floor instead — the first cut of this design —
+    // and each flank silently gains (floor − tip)·cos(flank), which is pure Y
+    // backlash: the seam still seats on its blind front stop, but the click is
+    // loose against a pull by that much before it bites.
+    const gap = (
+      a: [number, number],
+      b: [number, number],
+      pt: [number, number],
+      deg: number
+    ): number => {
+      const len = Math.hypot(b[0] - a[0], b[1] - a[1])
+      const cross = ((b[0] - a[0]) * (pt[1] - a[1]) - (b[1] - a[1]) * (pt[0] - a[0])) / len
+      expect(Math.abs((b[1] - a[1]) / (b[0] - a[0]))).toBeCloseTo(
+        1 / Math.tan((deg * Math.PI) / 180),
+        9
+      )
+      return Math.abs(cross)
+    }
+    const rad = (deg: number) => (deg * Math.PI) / 180
+    for (const fit of SLIDING_FIT_VALUES) {
+      const g = slidingDetentGeometry(p({ joint_type: 'sliding_dovetail', joint_fit: fit }))
+      const ridge = g.ridge(fit)
+      const notch = g.notch(fit)
+      expect(gap(ridge[0], ridge[1], notch[0], c.detentOutDeg), `out at ${fit}`).toBeCloseTo(
+        c.detentSlop,
+        9
+      )
+      expect(gap(ridge[3], ridge[2], notch[3], c.detentInDeg), `in at ${fit}`).toBeCloseTo(
+        c.detentSlop,
+        9
+      )
+    }
+    // A y-shift of s closes a flank-normal gap by s·sin(flank), so the free
+    // travel before the RETENTION flank bites — the only direction a flank
+    // bounds, since forward is the blind stop's business — is slop/sin(55°).
+    // That is the click's whole backlash, and the scad asserts it under 0.05.
+    const notch = dt.notch()
+    // read the notch's two flanks at the crest plane, where the ridge's own land
+    // is: the difference IS the free travel, in each direction
+    const at = (a: [number, number], b: [number, number], x: number) =>
+      a[1] + ((x - a[0]) / (b[0] - a[0])) * (b[1] - a[1])
+    expect(dt.crest0 - at(notch[0], notch[1], dt.crestX)).toBeCloseTo(dt.backlashOut, 12)
+    expect(at(notch[3], notch[2], dt.crestX) - dt.crest1).toBeCloseTo(dt.backlashIn, 12)
+    expect(dt.backlashOut).toBeCloseTo(0.048831, 6)
+    expect(dt.backlashOut).toBeLessThanOrEqual(0.05)
+    expect(dt.backlashIn).toBeCloseTo(0.129443, 6)
+    // what the discarded datum would have cost, in the same units
+    const wrong = (deg: number) =>
+      (sliding.joint_fit + (dt.floorX - (c.maleDepth + 0.01)) * Math.cos(rad(deg))) /
+      Math.sin(rad(deg))
+    expect(wrong(c.detentOutDeg)).toBeCloseTo(0.185099, 5)
+    expect(wrong(c.detentOutDeg) / dt.backlashOut).toBeGreaterThan(3.5)
+  })
+
+  it('the notch keeps off the rail’s flanks and leaves real rail behind it', () => {
+    // The B rail's half-height at the notch floor, against the notch's own — this
+    // is the scad's flank gate, and it binds at the LOOSEST coupon fit. It is the
+    // B section that carries the notch now, so the gate reads the middle neck; the
+    // relief channel gets the same gate read against the SMALL one, in its own test.
+    const railHalf = (fit: number) => c.neck / 2 + (c.maleDepth - c.detent - fit) * TAN14
+    for (const fit of SLIDING_FIT_VALUES) {
+      const notchHalf = c.detentHalfHeight + fit
+      expect(railHalf(fit) - notchHalf, `flank margin at fit ${fit}`).toBeGreaterThanOrEqual(0.3)
+      expect(c.maleDepth - c.detent - fit).toBeGreaterThanOrEqual(1.2)
+    }
+    // the dovetail's grip is untouched: the notch is a void in the tip face,
+    // 1.75 mm of rail deep, and the flanks it hooks on never see it
+    expect(dt.notchFloorX).toBeCloseTo(1.75, 12)
+    expect(railHalf(0.1) - (c.detentHalfHeight + 0.1)).toBeCloseTo(0.836327, 5)
+  })
+
+  it('the tongue is skin AND rail, not the 1.2 mm skin alone', () => {
+    // The slot frees the key together with the skin behind it, and the rail is
+    // welded to that skin down the whole free length — so the bending section is
+    // a rectangle plus the B trapezoid, and the rail is most of it. Integrated
+    // here from the section itself, so the closed form in the model cannot drift
+    // from the shape it claims to describe.
+    const neckB = c.neck
+    const depth = c.maleDepth
+    const total = c.leafT + depth
+    // material height at depth x from the slot's inner face: full slab through
+    // the skin, then the rail's own trapezoid out to the tip
+    const hAt = (x: number) =>
+      x < c.leafT ? S_FH_1 : neckB + 2 * (x - c.leafT) * Math.tan((c.angleDeg * Math.PI) / 180)
+    const N = 400000
+    let a = 0
+    let q = 0
+    let j = 0
+    for (let i = 0; i < N; i++) {
+      const x = (total * (i + 0.5)) / N
+      const dA = (hAt(x) * total) / N
+      a += dA
+      q += x * dA
+      j += x * x * dA
+    }
+    const xbar = q / a
+    expect(dt.leafA).toBeCloseTo(a, 3)
+    expect(dt.leafX).toBeCloseTo(xbar, 5)
+    expect(dt.inertia).toBeCloseTo(j - a * xbar ** 2, 3)
+    // the numbers themselves, and how far off the skin alone would be
+    expect(dt.leafA).toBeCloseTo(16.197312, 5)
+    expect(dt.leafX).toBeCloseTo(1.272219, 5)
+    // the outer fibre is the TIP side (3.2 − 1.272), not the slot side
+    expect(dt.leafC).toBeCloseTo(1.927781, 5)
+    expect(dt.leafC).toBeCloseTo(total - dt.leafX, 9)
+    expect(dt.inertia).toBeCloseTo(13.984813, 5)
+    expect(dt.inertia / ((S_FH_1 * c.leafT ** 3) / 12)).toBeGreaterThan(10)
+    // the female's post-groove wall is still reported, and is NOT the spring:
+    // this topology's flexure moved to the male when the ridge took the berth
+    expect(dt.backing).toBeCloseTo(1.25, 12)
+  })
+
+  it('the beam: an 11.25 mm cantilever, loaded at the notch', () => {
+    // Free at the tip gap, rooted at the slot's blind end 11.25 mm behind the
+    // crest — set so that root lands on the bar strip. The root wall does rotate,
+    // so the real spring is ~14% softer than this — overstating stiffness and
+    // strain alike is the safe direction for both gates.
+    expect(dt.springA).toBe(11.25)
+    // δ = F·a³/(3EI) and M = F·a at the root ⇒ ε = M·c/(EI) = 3·δ·c/a², E and I
+    // gone. Same wood-PLA line the snap clip is judged against (1.0% = ~1.5%/1.5).
+    expect(dt.strainPct).toBeCloseTo(0.685433, 6)
+    expect(dt.strainPct).toBeLessThanOrEqual(1.0)
+    expect(dt.strainPct).toBeCloseTo((300 * c.detent * dt.leafC) / c.springA ** 2, 12)
+    // …and the same thing the long way round, through a force the gate cancels
+    const force = (3 * c.modulusMPa * dt.inertia * c.detent) / c.springA ** 3
+    expect(dt.strainPct).toBeCloseTo(
+      (100 * (force * c.springA) * dt.leafC) / (c.modulusMPa * dt.inertia),
+      12
+    )
+    // force does NOT cancel: it is what says a hand can still push this home
+    expect(dt.stiffnessN).toBeCloseTo(73.664858, 5)
+    expect(dt.forceN).toBeCloseTo(11.049729, 5)
+    expect(dt.seatForceN).toBeCloseTo(6.91436, 5)
+    expect(dt.seatForceN).toBeLessThanOrEqual(15)
+    expect(dt.partForceN).toBeCloseTo(28.840042, 5)
+    expect(dt.partForceN).toBeGreaterThan(dt.seatForceN) // 55° out, 18° in
+  })
+
+  it('the retraction limit: the tongue can’t deflect past what the rail can back out', () => {
+    // The gate an insertion sweep cannot see. A sweep is a rigid-overlap check —
+    // it measures the ridge's volume, not whether the rail has anywhere to go.
+    // slideGrooveProfile builds the female by translating the male jointFit in +x,
+    // so the rail backs out of its groove EXACTLY jointFit before its own 14°
+    // flanks bottom on the groove's; refusing to come out radially is the whole
+    // job of a dovetail, and it is also the ceiling on this flexure's travel.
+    expect(dt.retractRoom).toBeGreaterThan(sliding.joint_fit)
+    expect(dt.retractRoom - sliding.joint_fit).toBeCloseTo(c.detentRelief / (2 * TAN14), 12)
+    expect(dt.retractRoom).toBeCloseTo(0.240377, 5)
+    // Peak deflection is the free TIP's, not the notch's: past its load a
+    // cantilever is straight, so the tip overswings by 1.5·b/a.
+    expect(dt.tipOver).toBeCloseTo(1.9, 12)
+    expect(dt.tipDefl).toBeCloseTo(c.detent * (1 + (1.5 * dt.tipOver) / dt.springA), 12)
+    expect(dt.tipDefl).toBeCloseTo(0.188, 12)
+    expect(dt.tipDefl).toBeGreaterThan(c.detent) // the overswing is real, ~25%
+    expect(dt.tipDefl).toBeLessThanOrEqual(dt.retractRoom)
+    // Without the neck relief this design does NOT clear: 0.188 into 0.10.
+    expect(dt.tipDefl).toBeGreaterThan(sliding.joint_fit)
+    // and the gate is a live predicate, not a coincidence
+    expect(failing(sliding)).not.toContain('detent_retract')
+    for (const fit of SLIDING_FIT_VALUES)
+      expect(
+        failing(p({ joint_type: 'sliding_dovetail', joint_fit: fit })),
+        `retraction at fit ${fit}`
+      ).not.toContain('detent_retract')
+  })
+
+  it('the spring slot is an L buried mid-module, and the front foot got its X back', () => {
+    const mf = moduleFeetLayout(sliding)
+    // it hugs the male seam edge: leafT of skin outboard of it, and the rest of
+    // sc_wall (1.5 mm) inboard, in front of the bead channel
+    expect(dt.slot.x0).toBeCloseTo(15.5, 12)
+    expect(dt.slot.w).toBeCloseTo(0.8, 12)
+    expect(derived(sliding).scW - (dt.slot.x0 + dt.slot.w)).toBeCloseTo(c.leafT, 12)
+    expect(dt.slot.x0).toBeGreaterThanOrEqual(c.minBackingWall)
+    // BOTH ends are inside the module now. The long leg runs tip → root, blind at
+    // each end; the short leg is the same width of Y turned 90° and driven out
+    // through the seam face, and THAT is what frees the tongue's tip.
+    expect(dt.slot.y0).toBeCloseTo(47.55, 12)
+    expect(dt.slot.y1).toBeCloseTo(61.5, 12)
+    expect(dt.slot.tipY0).toBe(dt.slot.y0)
+    expect(dt.slot.tipY1 - dt.slot.tipY0).toBeCloseTo(c.springSlot, 12)
+    expect(dt.slot.tipY1).toBeCloseTo(dt.springY0, 12)
+    // The tip gap goes at the forward-most station that does NOT cut the middle
+    // berth's seat pinch — one station splits un-sprung rail from tongue, so the
+    // pinch and the relief window can never overlap.
+    expect(dt.channelY1).toBeCloseTo(dt.midY0 + c.pinchLength, 12)
+    expect(dt.springY0).toBeCloseTo(dt.channelY1 + c.springSlot, 12)
+    // …and it still leaves the notch land in front of it
+    expect(dt.springY0).toBeLessThan(dt.y0)
+    // the free end is buried: ~48 mm from the front face, ~52 from the rear, with
+    // a neighbour's groove around it. Nothing can reach it to snap it off — which
+    // is the entire reason it is not at the module's front corner any more.
+    expect(dt.springY0).toBeGreaterThan(45)
+    expect(derived(sliding).outerD - dt.springY0).toBeGreaterThan(45)
+    // and with the slot off the front face, the FRONT foot shares the rear's X
+    // again instead of being squeezed into a band of its own
+    expect(mf.xFront).toBe(mf.x)
+    expect(mf.x).toBeCloseTo(13.375, 12)
+    // that band's bounds stay as a scale gate — a scale that couldn't fit them
+    // couldn't fit this pocket either
+    expect(mf.frontHi - mf.frontLo).toBeCloseTo(5, 12)
+  })
+
+  it('the gates can fail — but none of them is what bounds this topology’s scale', () => {
+    // The tongue is made of absolute knobs (leafT, maleDepth, springA, detent);
+    // only the slab height reaches its section, and only through the skin's
+    // height, so strain barely moves with scale and never reaches the gate.
+    const strainAt = (scale_factor: number) =>
+      slidingDetentGeometry(p({ joint_type: 'sliding_dovetail', scale_factor })).strainPct
+    expect(strainAt(0.9)).toBeCloseTo(0.670375, 5)
+    expect(strainAt(1.4)).toBeCloseTo(0.731238, 5)
+    expect(strainAt(1.4) - strainAt(0.9)).toBeLessThan(0.07)
+    for (const scale_factor of [0.9, 1, 1.2, 1.4])
+      expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor }))).not.toContain(
+        'detent_strain'
+      )
+    // …so the gates are proved on their predicates instead. Halving the free
+    // length quadruples the strain, which is the same statement as ε ∝ 1/a²:
+    expect((300 * c.detent * dt.leafC) / (c.springA / 2) ** 2).toBeGreaterThan(1)
+    // The slot's own scale gate DOES bind, at S ≥ 0.88 — sc_wall = 2.5S + 1 has
+    // to carry leafT + springSlot and still leave minBackingWall in front of the
+    // bead channel — but the female's backing wall gives out first (S ≥ 0.98),
+    // so the detent moves neither end of the buildable window.
+    expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor: 0.87 }))).toContain(
+      'detent_slot'
+    )
+    expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor: 0.88 }))).not.toContain(
+      'detent_slot'
+    )
+    // The reach gate cannot be tripped from the studio: the berth's rear station
+    // and the wedge both hang off outerD/2 and absolute knobs, so the margin is a
+    // constant 3.23 mm at every size. Moving the ridge is a scad -D, and the
+    // predicate is what decides:
+    const reaches = (rearToe: number) => rearToe <= dt.berthY1
+    expect(reaches(dt.rearToe)).toBe(true)
+    expect(reaches(dt.berthY1 + 0.001)).toBe(false)
+    expect(dt.rearToe - dt.y0).toBeCloseTo(1.544473, 5)
+    expect(dt.berthY1 - dt.rearToe).toBeCloseTo(3.230579, 5)
+    for (const scale_factor of [0.4, 0.85, 1, 1.35])
+      expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor }))).not.toContain(
+        'detent_reach'
+      )
+    // The channel's two gates are absolute in the same way — they read maleDepth,
+    // the small neck and the ridge's own size, none of which scale — so they too
+    // are proved on their predicates, at every size the studio can ask for.
+    for (const scale_factor of [0.4, 0.85, 1, 1.35]) {
+      const bad = failing(p({ joint_type: 'sliding_dovetail', scale_factor }))
+      expect(bad).not.toContain('detent_channel_rail')
+      expect(bad).not.toContain('detent_channel_flanks')
+      expect(bad).not.toContain('detent_tip_land')
+    }
+    expect(c.maleDepth - dt.channelDepth).toBeCloseTo(1.6, 12)
+    expect(dt.channelWidth).toBeCloseTo(2.2, 12)
   })
 })
 
@@ -147,30 +796,56 @@ describe('modular derived()', () => {
     }
   })
 
-  it('width identity: 2·modWe + (cols−2)·scW === frameW in modular mode', () => {
+  it('width identity: 2·modWe + (cols−2)·scW === frameW for both modular joints', () => {
     // exact at defaults (all inputs are dyadic decimals): 2·26 + 11·15.5 = 222.5
     const d = derived(p({ seam_mode: 'modular' }))
     expect(d.scW).toBe(15.5)
     expect(d.modWe).toBe(26)
     expect(d.frameW).toBe(222.5)
     expect(2 * d.modWe + (defaultParams.cols - 2) * d.scW).toBe(222.5)
-    // and to float precision across the knob space
-    for (const S of [0.85, 1, 1.4])
-      for (const cols of [3, 13, 21]) {
-        const dd = derived(p({ scale_factor: S, cols, seam_mode: 'modular' }))
-        expect(2 * dd.modWe + (cols - 2) * dd.scW).toBeCloseTo(dd.frameW, 9)
-      }
+    // the sliding edge allowance widens every edge wall to 3.5: 2·27 + 11·17.5
+    const s = derived(p({ seam_mode: 'modular', joint_type: 'sliding_dovetail' }))
+    expect(s.scW).toBe(17.5)
+    expect(s.modWe).toBe(27)
+    expect(s.frameW).toBe(246.5)
+    expect(2 * s.modWe + (defaultParams.cols - 2) * s.scW).toBe(246.5)
+    // and to float precision across the knob space, on either topology
+    for (const joint_type of ['vertical_snap', 'sliding_dovetail'] as const)
+      for (const S of [0.85, 1, 1.4])
+        for (const cols of [3, 13, 21]) {
+          const dd = derived(p({ scale_factor: S, cols, seam_mode: 'modular', joint_type }))
+          expect(2 * dd.modWe + (cols - 2) * dd.scW).toBeCloseTo(dd.frameW, 9)
+        }
   })
 
-  it('modular widens the abacus by exactly (cols−1)·web·S', () => {
+  it('modular widens the abacus by (cols−1)·web·S, plus 2 mm per sliding seam', () => {
     expect(derived(p({ seam_mode: 'modular' })).frameW - derived(p()).frameW).toBeCloseTo(
       12 * 2.5,
       12
     )
+    // the allowance is absolute (1 mm of print material per edge), so it does
+    // NOT scale with the design the way the web does
+    const slide = derived(p({ seam_mode: 'modular', joint_type: 'sliding_dovetail' }))
+    expect(slide.frameW - derived(p({ seam_mode: 'modular' })).frameW).toBeCloseTo(12 * 2, 12)
     const over = { cols: 5, scale_factor: 0.9 } as const
     expect(
       derived(p({ ...over, seam_mode: 'modular' })).frameW - derived(p(over)).frameW
     ).toBeCloseTo(4 * 2.5 * 0.9, 12)
+    expect(
+      derived(p({ ...over, seam_mode: 'modular', joint_type: 'sliding_dovetail' })).frameW -
+        derived(p({ ...over, seam_mode: 'modular' })).frameW
+    ).toBeCloseTo(4 * 2, 12)
+  })
+
+  it('joint_type moves ONLY the module widths — the mono footprint is topology-blind', () => {
+    const snap = derived(p())
+    const slide = derived(p({ joint_type: 'sliding_dovetail' }))
+    for (const k of Object.keys(snap) as (keyof typeof snap)[]) {
+      if (k === 'scW' || k === 'modWe') continue
+      expect(slide[k], `mono derived().${k} must not depend on joint_type`).toBe(snap[k])
+    }
+    expect(slide.scW).toBe(17.5)
+    expect(slide.modWe).toBe(27)
   })
 
   it('mono is untouched: pre-CP4 pitch and outer dims, and seam_mode moves ONLY sCp/frameW', () => {
@@ -362,7 +1037,7 @@ describe('seamFit', () => {
     'sliding fit %.2f derives groove and flank-normal clearance',
     (fit) => {
       const g = slidingDovetailDerived(fit)
-      expect(g.grooveDepth).toBeCloseTo(1 + fit, 12)
+      expect(g.grooveDepth).toBeCloseTo(2 + fit, 12)
       expect(g.runningClearance).toBeCloseTo(fit * Math.sin((14 * Math.PI) / 180), 12)
       expect(seamFit(p({ joint_type: 'sliding_dovetail', joint_fit: fit })).ok).toBe(true)
     }
@@ -372,9 +1047,22 @@ describe('seamFit', () => {
     const vertical = moduleFeetLayout(p())
     const sliding = moduleFeetLayout(p({ joint_type: 'sliding_dovetail' }))
     expect(vertical.sock).toBeCloseTo(4.9, 12)
-    // sliding sock clears the DEEP ANCHOR pocket (bottom-open through the
-    // underside along its rear span): deep depth + fit + floor relief
-    expect(sliding.sock).toBeCloseTo(3.75, 12)
+    // sliding sock clears the DEEP ANCHOR pocket — deep depth + fit + floor
+    // relief. A 9 mm bite reaches most of the way across the module, so the
+    // band beside it is what sizes the rear foot: 17.5 − 9.25 − 3.2 − 0.7 =
+    // 4.35, still over the 4 mm floor, and 1.6 mm of wall on both sides.
+    expect(sliding.sock).toBeCloseTo(9.25, 12)
+    expect(sliding.band).toBeCloseTo(4.35, 12)
+    expect(sliding.w).toBeCloseTo(4.35, 12)
+    expect(sliding.capped).toBe(true)
+    expect(sliding.fits).toBe(true)
+    expect(sliding.x).toBeCloseTo(13.375, 12)
+    expect(sliding.seat).toBeCloseTo(5.05, 12)
+    expect(sliding.x - sliding.seat / 2 - sliding.sock).toBeCloseTo(1.6, 12)
+    expect(
+      derived(p({ joint_type: 'sliding_dovetail' })).scW - sliding.x - sliding.seat / 2
+    ).toBeCloseTo(1.6, 12)
+    expect(sliding.walls).toBe(true)
     expect(seamFit(p()).verdicts.map((v) => v.code)).toEqual([
       'strain',
       'dove_walls',
@@ -387,10 +1075,12 @@ describe('seamFit', () => {
     ])
   })
 
-  it('sliding verdict table: no flexures, so no strain row — retention is physics instead', () => {
+  it('sliding verdict table: retention is physics, plus the detent’s own gates', () => {
     const fit = seamFit(p({ joint_type: 'sliding_dovetail' }))
     expect(fit.ok).toBe(true)
-    expect(fit.strainPct).toBe(0) // nothing bends in this topology
+    // the one flexure: the male tongue the notch is cut into, at the engagement
+    // it gives up to let the ridge past
+    expect(fit.strainPct).toBeCloseTo(0.685433, 5)
     expect(fit.verdicts.map((v) => v.code)).toEqual([
       'sliding_fit',
       'backing_wall',
@@ -398,11 +1088,31 @@ describe('seamFit', () => {
       'datum_lead',
       'deep_backing',
       'deep_lip',
+      'anchor_flanks',
+      'anchor_flats',
+      'anchor_lead_tip',
+      'anchor_lead_bearing',
+      'mouth_lip',
+      'detent_flanks',
+      'detent_rail',
+      'detent_pinch',
+      'detent_reach',
+      'detent_retract',
+      'detent_tip_land',
+      'detent_channel_rail',
+      'detent_channel_flanks',
+      'detent_strain',
+      'detent_push',
+      'detent_backlash',
+      'detent_skin',
+      'detent_slot',
+      'detent_slot_end',
       'retention',
       'module_feet',
       'feet_bumper',
       'feet_socket',
       'feet_crossbar',
+      'feet_front_band',
     ])
     const retention = fit.verdicts.find((v) => v.code === 'retention')
     expect(retention?.ok).toBe(true)
@@ -410,21 +1120,46 @@ describe('seamFit', () => {
     expect(retention?.message).toContain('self-holding')
   })
 
-  it('sliding rejects non-coupon fit, thin backing and a squeezed anchor ceiling', () => {
+  it('the deeper rail is paid for by the edge allowance: the backing wall is unmoved', () => {
+    // 2.5S + 1 − (2 + 0.1 + 0.15) is the same 2.5S − 1.25 a 1 mm rail had, so
+    // the sliding topology's minimum scale is exactly where it was: S ≥ 0.98.
+    const row = (S: number) =>
+      seamFit(p({ joint_type: 'sliding_dovetail', scale_factor: S })).verdicts.find(
+        (v) => v.code === 'backing_wall'
+      )
+    expect(row(1)?.message).toContain('1.25 mm backing wall')
+    expect(row(1)?.ok).toBe(true)
+    expect(row(0.98)?.ok).toBe(true)
+    expect(row(0.97)?.ok).toBe(false)
+  })
+
+  it('sliding rejects non-coupon fit, thin backing and an anchor the slab cannot hold', () => {
     expect(failing(p({ joint_type: 'sliding_dovetail', joint_fit: 0.13 }))).toContain('sliding_fit')
     expect(
       failing(p({ joint_type: 'sliding_dovetail', joint_fit: 0.1, scale_factor: 0.8 }))
     ).toContain('backing_wall')
-    // S=0.85: the deep anchor's TIGHT ceiling is the first Z casualty —
-    // 6.8 − (3.4 + 1.7 + 3.89·tan14°) = 0.73 < 1.2 — while the shallow runway
-    // lips still clear ((6.8 − 4.073)/2 = 1.36)
+    // The berth floor and the ceiling lip mirroring it are BOTH absolute, so
+    // deep_lip is scale-free now (1.8 − 0.1 = 1.7 ≥ 1.2 at every size) — what
+    // shrinking actually kills is the room between neck and floor.
     const at85 = failing(p({ joint_type: 'sliding_dovetail', joint_fit: 0.1, scale_factor: 0.85 }))
-    expect(at85).toContain('deep_lip')
-    expect(at85).not.toContain('z_lips')
-    // S=0.8: now the runway lips go too ((6.4 − 4.073)/2 = 1.16 < 1.2)
-    expect(
-      failing(p({ joint_type: 'sliding_dovetail', joint_fit: 0.1, scale_factor: 0.8 }))
-    ).toContain('z_lips')
+    expect(at85).not.toContain('deep_lip')
+    expect(at85).toContain('anchor_flanks') // 3.4 − 1.7 − 1.8 = −0.10 < 0.30
+    expect(at85).toContain('z_lips') // (6.8 − 4.5718)/2 = 1.11 < 1.2
+    // the gate opens just under S = 0.95 (4S − 3.5 ≥ 0.3), well below the
+    // backing wall's S ≥ 0.98, so it never fires alone on a buildable design
+    expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor: 0.96 }))).not.toContain(
+      'anchor_flanks'
+    )
+    // …and GROWING is bounded too, uniquely in this cluster: a taller slab puts
+    // the neck further above the absolute floor, so the flanks run longer before
+    // they clamp. Past S ≈ 1.374 they would reach the floor behind the tip, and
+    // the anchor is still what says so — the detent's own rows are all absolute
+    // knobs, so the window is exactly the one this topology had before the click.
+    expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor: 1.4 }))).toEqual([
+      'anchor_flats',
+    ])
+    expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor: 1.37 }))).toEqual([])
+    expect(failing(p({ joint_type: 'sliding_dovetail', scale_factor: 1.15 }))).toEqual([])
   })
 })
 

--- a/apps/web/src/components/create/abacus/abacus-model.ts
+++ b/apps/web/src/components/create/abacus/abacus-model.ts
@@ -266,10 +266,11 @@ export type Derived = {
   frameW: number
   outerD: number
   /** Mid-module width (the seam coupon's sc_w): bead + clearances + a full
-   *  edge web per side. Meaningful in modular mode; computed always. */
+   *  edge wall per side — a web, plus the sliding rail's edge allowance on that
+   *  topology. Meaningful in modular mode; computed always. */
   scW: number
   /** End-module width (scad mod_we): border + field margin + half its column's
-   *  channel + one full edge web. 2·modWe + (cols−2)·scW === frameW exactly in
+   *  channel + one full edge wall. 2·modWe + (cols−2)·scW === frameW exactly in
    *  modular mode — the identity the width tests pin. */
   modWe: number
 }
@@ -288,8 +289,13 @@ export const derived = (p: Params): Derived => {
   // couldn't capture beads), so each seam costs +web·S vs mono — the honest
   // price of modularity, paid here so every consumer (assembled width, the
   // shell classifier's bead-column matching, the panel's size delta) reads the
-  // same number. scad mirror: sc_wall / the module composition, not s_cp.
-  const sCp = sBd + 2 * cl + (p.seam_mode === 'modular' ? 2 : 1) * p.web * S
+  // same number. The sliding rail buys its depth with a further edgeAllowance
+  // per edge; like the scad's sc_wall that rides on joint_type alone, since a
+  // mono render has no seam face to widen. scad mirror: sc_wall / the module
+  // composition, not s_cp.
+  const seamEdge =
+    p.web * S + (p.joint_type === 'sliding_dovetail' ? SLIDING_DOVETAIL.edgeAllowance : 0)
+  const sCp = sBd + 2 * cl + (p.seam_mode === 'modular' ? 2 * seamEdge : p.web * S)
   const sEm = sShelf + cl + sBd / 2
   const sEp = sBl + p.print_gap
   const sElo = sShelf + cl + sBl / 2
@@ -315,8 +321,8 @@ export const derived = (p: Params): Derived => {
     chamf,
     frameW: fieldW + 2 * sBw,
     outerD: sFd + 2 * sBw,
-    scW: sBd + 2 * cl + 2 * p.web * S,
-    modWe: sBw + sEm + sBd / 2 + cl + p.web * S,
+    scW: sBd + 2 * cl + 2 * seamEdge,
+    modWe: sBw + sEm + sBd / 2 + cl + seamEdge,
   }
 }
 // OUTER dims: bead field (from cols) + the flush border band on each side.
@@ -1691,19 +1697,28 @@ export const SEAM = {
  * smallest at the blind front stop) and rides one continuous female groove
  * whose only tight sections are the three seated berths — every rail section
  * clears every female station it passes by ≥ step/2 per side until the final
- * keyLength of travel. The rear segment is the DEEP ANCHOR: deepDepth into the
- * neighbor, top flank the only hook (~1.75× the shallow hook, ~3.5× the flank
- * bearing area), a 45° skirt running to the BED below it and a bottom-open
- * female pocket — the seated anchor block fills the opening flush with both
- * bottoms. Retention is the seat itself: the berth-front pinch is a ~1.9°
- * travel-direction taper, far inside PLA's atan(µ)≈14° self-holding limit, so
- * the joint seats with a firm push and releases with a firm rearward tug.
- * No flexures — nothing to crack, and the insertion sweep is provably
- * collision-free at every offset (female depth is monotone non-decreasing
- * toward the mouth, and the rail only ever sits rearward of its seat). */
+ * keyLength of travel. Every profile is centered in the slab; nothing in this
+ * topology reaches the plate, so no part of the seam prints as a blade over a
+ * sliver. The rear segment is the DEEP ANCHOR: deepDepth into the neighbor,
+ * both flanks leaving the neck at angleDeg and then CLAMPED FLAT at deepFloor
+ * and its mirror — symmetric about mid-slab, landing on a solid berth floor,
+ * hooking on both lips with the per-side undercut the full-length teeth carry,
+ * and spending its depth on bearing area rather than lip. Retention is the seat
+ * itself: the berth-front pinch is a ~1.9° travel-direction taper, far inside
+ * PLA's atan(µ)≈14° self-holding limit, so the joint seats with a firm push and
+ * releases with a firm rearward tug — and a detent ridge makes that seat positive
+ * rather than frictional. ONE flexure, and it is not an added finger: the male's
+ * own front key, cut free as a tongue. The insertion sweep is collision-free at every
+ * offset except that one designed interference, which is checked as a deflection
+ * instead (female depth is monotone non-decreasing toward the mouth, and the rail
+ * only ever sits rearward of its seat). */
 export const SLIDING_DOVETAIL = {
   angleDeg: 14,
-  maleDepth: 1, // shallow rail X depth — capped by the channel webs
+  maleDepth: 2, // full-length rail X depth — capped by the channel webs, which
+  // edgeAllowance widens
+  edgeAllowance: 1, // extra solid on EACH sliding module seam edge (+2 mm of
+  // column spacing per assembled seam), spent entirely on tooth engagement: the
+  // groove keeps the same backing wall a 1 mm rail had
   neck: 2.8, // MID segment Z neck; sizes are neck ± step
   step: 0.6, // Z graduation between adjacent rail sizes
   minBackingWall: 1.2,
@@ -1714,16 +1729,94 @@ export const SLIDING_DOVETAIL = {
   pinchLength: 1.5, // … this much travel — the self-holding retention wedge
   floorRelief: 0.15, // runway floor relief past groove depth (loose travel)
   datumRelief: 0.2, // non-datum berth fronts stand off — ONE Y stop
+  leadOut: 0.6, // ramp AHEAD of a berth's front, out to the runway. funnel does
+  // this at a berth's REAR; nothing did it at the front, so the runway (cut
+  // floorRelief deeper) butted the berth (pinch tighter) and left a rearward
+  // facing ledge of floorRelief + pinch standing the berth's full height. Only
+  // the next size DOWN is ever at those stations, so the ramp costs no travel
   seatClear: 0.02, // CAD gap at the front stop (print swell closes it)
   mouthFlare: 0.6, // rear-mouth Z flare beyond the pass-through size
-  deepDepth: 3.5, // rear anchor X depth — bounded by the top lip over the
-  // anchor pocket ceiling, NOT by the channel webs: the anchor never leaves
+  deepDepth: 9, // rear anchor X depth — bounded by the NEIGHBOUR's rear foot
+  // pocket (sock + mfWall), NOT by the channel webs: the anchor never leaves
   // the solid back strip
-  deepFloor: 0.5, // thinnest printable female floor; below it the anchor
-  // pocket opens through the bottom face (both sides take the open branch at
-  // default frame_h = 8)
+  deepFloor: 1.8, // female berth floor under the anchor AND, mirrored about
+  // mid-slab, the ceiling lip over it — ONE knob for both, which is what makes
+  // the anchor symmetric. Nothing on the male sits below it, and the berth
+  // never opens through the underside
   mouthLength: 2.5, // deep rear mouth flare length
+  corner: 0.5, // anchor edge break — an inset in x/z hulled over the same run in
+  // Y, so every broken face (underside included) is at exactly 45°
+  anchorLead: 1.5, // B→anchor graduation run. The jump from a 2 mm rail to a
+  // 9 mm one is the largest single face on the part — 7 mm of x by
+  // (sFh − 2·deepFloor) of z, a cliff standing across the track — and at
+  // `corner` it was barely broken at all. Same 45° inset break, given enough run
+  // to BE the graduation instead of decorating it. Not the Y-blend the underside
+  // can't have: an inset hulled over its own run is 45° everywhere, floor
+  // included. Bounded by the z budget (the inset closes from floor AND ceiling,
+  // so twice the lead has to leave a tip land) and by anchor bearing (the ramp
+  // is inset for its whole run, so it bears on nothing)
   selfHoldMu: 0.25, // conservative PLA-on-PLA static friction lower bound
+  // The detent — the click. A ridge on the female MIDDLE berth's floor drops into
+  // a notch in the male's MIDDLE (B) section, at the mid-length of the track —
+  // NOT out at the module's front corner, where the tongue's free end would be a
+  // lever a thumb can reach and crack off, and never on the anchor (a spring
+  // there would make the anchor itself a lever). Mid-track costs the kinematic
+  // exclusivity a front-berth ridge got for free — rear entry means a female
+  // feature at f is swept by every male section ahead of f — so exclusivity is
+  // bought geometrically instead, by the relief channel below. The spring is the
+  // male side: a Z-through slot behind the rail turns the B key plus its backing
+  // skin into a cantilever tongue, so the female stays rigid and the ridge gets a
+  // flat, known berth floor to stand on.
+  detent: 0.15, // ridge engagement — how far the crest stands INSIDE the rail's
+  // tip face at seat, which is also the deflection the tongue takes to pass it.
+  // Bounded by TWO gates: the flexure's strain against the WHOLE tongue section
+  // (see leaf below — skin plus rail is ~11× the skin's own second moment), and
+  // the RETRACTION LIMIT, which is the non-obvious one. The female is the male
+  // profile translated jointFit in +x, so the rail can back out of its groove
+  // exactly jointFit before its own 14° flanks bottom on the groove's — refusing
+  // to come out radially is the whole job of a dovetail — and the tongue cannot
+  // deflect further than the rail it carries can retract. An insertion sweep is
+  // blind to that: it measures the ridge's volume, not whether the rail has
+  // anywhere to go
+  detentRelief: 0.07, // middle berth NECK opened over the detent window, TOTAL
+  // across both flanks (half per side). Converts to X retraction at
+  // 1/(2·tan(angle)) — 0.07 of neck is 0.14 of extra room. Floor depth and flank
+  // angle untouched, so neither the seat nor the undercut changes; it is purely
+  // the sideways slack the deflecting tongue needs. The MIDDLE berth deliberately:
+  // the front and anchor berths locate the module, so this is the one berth that
+  // can afford to give up a sliver of Z grip — itself an argument for mid-track
+  channelClear: 0.2, // relief channel half-width past the ridge, per side
+  channelAir: 0.25, // gap between the ridge crest and the channel floor — the
+  // margin every un-sprung section ahead of the tongue passes the ridge on. The
+  // channel runs down the CENTRE of the rail's tip face, nose → tongue tip, and
+  // is a tip-face feature only: the 14° flanks, which are what actually grip, are
+  // never cut, so the small section keeps its full undercut
+  detentLand: 0.6, // crest land in Y
+  detentHalfHeight: 0.9, // ridge half-height in Z — the notch grown from it has
+  // to stay off the rail's flanks at EVERY coupon fit, and 1.0 misses that gate
+  // at 0.12
+  detentOutDeg: 55, // front flank — the retention wall the male pulls out over
+  detentInDeg: 18, // rear flank — the insertion cam
+  detentSlop: 0.04, // flank-normal gap between ridge and notch at seat. NOT
+  // joint_fit: joint_fit is running clearance for a sliding fit and a detent does
+  // not run, it parks. Whatever is here is pure Y backlash before the retention
+  // flank bites (slop/sin(out)), so it is held to the seat's tolerance rather than
+  // the rail's — and it is still a real gap, so the click can never hold the seam
+  // off its blind front stop
+  springSlot: 0.8, // Z-THROUGH slot behind the rail that frees the tongue, and —
+  // turned 90° at the tongue's tip and driven out through the seam face — the gap
+  // that frees that tip. Both ends are inside the module now, so the slot is an L
+  // in plan with a rounded blind root; it cannot move in x or y to dodge anything
+  leafT: 1.2, // seam skin kept in front of the slot: the rail's backing, and the
+  // tongue's root section with it
+  springA: 11.25, // notch → root. The cantilever length, so the strain knob: ε
+  // goes as 1/a², k as 1/a³. Set so the root lands ON scB0 — the bar strip is the
+  // only solid the tongue can grow out of without a bead channel behind it to bow
+  // into, and the gate below holds it there
+  // Wood PLA's tensile modulus (MPa) and the conservative PLA-on-PLA static
+  // friction bound the seat taper is judged against. Strain does not need either;
+  // the assembly-force gate needs both, and the scad carries the same two.
+  modulusMPa: 2500,
 } as const
 
 export const SLIDING_FIT_VALUES = [0.1, 0.11, 0.12] as const
@@ -1741,9 +1834,12 @@ export const slidingDovetailDerived = (jointFit: number) => {
   // (the deep mouth's Z-flare is derived from the remaining lip budget in the
   // scad, so it can never open wider than the lip gate allows).
   const runwayOpening = c.neck + c.step + 2 * (c.maleDepth + 2 * jointFit + c.floorRelief) * tan
-  // The deep anchor's Z hook — its top flank's rise over deepDepth, the only
-  // pull-apart engagement (~1.75× the shallow hook, ~3.5× the bearing area).
-  const anchorHook = c.deepDepth * tan
+  // The berth floor left under the deep anchor, which is ALSO the ceiling lip
+  // over it — the profile is symmetric about mid-slab, so one number is both.
+  const anchorFloor = c.deepFloor - jointFit
+  // The deep mouth's Z-flare, spent out of that lip budget and capped at the
+  // shallow mouth's step + flare (scad: the zf clamp in slide_pockets).
+  const anchorMouthFlare = Math.min(c.step + c.mouthFlare, Math.max(0, anchorFloor - c.minLip))
   const runningClearance = jointFit * Math.sin(angleRad) // flank-normal, in-berth
   // A rail section passing any female station sized one graduation step up (per side).
   const passClearance = c.step / 2 + jointFit * tan
@@ -1751,6 +1847,7 @@ export const slidingDovetailDerived = (jointFit: number) => {
   const selfHoldLimitDeg = (Math.atan(c.selfHoldMu) * 180) / Math.PI
   return {
     angleRad,
+    tan,
     grooveDepth,
     deepestCut,
     deepPocketCut,
@@ -1758,11 +1855,351 @@ export const slidingDovetailDerived = (jointFit: number) => {
     head: headOf(c.neck),
     headL: headOf(c.neck + c.step),
     runwayOpening,
-    anchorHook,
+    anchorFloor,
+    anchorMouthFlare,
     runningClearance,
     passClearance,
     seatTaperDeg,
     selfHoldLimitDeg,
+  }
+}
+
+/** An XZ cross-section of the seam, in the scad's coordinates: x = depth into
+ *  the neighbour measured from the seam face, z = height off the build plate.
+ *  Vertices run counter-clockwise, the ordering the scad's prism_xz needs. */
+export type SeamProfile = [number, number][]
+
+/** The male rail's full-length cross-section (scad slide_profile): a trapezoid
+ *  centered on the slab, `neck` tall at the seam face, opening at angleDeg. */
+export const slideProfile = (
+  neck: number,
+  sFh: number,
+  depth: number = SLIDING_DOVETAIL.maleDepth
+): SeamProfile => {
+  const t = Math.tan((SLIDING_DOVETAIL.angleDeg * Math.PI) / 180)
+  const cz = sFh / 2
+  return [
+    [0, cz - neck / 2],
+    [depth, cz - neck / 2 - depth * t],
+    [depth, cz + neck / 2 + depth * t],
+    [0, cz + neck / 2],
+  ]
+}
+
+/** The deep anchor's male cross-section (scad slide_deep_profile): the same
+ *  trapezoid until each flank reaches deepFloor / its mirror, then CLAMPED flat
+ *  to the tip. Symmetric about mid-slab, so both lips hook and the per-side
+ *  undercut is fixed by the floor knob instead of growing with the bite.
+ *  `corner` breaks the two long tip edges. `inset` shrinks floor, cap and tip
+ *  while the seam root stays put — hulling an inset section `corner` behind a
+ *  full one is what breaks each END of the anchor at 45°, underside included —
+ *  and an inset deep enough to reach the neck leaves no flank to state. */
+export const slideDeepProfile = (
+  neck: number,
+  sFh: number,
+  inset = 0,
+  corner = SLIDING_DOVETAIL.corner
+): SeamProfile => {
+  const c = SLIDING_DOVETAIL
+  const t = Math.tan((c.angleDeg * Math.PI) / 180)
+  const cz = sFh / 2
+  const rb = cz - neck / 2
+  const rt = cz + neck / 2
+  const fl = c.deepFloor + inset
+  const cap = sFh - c.deepFloor - inset
+  const xb = Math.max(0, (rb - fl) / t)
+  const xt = Math.max(0, (cap - rt) / t)
+  const d = c.deepDepth - inset
+  const k = Math.min(corner, (d - Math.max(xb, xt)) / 2, (cap - fl) / 2)
+  return [
+    [0, rb],
+    ...(xb > 0 ? ([[xb, fl]] as SeamProfile) : []),
+    [d - k, fl],
+    [d, fl + k],
+    [d, cap - k],
+    [d - k, cap],
+    ...(xt > 0 ? ([[xt, cap]] as SeamProfile) : []),
+    [0, rt],
+  ]
+}
+
+/** The female berth containing it (scad slide_deep_groove_profile): the same
+ *  shape grown the file's way — flanks offset `fit` along +x (the uniform
+ *  fit·sin(angle) flank-normal gap), floor and ceiling offset `fit` along ∓z,
+ *  far wall pushed out by `xr`. `zflare` opens floor and ceiling — each with its
+ *  own root corner, so neither corner moves — by the same amount at the rear
+ *  mouth: it eases all four sides, which only became possible once the anchor
+ *  landed on a floor instead of on the bed. The berth keeps deepFloor − fit of
+ *  solid PLA underneath: the catch shelf, whose seam-edge lip hooks the male's
+ *  bottom flank. */
+export const slideDeepGrooveProfile = (
+  neck: number,
+  fit: number,
+  sFh: number,
+  xr = 0,
+  zflare = 0
+): SeamProfile => {
+  const c = SLIDING_DOVETAIL
+  const t = Math.tan((c.angleDeg * Math.PI) / 180)
+  const cz = sFh / 2
+  const d = c.deepDepth + fit + xr
+  const rb = cz - neck / 2 - zflare
+  const rt = cz + neck / 2 + zflare
+  const fl = c.deepFloor - fit - zflare
+  const cap = sFh - c.deepFloor + fit + zflare
+  return [
+    [-0.01, rb - (fit - 0.01) * t],
+    [(rb - fl) / t - fit, fl],
+    [d, fl],
+    [d, cap],
+    [(cap - rt) / t - fit, cap],
+    [-0.01, rt + (fit - 0.01) * t],
+  ]
+}
+
+/** The deep anchor's scale-dependent geometry — the only part of the sliding
+ *  identity that is not scale-free, because the neck and the berth floor are
+ *  absolute while the slab centerline is not. `flankRun` is where each flank
+ *  clamps flat; `flatLength` is what is left of the bite to bear on, and the
+ *  scad gates both (a slab tall enough to push flankRun past the tip would fold
+ *  the profile on itself). */
+export const slidingAnchorGeometry = (sFh: number) => {
+  const c = SLIDING_DOVETAIL
+  const t = Math.tan((c.angleDeg * Math.PI) / 180)
+  const neck = c.neck + c.step // the anchor is always the LARGE graduation
+  const rootBottom = sFh / 2 - neck / 2
+  const undercut = rootBottom - c.deepFloor // per side; == capPlane − rootTop
+  const flankRun = undercut / t
+  return {
+    neck,
+    centerZ: sFh / 2,
+    rootBottom,
+    rootTop: sFh / 2 + neck / 2,
+    floorPlane: c.deepFloor,
+    capPlane: sFh - c.deepFloor,
+    undercut,
+    flankRun,
+    flatLength: c.deepDepth - flankRun,
+  }
+}
+
+/** An XY plan polygon in the scad's coordinates: x = depth into the neighbour
+ *  measured from the seam face, y = along the seam from the module's front
+ *  face. Extruded in Z — the detent's wedges are plan shapes, where every
+ *  other seam profile in this file is a cross-section. */
+export type SeamPlan = [number, number][]
+
+/** The detent — the click, and the one flexure in this topology. The ridge sits
+ *  in the MIDDLE berth, at the mid-length of the track: a berth floor is the one
+ *  stretch of groove with a flat, known floor (the runway behind it is relieved
+ *  and the berth's own front is the seat pinch), so the proud height is a
+ *  constant, and mid-track keeps the tongue's free end buried ~48 mm from either
+ *  end of the module where nothing can reach it to snap it off.
+ *
+ *  Mid-track gives up the exclusivity a front-berth ridge got free from rear
+ *  entry — a female feature at f is swept by every male section ahead of f, and
+ *  mid-track that is most of the rail — so exclusivity is bought geometrically:
+ *  the RELIEF CHANNEL, a channelDepth-deep slot down the centre of the rail's TIP
+ *  FACE from the nose to the tongue's tip, wide enough to clear the ridge by
+ *  channelClear per side and deep enough to clear its crest by channelAir. Every
+ *  un-sprung section runs past the ridge on air; contact begins only when the
+ *  ridge reaches the tongue, a couple of millimetres before seat, so the click
+ *  still lands on the seat. Tip face only — the 14° flanks are never cut.
+ *
+ *  The spring is the MALE side. An L-shaped Z-through slot behind the rail frees
+ *  the B key and the leafT of skin backing it into one cantilever tongue: rooted
+ *  at the slot's blind end on the solid bar strip, free at the short leg that
+ *  cuts out through the seam face. Its bending SECTION is the whole tongue — skin
+ *  AND the rail's own trapezoid, which is welded to it along the entire free
+ *  length and carries ~11× the skin's second moment. Counting the skin alone is
+ *  the same class of error as counting the female's backing strip without its
+ *  groove lips, in the other direction. Strain is one gate; force is the second,
+ *  because a click nobody can push home is as dead as one that cracks; the
+ *  RETRACTION LIMIT (see detent/detentRelief) is the third, and it binds on the
+ *  free TIP, which overswings the notch because a cantilever is straight past its
+ *  load. All use the RIGID-ROOT cantilever: the wall the tongue roots into does
+ *  rotate, making the real spring ~14% softer, and overstating both stiffness and
+ *  strain is the safe direction. */
+export const slidingDetentGeometry = (p: Params) => {
+  const c = SLIDING_DOVETAIL
+  const b = seamBands(p)
+  const g = slidingDovetailDerived(p.joint_fit)
+  const rad = (deg: number) => (deg * Math.PI) / 180
+  const tanOut = Math.tan(rad(c.detentOutDeg))
+  const tanIn = Math.tan(rad(c.detentInDeg))
+  const cz = b.sFh / 2
+  const k0S = b.d.chamf + 1 + c.seatClear // rail front datum
+  const k0M = b.d.outerD / 2 - c.keyLength / 2 // A→B graduation
+  const midY0 = k0M - c.datumRelief // the MIDDLE berth's front …
+  const midY1 = k0M + c.keyLength + 0.3 // … and its rear
+  const berthY1 = midY1 // the berth the ridge lives in
+  const yc = k0M + c.keyLength / 2 // crest centre = the berth's mid-length,
+  // which on this module lands on outerD / 2 exactly: the middle of the track
+  const y0 = yc - c.detentLand / 2 // crest land [y0, y1]
+  const y1 = yc + c.detentLand / 2
+  const proud = p.joint_fit + c.detent // over the BERTH floor
+  const y00 = y0 - proud / tanOut // front toe, on the berth floor
+  const yr = y1 + proud / tanIn
+  // The tongue's tip, and with it the relief channel's rear end: the slot's short
+  // leg goes at the forward-most station that does NOT cut the middle berth's
+  // seat pinch. One station splits rail from tongue — everything ahead of it is
+  // un-sprung rail that must pass the ridge on air, everything behind it flexes.
+  const channelY1 = midY0 + c.pinchLength
+  const springY0 = channelY1 + c.springSlot
+  const springA = c.springA // notch → the slot's blind root
+  const springY1 = yc + springA
+  const channelDepth = c.detent + c.channelAir // into the rail's tip face
+  const channelWidth = 2 * (c.detentHalfHeight + c.channelClear) // … and in Z
+  const floorX = g.grooveDepth // berth floor the ridge grows from
+  const crestX = c.maleDepth - c.detent // crest, inside the rail's tip face
+  const notchFloorX = crestX - p.joint_fit // rail left behind the notch
+  // The retraction limit. Past its load a cantilever is straight, so the free tip
+  // overswings the notch by 1.5·b/a and the TIP is what binds. Against it: the
+  // jointFit the dovetail leaves before its 14° flanks bottom, plus what the
+  // berth's neck relief converts to, at 1/(2·tan(angle)) per unit of neck.
+  const tipOver = yc - springY0 // load → free tip
+  const tipDefl = c.detent * (1 + (1.5 * tipOver) / springA)
+  const retractRoom = p.joint_fit + c.detentRelief / (2 * g.tan)
+  // The tongue's section, in x measured from the slot's inner face: the skin is a
+  // rectangle at full slab height, the rail is the B trapezoid (neck at the seam
+  // face, head at the tip). Moments are accumulated about x = 0 and shifted to
+  // the centroid once, so no piece needs its own parallel-axis term.
+  const wall = p.web * p.scale_factor + c.edgeAllowance
+  const backing = wall - g.deepestCut // the FEMALE's post-groove wall, reported only
+  const neckB = c.neck // the tongue carries the MIDDLE section now, not the small
+  const headB = neckB + 2 * c.maleDepth * Math.tan(g.angleRad)
+  const railArea = (c.maleDepth * (neckB + headB)) / 2
+  const leafA = c.leafT * b.sFh + railArea
+  const leafQ =
+    (b.sFh * c.leafT ** 2) / 2 + c.leafT * railArea + c.maleDepth ** 2 * (neckB / 6 + headB / 3)
+  const leafJ =
+    (b.sFh * c.leafT ** 3) / 3 +
+    c.leafT ** 2 * railArea +
+    2 * c.leafT * c.maleDepth ** 2 * (neckB / 6 + headB / 3) +
+    c.maleDepth ** 3 * (neckB / 12 + headB / 4)
+  const leafX = leafQ / leafA // centroid depth
+  const inertia = leafJ - leafA * leafX ** 2
+  const leafC = Math.max(leafX, c.leafT + c.maleDepth - leafX) // outer fibre
+  // Cantilever, loaded at the notch: δ = F·a³/(3EI) and M = F·a at the root, so
+  // ε = M·c/(EI) drops E and I alike and the gate is 3·δ·c/a² (×100 for %).
+  const strainPct = (300 * c.detent * leafC) / springA ** 2
+  const stiffnessN = (3 * c.modulusMPa * inertia) / springA ** 3 // N/mm
+  const forceN = stiffnessN * c.detent
+  // Axial force at a flank: the spring load through a wedge of that angle to
+  // the travel, with PLA's friction taken at the same conservative µ the seat
+  // taper is judged against. Rearward (18°) is the insertion cam; forward (55°)
+  // is the wall a pull has to climb.
+  const cam = (deg: number) =>
+    (forceN * (Math.tan(rad(deg)) + c.selfHoldMu)) / (1 - c.selfHoldMu * Math.tan(rad(deg)))
+  return {
+    k0S,
+    k0M,
+    midY0,
+    midY1,
+    y0: y00,
+    crest0: y0,
+    crest1: y1,
+    rearToe: yr,
+    crestY: yc,
+    proud,
+    floorX,
+    crestX,
+    notchFloorX,
+    berthY1,
+    springA,
+    springY0,
+    springY1,
+    channelY1,
+    channelDepth,
+    channelWidth,
+    tipOver,
+    tipDefl,
+    retractRoom,
+    backing,
+    leafA,
+    leafX,
+    leafC,
+    inertia,
+    strainPct,
+    stiffnessN,
+    forceN,
+    seatForceN: cam(c.detentInDeg),
+    partForceN: cam(c.detentOutDeg),
+    /** Y free travel at seat before a flank bears: a y-shift of s closes a
+     *  flank-normal gap by s·sin(flank). Forward is the blind stop's business,
+     *  so the retention (out) flank's number is the click's backlash. */
+    backlashOut: c.detentSlop / Math.sin(rad(c.detentOutDeg)),
+    backlashIn: c.detentSlop / Math.sin(rad(c.detentInDeg)),
+    /** the female wedge, standing off the berth floor. `fit` is the SAMPLE's, so
+     *  a coupon plate's other fits can never leave the ridge floating over a
+     *  floor cut somewhere else — the crest land stays pinned to the berth's
+     *  mid-length and only the toes move with the floor. */
+    ridge: (fit = p.joint_fit): SeamPlan => {
+      const xf = c.maleDepth + fit
+      const pr = xf - crestX
+      return [
+        [xf, y0 - pr / tanOut],
+        [crestX, y0],
+        [crestX, y1],
+        [xf, y1 + pr / tanIn],
+      ]
+    },
+    /** the male wedge: the ridge's two flank LINES, each stepped back detentSlop
+     *  along its own normal, plus a `fit` of depth at the floor and of half-height
+     *  in Z. The flanks are stated where the ridge's cross the rail's TIP face —
+     *  the surface the notch is cut into. Read them off the ridge's toes on the
+     *  groove floor instead and every flank gains (floor − tip)·cos(flank) it
+     *  never asked for, which is backlash: the seam still seats on its blind front
+     *  stop, but the click is loose against a pull by that much before it bites. */
+    notch: (fit = p.joint_fit): SeamPlan => {
+      const xt = c.maleDepth + 0.01
+      const xc = crestX - fit
+      const yf = y0 - c.detent / tanOut - c.detentSlop / Math.sin(rad(c.detentOutDeg))
+      const yb = y1 + c.detent / tanIn + c.detentSlop / Math.sin(rad(c.detentInDeg))
+      const front = (x: number) => yf - (x - c.maleDepth) / tanOut
+      const rear = (x: number) => yb + (x - c.maleDepth) / tanIn
+      return [
+        [xt, front(xt)],
+        [xc, front(xc)],
+        [xc, rear(xc)],
+        [xt, rear(xt)],
+      ]
+    },
+    ridgeZ: [cz - c.detentHalfHeight, cz + c.detentHalfHeight] as [number, number],
+    notchZ: [cz - c.detentHalfHeight - p.joint_fit, cz + c.detentHalfHeight + p.joint_fit] as [
+      number,
+      number,
+    ],
+    /** the L-shaped slot that frees the tongue (scad slide_spring_slot_cut), in
+     *  the module's own x from its LEFT face. The LONG leg sits behind the seam
+     *  skin on the male (right) edge and runs [channelY1, springY1], blind at both
+     *  ends — the rounded root is the tongue's; the SHORT leg is the same width of
+     *  Y turned 90° at channelY1 and driven out through the seam face, which is
+     *  what frees the tongue's TIP. Both ends are inside the module, so nothing
+     *  about this slot reaches an outer face in plan. Z-through — it opens the top
+     *  face as well as the bottom. */
+    slot: {
+      x0: b.d.scW - c.leafT - c.springSlot,
+      w: c.springSlot,
+      y0: channelY1,
+      y1: springY1,
+      /** the short leg: [tipY0, tipY1] in Y, out through the seam face in x */
+      tipY0: channelY1,
+      tipY1: springY0,
+    },
+    /** the relief channel (scad slide_relief_channel), the feature that buys back
+     *  the exclusivity mid-track gave up: a groove down the CENTRE of the rail's
+     *  TIP FACE, from the nose to the tongue's tip, that every un-sprung section
+     *  passes the ridge inside. Stated as the cut, in the rail's own x (depth from
+     *  the seam face) and z about mid-slab. Tip face only — it stops channelDepth
+     *  short of the flanks, so the 14° grip surfaces are untouched. */
+    channel: {
+      x0: c.maleDepth - channelDepth,
+      d: channelDepth,
+      y0: k0S,
+      y1: springY0,
+      z: [cz - channelWidth / 2, cz + channelWidth / 2] as [number, number],
+    },
   }
 }
 
@@ -1797,8 +2234,20 @@ export type ModuleFeetLayout = {
   w: number
   mouth: number
   seat: number
-  /** pocket center X in module-local coords — centered in the band beside the socket */
+  /** REAR pocket center X in module-local coords — centered in the band beside
+   *  the socket (the socket is the rear anchor berth, a rear-strip feature) */
   x: number
+  /** FRONT pocket center X — the rear's again. It was not, when the tongue was a
+   *  front-corner cantilever: the spring slot ran out through the module's FRONT
+   *  face, straight past this pocket, so the front foot had to be squeezed into
+   *  its own band between the groove's deepest cut and the slot's inner face. The
+   *  tongue is mid-track now, forty-odd millimetres behind the front foot, so the
+   *  front strip's only obstruction is the groove again. */
+  xFront: number
+  /** that band's bounds, kept because the slot verdict still reads them: a scale
+   *  that couldn't fit the band couldn't fit this pocket either */
+  frontLo: number
+  frontHi: number
   /** deepest seam-socket cut into module X (tab + fit + deepening) */
   sock: number
   /** the free width beside the socket a mid-module pocket can occupy */
@@ -1834,6 +2283,11 @@ export function moduleFeetLayout(p: Params): ModuleFeetLayout {
   const mouth = w + 2 * fitEff
   const seat = mouth + 2 * undercutEff
   const x = (sock + d.scW) / 2
+  const g = slidingDovetailDerived(p.joint_fit)
+  const frontLo = g.deepestCut + SEAM.mfWall + seat / 2
+  const frontHi =
+    d.scW - SLIDING_DOVETAIL.leafT - SLIDING_DOVETAIL.springSlot - SEAM.mfWall - seat / 2
+  const xFront = x // scad mf_x_front — see the type's note
   const bumperFits = printed || p.feet_w <= band
   let minScale: number | null = null
   if (!bumperFits && p.feet_w <= bandAt(4)) {
@@ -1851,6 +2305,9 @@ export function moduleFeetLayout(p: Params): ModuleFeetLayout {
     mouth,
     seat,
     x,
+    xFront,
+    frontLo,
+    frontHi,
     sock,
     band,
     fits: w >= 4,
@@ -1871,9 +2328,9 @@ export function moduleFeetPositions(p: Params, kind: 'left' | 'mid' | 'right'): 
   const { c } = feetEffective(p)
   const D = d.outerD
   if (kind === 'mid') {
-    const { x } = moduleFeetLayout(p)
+    const { x, xFront } = moduleFeetLayout(p)
     return [
-      [x, c],
+      [xFront, c],
       [x, D - c],
     ]
   }
@@ -1905,6 +2362,26 @@ export type SeamVerdict = {
     | 'datum_lead'
     | 'deep_backing'
     | 'deep_lip'
+    | 'anchor_flanks'
+    | 'anchor_flats'
+    | 'anchor_lead_tip'
+    | 'anchor_lead_bearing'
+    | 'mouth_lip'
+    | 'detent_flanks'
+    | 'detent_rail'
+    | 'detent_reach'
+    | 'detent_pinch'
+    | 'detent_retract'
+    | 'detent_tip_land'
+    | 'detent_channel_rail'
+    | 'detent_channel_flanks'
+    | 'detent_strain'
+    | 'detent_push'
+    | 'detent_backlash'
+    | 'detent_skin'
+    | 'detent_slot'
+    | 'detent_slot_end'
+    | 'feet_front_band'
     | 'retention'
   ok: boolean
   message: string
@@ -1916,8 +2393,9 @@ export type SeamFit = {
   verdicts: SeamVerdict[]
   /** wood-PLA peak outer-fibre strain at worst intended engagement, in % —
    *  the number the flexure gate compares against wood PLA's ~1.5% break
-   *  strain with 1.5× safety (so the gate line is 1.0). Knob-only: it cannot
-   *  change from the studio, but the panel shows it as provenance. */
+   *  strain with 1.5× safety (so the gate line is 1.0). The snap clip's is
+   *  knob-only; the sliding detent's rides scale_factor and joint_fit, because
+   *  its leaf is the module's own channel wall rather than a printed finger. */
   strainPct: number
 }
 
@@ -1995,11 +2473,15 @@ function slidingSeamFit(p: Params): SeamFit {
   const mf = moduleFeetLayout(p)
   const g = slidingDovetailDerived(p.joint_fit)
   const c = SLIDING_DOVETAIL
-  const tanA = Math.tan(g.angleRad)
+  const a = slidingAnchorGeometry(b.sFh)
+  const dt = slidingDetentGeometry(p)
   const feetOn = p.feet_mode !== 'none'
   const crossbar = feetEffective(p).crossbar
   const legalFit = SLIDING_FIT_VALUES.some((fit) => Math.abs(fit - p.joint_fit) < 1e-9)
-  const backingWall = p.web * p.scale_factor - g.deepestCut
+  // scad sc_wall: the solid a modular edge carries, groove and slot both cut
+  // from it.
+  const seamWall = p.web * p.scale_factor + c.edgeAllowance
+  const backingWall = seamWall - g.deepestCut
   const lip = (b.sFh - g.runwayOpening) / 2
   // The scad's Y stations, in the same names (slide_k0_s … slide_mouth0):
   // rail front datum, A→B graduation, shallow→deep taper start, deep mouth.
@@ -2007,21 +2489,23 @@ function slidingSeamFit(p: Params): SeamFit {
   const k0S = chamf + 1 + c.seatClear
   const k0M = outerD / 2 - c.keyLength / 2
   const taper0 = b.scK0 + 0.3
+  const anchor0 = taper0 + c.funnel + c.datumRelief
   const mouth0 = outerD - c.mouthLength
-  // Mirror of the scad berth-layout assert: S berth + funnel clear the mid
-  // berth, mid berth + funnel clear the taper start, and taper + funnel +
-  // pinch clear the deep mouth, each with slack.
+  // Mirror of the scad berth-layout assert: S berth + funnel + lead-out clear
+  // the mid berth, mid berth + funnel clear the taper start, and taper + funnel
+  // + pinch clear the deep mouth, each with slack.
   const layoutOk =
-    k0S + c.keyLength + 0.3 + c.funnel + 1 <= k0M - c.datumRelief &&
+    k0S + c.keyLength + 0.3 + c.funnel + c.leadOut + 1 <= k0M - c.datumRelief &&
     k0M + c.keyLength + 0.3 + c.funnel + 1 <= taper0 &&
     taper0 + c.funnel + c.pinchLength + 2 <= mouth0
-  // Deep-anchor gates at the WORST legal fit, exactly as the scad hardcodes
-  // 0.12 — the anchor must clear at any coupon-calibrated compensation.
+  // The pocket-vs-own-rail gate runs at the WORST legal fit, exactly as the
+  // scad hardcodes 0.12 — that cut must clear at any coupon-calibrated
+  // compensation. The lip gate reads the actual fit, like its scad assert: the
+  // ceiling is the mirrored berth floor, so it is scale-free and the fit is the
+  // only thing that eats it.
   const worstFit = Math.max(...SLIDING_FIT_VALUES)
   const deepBacking = scW - (c.deepDepth + worstFit + c.floorRelief)
-  const deepLip =
-    b.sFh -
-    (b.sFh / 2 + (c.neck + c.step) / 2 + (c.deepDepth + 2 * worstFit + c.floorRelief) * tanA)
+  const deepLip = g.anchorFloor
   const verdicts: SeamVerdict[] = [
     {
       code: 'sliding_fit',
@@ -2058,13 +2542,146 @@ function slidingSeamFit(p: Params): SeamFit {
     {
       code: 'deep_lip',
       ok: deepLip >= c.minLip,
-      message: `deep anchor pocket ceiling leaves ${deepLip.toFixed(2)} mm top lip`,
+      message: `deep anchor berth floor — and the ceiling lip mirroring it — is ${deepLip.toFixed(2)} mm`,
+      knob: 'joint_fit',
+    },
+    {
+      code: 'anchor_flanks',
+      ok: a.undercut >= 0.3,
+      message: `deep anchor hooks ${a.undercut.toFixed(2)} mm per side between neck and berth floor (minimum 0.30 mm)`,
+      knob: 'scale_factor',
+    },
+    {
+      code: 'anchor_flats',
+      ok: a.flatLength >= 1,
+      message: `deep anchor flanks clamp flat ${a.flatLength.toFixed(2)} mm before the tip (minimum 1 mm) — a taller slab needs a shallower bite`,
+      knob: 'scale_factor',
+    },
+    {
+      code: 'anchor_lead_tip',
+      ok: b.sFh - 2 * (c.deepFloor + c.anchorLead) >= 0.4,
+      message: `B→anchor ramp closes to a ${(b.sFh - 2 * (c.deepFloor + c.anchorLead)).toFixed(2)} mm tip land (minimum 0.40 mm) — the inset eats the anchor from floor and ceiling at once`,
+      knob: 'scale_factor',
+    },
+    {
+      code: 'anchor_lead_bearing',
+      ok: outerD - c.corner - (anchor0 + c.anchorLead) >= 6,
+      message: `B→anchor ramp leaves ${(outerD - c.corner - (anchor0 + c.anchorLead)).toFixed(2)} mm of full-section anchor bearing (minimum 6 mm)`,
+      knob: 'scale_factor',
+    },
+    {
+      code: 'mouth_lip',
+      ok: c.deepFloor - p.joint_fit - c.minLip >= 0,
+      message: `deep mouth has ${(c.deepFloor - p.joint_fit - c.minLip).toFixed(2)} mm of flare budget over the berth floor lip`,
+      knob: 'joint_fit',
+    },
+    {
+      code: 'detent_flanks',
+      ok:
+        c.detentHalfHeight + p.joint_fit + 0.3 <=
+        c.neck / 2 + dt.notchFloorX * Math.tan(g.angleRad),
+      message:
+        'detent notch would cut the rail flanks — the dovetail’s grip is what it must not touch',
+      knob: 'joint_fit',
+    },
+    {
+      code: 'detent_rail',
+      ok: dt.notchFloorX >= 1.2,
+      message: `detent notch leaves ${dt.notchFloorX.toFixed(2)} mm of rail depth behind it (minimum 1.2 mm)`,
+      knob: 'joint_fit',
+    },
+    {
+      code: 'detent_pinch',
+      ok: dt.y0 >= dt.midY0 + c.pinchLength,
+      message: 'detent ridge starts on the berth’s seat pinch, not on its floor',
+      knob: 'scale_factor',
+    },
+    {
+      code: 'detent_reach',
+      ok: dt.rearToe <= dt.berthY1,
+      message: `detent ridge ends ${(dt.berthY1 - dt.rearToe).toFixed(2)} mm inside the middle berth — past it it would stand on relieved runway`,
+      knob: 'scale_factor',
+    },
+    {
+      // The gate an insertion sweep is blind to: it measures the ridge's volume,
+      // not whether the rail carrying the tongue has anywhere to retract to.
+      code: 'detent_retract',
+      ok: dt.tipDefl <= dt.retractRoom,
+      message: `tongue’s tip swings ${dt.tipDefl.toFixed(3)} mm into the ${dt.retractRoom.toFixed(3)} mm the dovetail leaves it — past that the 14° flanks bottom out and the click stops being a flexure`,
+      knob: 'joint_fit',
+    },
+    {
+      code: 'detent_tip_land',
+      ok: dt.springY0 < dt.y0,
+      message: `tongue’s tip gap leaves ${(dt.y0 - dt.springY0).toFixed(2)} mm of land in front of the notch`,
+      knob: 'scale_factor',
+    },
+    {
+      code: 'detent_channel_rail',
+      ok: dt.channelDepth + 1.2 <= c.maleDepth,
+      message: `relief channel leaves ${(c.maleDepth - dt.channelDepth).toFixed(2)} mm of rail behind it (minimum 1.2 mm)`,
+      knob: 'none',
+    },
+    {
+      code: 'detent_channel_flanks',
+      ok:
+        dt.channelWidth / 2 + 0.3 <=
+        (c.neck - c.step) / 2 + (c.maleDepth - dt.channelDepth) * Math.tan(g.angleRad),
+      message:
+        'relief channel would cut the small section’s flanks — it is a tip-face feature, and the 14° flanks are what grip',
+      knob: 'none',
+    },
+    {
+      code: 'detent_strain',
+      ok: dt.strainPct <= 1.0,
+      message:
+        dt.strainPct <= 1.0
+          ? `detent strain ${dt.strainPct.toFixed(2)}% — safe for wood PLA (gate 1.0%)`
+          : `detent strain ${dt.strainPct.toFixed(2)}% would crack wood PLA`,
+      knob: 'scale_factor',
+    },
+    {
+      code: 'detent_push',
+      ok: dt.seatForceN <= 15,
+      message: `detent needs ${dt.seatForceN.toFixed(1)} N along the seam to push home (hand limit 15 N)`,
+      knob: 'scale_factor',
+    },
+    {
+      code: 'detent_backlash',
+      ok: dt.backlashOut <= 0.05,
+      message: `detent has ${dt.backlashOut.toFixed(3)} mm of free travel before the retention flank bites (limit 0.05 mm)`,
+      knob: 'none',
+    },
+    {
+      code: 'detent_skin',
+      ok: c.leafT >= c.minBackingWall,
+      message: `spring slot leaves the rail ${c.leafT.toFixed(2)} mm of backing skin (minimum ${c.minBackingWall})`,
+      knob: 'none',
+    },
+    {
+      code: 'detent_slot',
+      ok: c.leafT + c.springSlot <= seamWall - c.minBackingWall,
+      message: `spring slot leaves ${(seamWall - c.leafT - c.springSlot).toFixed(2)} mm of wall in front of the bead channel (minimum ${c.minBackingWall})`,
+      knob: 'scale_factor',
+    },
+    {
+      // The root has to land ON the bar strip: it is the only solid the tongue can
+      // grow out of with no bead channel behind it to bow into. Past scB0 the slot
+      // runs THROUGH that strip; short of scF1 the root is still in the front one.
+      code: 'detent_slot_end',
+      ok: dt.springY1 <= b.scB0 && dt.springY1 >= b.scF1,
+      message:
+        dt.springY1 > b.scB0
+          ? `spring slot runs ${(dt.springY1 - b.scB0).toFixed(1)} mm through the bar strip the tongue is meant to root in`
+          : dt.springY1 < b.scF1
+            ? 'spring slot’s root is still in the front strip — the tongue is not rooted where it thinks it is'
+            : `spring slot roots ${(b.scB0 - dt.springY1).toFixed(1)} mm inside the bar strip`,
       knob: 'scale_factor',
     },
     {
       code: 'retention',
       ok: g.seatTaperDeg <= g.selfHoldLimitDeg,
-      message: `seat taper ${g.seatTaperDeg.toFixed(1)}° is self-holding (PLA µ ≥ ${c.selfHoldMu} → limit ${g.selfHoldLimitDeg.toFixed(0)}°)`,
+      message: `seat taper ${g.seatTaperDeg.toFixed(1)}° is self-holding (PLA µ ≥ ${c.selfHoldMu} → limit ${g.selfHoldLimitDeg.toFixed(0)}°), and the detent adds a ${dt.partForceN.toFixed(0)} N wall to climb`,
       knob: 'none',
     },
     {
@@ -2091,10 +2708,16 @@ function slidingSeamFit(p: Params): SeamFit {
       message: 'module foot crossbar would break into the bead channel',
       knob: 'feet_w',
     },
+    {
+      code: 'feet_front_band',
+      ok: !feetOn || mf.frontHi - mf.frontLo >= 1.5,
+      message: `front module foot has ${(mf.frontHi - mf.frontLo).toFixed(2)} mm of band between the sliding groove and the spring slot (minimum 1.5 mm)`,
+      knob: 'scale_factor',
+    },
   ]
-  // No flexures in this topology — nothing bends, so peak strain is 0. The
-  // panel's strain provenance line branches on topology instead.
-  return { ok: verdicts.every((v) => v.ok), verdicts, strainPct: 0 }
+  // The one flexure: the tongue the detent notch rides on, at the engagement it
+  // has to give up to let the ridge pass.
+  return { ok: verdicts.every((v) => v.ok), verdicts, strainPct: dt.strainPct }
 }
 
 /** Topology dispatcher. The legacy branch is intentionally isolated above so its

--- a/apps/web/src/components/create/abacus/abacus-module-kit.ts
+++ b/apps/web/src/components/create/abacus/abacus-module-kit.ts
@@ -452,19 +452,30 @@ graduated dovetail rail that enters through the REAR face: align the new
 module behind its neighbor, drop the rail into the rear entry mouth, and
 slide it forward on the table. The rail runs loose for almost the whole
 travel and only engages over roughly the last centimeter, so there is no
-full-length scraping. Its rear end is a deep anchor block that reaches
-3.5 mm into the neighbor and hooks the pull-apart direction; the anchor
-pocket opens through the bottom face and the seated block fills that
-opening flush, so keep both modules flat on the table while sliding —
-the table is the height datum. Push firmly until the module stops against
-the blind front seat and the seam shoulders close — the tapered seat is
-self-holding, like a lightly set Morse taper. There is no clip and nothing
-to click.
+full-length scraping. Its rear end is a deep anchor block that bites
+9 mm into the neighbor — more than half way across its underside — and
+hooks the pull-apart direction on BOTH lips: the anchor is symmetric top
+to bottom, and it rides on a solid 1.7 mm berth floor rather than on the
+table, so no seam surface opens through the bottom face. Keep both
+modules flat on the table while sliding. Push firmly until the module
+stops against the blind front seat and the seam shoulders close — the
+tapered seat is self-holding, like a lightly set Morse taper. Over the
+last few millimeters the rail climbs a ridge on the berth floor and the
+push gets noticeably firmer; the ridge drops into a notch with a click as
+the seat is reached. That click is the seated signal: if it has not
+happened, the module is not home. There is no separate clip — a slot
+behind the middle of the rail makes that stretch of rail its own spring,
+so it is the module you are pushing that flexes, not the one already in
+the row.
 
-To remove a module, grip it and give it a firm rearward tug to break the
-taper, then slide it out the back. A middle module cannot lift straight out;
-unzip the row from either end until the module is exposed. Do not pry the
-dovetail apart.`
+Each sliding seam adds 2 mm of assembled width — that is what pays for a
+2 mm-deep rail — so a sliding row is wider than the same abacus in
+vertical-snap modules. The bead channels are untouched.
+
+To remove a module, grip it and give it a firm rearward tug — enough to
+lift the detent out of its notch and break the taper — then slide it out
+the back. A middle module cannot lift straight out; unzip the row from
+either end until the module is exposed. Do not pry the dovetail apart.`
   }
   return `Modules join left to right. The two vertical dovetails (front and back
 edges) carry the pull-apart load, and the two-prong clip at the crossbar
@@ -478,11 +489,13 @@ function couponNote(p: Params): string {
     return `Before printing the whole kit, print the bounded sliding-dovetail coupon
 plate from the studio. It contains mechanically representative 0.10, 0.11,
 and 0.12 mm compensation samples. Slide pairs together from the rear mouth:
-reject a sample if it binds before reaching the front stop or cannot be
-released with a firm rearward tug. Among the remainder, choose the
-loosest-running sample with no perceptible seated X/Z/rocking play, set
-joint fit to that value, and regenerate the kit. The outer filename records
-both the sliding-dovetail topology and selected fit.`
+reject a sample if it binds before the detent ridge, never clicks into the
+notch at the front stop, or cannot be released with a firm rearward tug.
+The last stretch is MEANT to be firm — that is the ridge, not a bad fit.
+Among the remainder, choose the loosest-running sample with no perceptible
+seated X/Z/rocking play, set joint fit to that value, and regenerate the
+kit. The outer filename records both the sliding-dovetail topology and
+selected fit.`
   }
   return `Before printing the whole kit, print the vertical-snap seam coupon pair
 from the studio and walk joint_fit in 0.05 mm steps: looser (+) if the click


### PR DESCRIPTION
The rear-entry rail was a 1 mm-deep dovetail with a 3.5 mm anchor sitting on the table, held only by a self-holding taper. This makes it a real joint, and fixes a zero-width wall the studio was drawing across the anchor berth.

This is `04eef4fbb` from `create-hub-artifact-gallery`, replayed onto current `main`. Everything else on that branch already landed via #171 and #172; this commit is the only thing left on it.

## Geometry

- `slide_depth` 1.0 → 2.0, paid for by a new `slide_edge_allow` of 1 mm on each mating seam edge. Each sliding seam now costs 2 mm of assembled width; the panel and the kit README say so. Bead channels untouched.
- `slide_deep_depth` 3.5 → 9.0 on a solid 1.8 mm berth floor. The anchor is symmetric top to bottom so it hooks **both** lips, and nothing opens through the bottom face any more — the table is no longer part of the joint.
- A detent: a ridge on the berth floor that the rail climbs over the last few millimetres and drops into a notch with an audible click, so "seated" is a signal instead of a guess. The rail is its own spring — a Z-through slot behind its middle stretch makes that run a buried tongue — so the module being pushed flexes, never the one already in the row. Detent strain 0.69% against the 1.0% wood-PLA gate.
- `slide_corner`, `slide_lead_out` and `slide_anchor_lead` break the three worst faces. The B→anchor step was the largest single face on the part — 7 mm of x by the full rail height, a cliff standing across the track — and `slide_anchor_lead` runs the same 45° inset break out far enough to *be* the graduation.

## The zero-width wall

The taper hull ended at exactly `slide_taper0 + slide_funnel` and the deep zone began at exactly the same station — the one zero-overlap abutment in the seam. CGAL welds an exact abutment; Manifold keeps the shared face, and a coincident face inside a void is a sheet of zero width standing across the cavity. The studio drew a wall between the anchor berth and the runway; every CGAL-rendered STL of the same source was clean.

Giving the junction the file's standard 0.01 overlap removes it, with the solid geometry unchanged (mono fingerprint: same solid).

**The harness could not have caught this.** The `openscad` CLI here is 2021.01/CGAL; the shipped viewer is `public/openscad/openscad.wasm`, 2025.03.25, run with `--backend=Manifold`. `scripts/scad/README.md` now documents the split, the always-overlap-never-abut rule it implies, and how to render and audit through the engine that actually ships.

## Verification

- **Manifold** — `module_mid` at fits 0.10 / 0.11 / 0.12, plus `module_left`, `module_right` and the assembled row: 0 coincident sheets, 0 boundary edges, 0 non-manifold edges, 0 flipped pairs.
- **CGAL** insertion sweep, all three fits: all 181 offsets rigid-clear; the detent rides the ridge over 42 offsets, peak interference 0.150 mm / 0.239 mm³, within bound. Negative controls still fail where they should.
- `slidingSeamFit` gains `anchor_lead_tip` and `anchor_lead_bearing`, each mirroring an assert in the scad.
- 676 abacus tests pass and `tsc` reports no new errors — verified by diffing against pristine `main` in a clean worktree. The 2 test failures and 12 type errors that remain are identical on `main`: `@eink/plate-packing` isn't installed locally yet.

Printed geometry has been eyeballed in the studio; the physical print is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgAptHZR8Dc4XqirVFz8vD
