### PR TITLE
fix(abacus): trim phantom bead roles + surface planner refusals

### DIFF
--- a/apps/web/src/components/create/abacus/AbacusStudioContext.tsx
+++ b/apps/web/src/components/create/abacus/AbacusStudioContext.tsx
@@ -500,6 +500,13 @@ function useStudioController(playerId: string | null, designId: string | null) {
     // disagree, which is the property the panel has always relied on.
     servicePlan: filamentPlan.plan,
     unpinnedServicePlan: unpinnedPlan.plan,
+    // The PINNED plan's refusal — that read is the one that drives `materialize`,
+    // the ticket and the submit, so it is the one whose absence would otherwise
+    // let the panel paint designed colors as if they were printable. The unpinned
+    // read only badges the picker's recommendation; a refusal there costs a badge,
+    // not a correct print, and must not take over the panel.
+    servicePlanUnavailable: filamentPlan.unavailable,
+    servicePlanUnavailableDetail: filamentPlan.unavailableDetail,
     // "no settled answer for the CURRENT question" — which covers both the first
     // load and the window where `keepPreviousData` is holding the previous key's
     // answer on screen. A consumer that only watched `isLoading` would read a

--- a/apps/web/src/components/create/abacus/FabricationRail.tsx
+++ b/apps/web/src/components/create/abacus/FabricationRail.tsx
@@ -56,6 +56,8 @@ export function FabricationRail() {
     catalog,
     servicePlan,
     unpinnedServicePlan,
+    servicePlanUnavailable,
+    servicePlanUnavailableDetail,
     unplacedRoles,
     filamentMap,
     solveResult,
@@ -367,7 +369,14 @@ export function FabricationRail() {
         isLoading={thhFilaments.isLoading}
         isFetching={thhFilaments.isFetching}
         connectionId={selectedConnectionId}
-        unavailable={thhFilaments.unavailable}
+        // The roster read wins: when it fails the plan read never fires (an empty
+        // rosterSignature disables it), so this `??` is belt-and-braces, not a
+        // precedence rule anyone should rely on. The detail rides unconditionally
+        // because only the PLAN hook can produce 'refused', and the panel shows
+        // the detail only under that reason — so a catalog failure can never wear
+        // the planner's words.
+        unavailable={thhFilaments.unavailable ?? servicePlanUnavailable}
+        unavailableDetail={servicePlanUnavailableDetail}
         exportBlocked={exportBlocked}
         unplacedRoles={unplacedRoles}
         requestExportParts={requestExportParts}

--- a/apps/web/src/components/create/abacus/PrintPanel.tsx
+++ b/apps/web/src/components/create/abacus/PrintPanel.tsx
@@ -128,6 +128,10 @@ export interface PrintPanelProps {
    *  connection fallback; required once the user has paired more than one. */
   connectionId?: string
   unavailable: PrintUnavailableReason | null
+  /** The service's own sentence for a `refused` plan — quoted verbatim, because
+   *  it names WHICH constraint it refused ("palette supports at most 8 entries")
+   *  and nothing client-side can reconstruct that. Only rendered for 'refused'. */
+  unavailableDetail?: string | null
   /** Solver gate — a design that won't print can't be submitted either. */
   exportBlocked: boolean
   /** Role labels the filament planner could not serve from the loaded roster
@@ -198,6 +202,8 @@ const UNAVAILABLE_COPY: Record<PrintUnavailableReason, string> = {
   unreachable: 'Print service unreachable right now.',
   unauthorized: 'The print service rejected our credentials — re-pair to reconnect.',
   'no-printer': 'The print service has no printers.',
+  refused:
+    'The print service read this design and refused to plan it — its answer is below. This isn’t a hiccup: the same design gets the same answer, so change the design (fewer colors, fewer text groups) — or download the 3MF above and pick the filaments yourself.',
   error:
     'The print service hit an unexpected error reading your filaments — retry, or check the connection in Settings.',
 }
@@ -238,6 +244,7 @@ export function PrintPanel(props: PrintPanelProps) {
     isFetching = false,
     connectionId,
     unavailable,
+    unavailableDetail = null,
     exportBlocked,
     unplacedRoles = EMPTY_ROLES,
     requestExportParts,
@@ -746,12 +753,26 @@ export function PrintPanel(props: PrintPanelProps) {
       {unavailable !== null ? (
         <div data-element="print-service-unavailable" style={{ color: 'rgba(148,163,184,0.95)' }}>
           {UNAVAILABLE_COPY[unavailable]}
+          {unavailable === 'refused' && unavailableDetail && (
+            // The service's own words, marked as a quotation so it reads as the
+            // printer talking rather than as our copy.
+            <div
+              data-element="print-plan-refusal-detail"
+              style={{ marginTop: 6, fontStyle: 'italic', color: 'rgba(203,213,225,0.92)' }}
+            >
+              “{unavailableDetail}”
+            </div>
+          )}
           {/* Remediation is per-reason: not-configured (zero connections) gets an
               inline quick-pair (0 → 1, keeps the sole-connection fallback);
               unreachable/error get a retry that re-runs the reads; unauthorized/
               error also link to Settings › Printing (a dead or ambiguous
               connection must be fixed there, not re-paired inline). no-printer is
-              service-side with no client action, so it stays copy-only. */}
+              service-side with no client action, so it stays copy-only — and so
+              does refused: retrying re-asks a question the planner already
+              answered (staleTime Infinity plus a request-bytes key means the
+              answer only changes when the design does), so a control here would
+              be a lie. */}
           {unavailable === 'not-configured' ? (
             <PairPrinterPrompt />
           ) : (

--- a/apps/web/src/components/create/abacus/__tests__/abacus-plan-request.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-plan-request.test.ts
@@ -65,11 +65,54 @@ describe('designRoles', () => {
   it('mints roles from design INTENT, not from what a given render emits', () => {
     // Deliberately not gated on show_frame / show_markers: the plan answers "which
     // spool would this role use", and the 3MF re-checks visibility before consuming
-    // a slot. An unused role here is inert.
+    // a slot. A visibility-gated role here is inert (unlike an unreachable BEAD
+    // role, which the trim below refuses to mint at all).
     const hidden = designFor({ show_frame: false, show_markers: false })
     const keys = designRoles(hidden).map((r) => r.key)
     expect(keys).toContain('frame')
     expect(keys).toContain('marker-black')
+  })
+
+  it('mints only the bead roles a column can actually resolve to', () => {
+    // place-value maps column i to role (cols-1-i) % paletteLen, so a 3-column
+    // design never touches roles 3/4 ('1k', '10k'). Those phantom entries used to
+    // ride the palette anyway — joining every bead `different` pair and counting
+    // against the planner's palette cap, a hard 400 for a distinction the design
+    // never draws.
+    const keys = designRoles(designFor({ color_scheme: 'place-value', cols: 3 })).map((r) => r.key)
+    expect(keys.filter((k) => k.startsWith('bead-'))).toEqual(['bead-0', 'bead-1', 'bead-2'])
+
+    // enough columns to reach the whole palette: nothing is trimmed
+    const full = designRoles(designFor({ color_scheme: 'place-value', cols: 13 })).map((r) => r.key)
+    expect(full.filter((k) => k.startsWith('bead-'))).toEqual([
+      'bead-0',
+      'bead-1',
+      'bead-2',
+      'bead-3',
+      'bead-4',
+    ])
+
+    // alternating with ONE column never renders an odd column — role 1 is phantom
+    const single = designRoles(designFor({ color_scheme: 'alternating', cols: 1 })).map(
+      (r) => r.key
+    )
+    expect(single.filter((k) => k.startsWith('bead-'))).toEqual(['bead-0'])
+
+    // heaven-earth indexes by bead TYPE, not column — both roles survive one column
+    const he = designRoles(designFor({ color_scheme: 'heaven-earth', cols: 1 })).map((r) => r.key)
+    expect(he.filter((k) => k.startsWith('bead-'))).toEqual(['bead-0', 'bead-1'])
+  })
+
+  it('constrains only the SURVIVING bead roles to differ', () => {
+    // The trim's real payoff: no `different` pair may name a role that no bead can
+    // resolve to — such a pair spends a distinct spool on a phantom.
+    const req = buildFilamentPlanRequest(designFor({ color_scheme: 'place-value', cols: 3 }))
+    const different = req.constraints?.different ?? []
+    const beadPairs = different.filter((p) => p.paletteIds.some((id) => id.startsWith('bead-')))
+    expect(beadPairs.length).toBe(3) // C(3,2) — not C(5,2)
+    for (const p of beadPairs) {
+      for (const id of p.paletteIds) expect(['bead-0', 'bead-1', 'bead-2']).toContain(id)
+    }
   })
 
   it('omits feet unless they are printed, and text unless the inlay is inset', () => {

--- a/apps/web/src/components/create/abacus/__tests__/abacus-print-panel-state.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-print-panel-state.test.ts
@@ -63,6 +63,12 @@ describe('abacusPrintPanelState — branch order', () => {
   it('loading wins over the degrade/printable states (once service is available)', () => {
     expect(st({ isLoading: true, catalog: manual(), rosterEmpty: true }).kind).toBe('loading')
   })
+
+  it('a planner refusal takes the panel over too — it is not a milder state', () => {
+    // Deliberately with a printable live catalog: the roster is fine and the
+    // design still can't be planned, which is exactly what must not look healthy.
+    expect(st({ unavailable: 'refused', catalog: thh([spool()]) }).kind).toBe('unavailable')
+  })
 })
 
 describe('abacusPrintPanelState — degrade priority chain (source !== thh-ams)', () => {

--- a/apps/web/src/components/create/abacus/abacus-plan-request.ts
+++ b/apps/web/src/components/create/abacus/abacus-plan-request.ts
@@ -28,7 +28,7 @@ import type {
 import type { FilamentCatalog, FilamentSpool } from './abacus-catalog'
 
 import type { AbacusDesign } from './abacus-design'
-import { beadRoleColors, beadRoleNames, textGroups } from './abacus-model'
+import { beadRoleColors, beadRoleIndex, beadRoleNames, textGroups } from './abacus-model'
 
 export type PrintRoleKind = 'frame' | 'markerBlack' | 'markerWhite' | 'bead' | 'text' | 'feet'
 
@@ -52,23 +52,53 @@ export type PrintRole = {
  * Roles are minted from design INTENT, not from what a given render emits —
  * deliberately not gated on `show_frame` / `show_markers`, because the plan
  * answers "which spool would this role use", and the 3MF re-checks visibility
- * before consuming a slot. An unused role index here is inert.
+ * before consuming a slot. A visibility-gated role index here is inert.
+ *
+ * Bead roles are the exception to "mint from intent": a role NO bead can ever
+ * resolve to is not inert, it is harmful. `beadRoleIndex` maps column `i` to
+ * `(cols-1-i) % paletteLen` for place-value schemes, so a 3-column design never
+ * references role 3 or 4 — yet those phantom entries used to join the palette
+ * anyway, where they consumed slots in the all-bead-pairs `different`
+ * constraints (crowding real roles off spools) and could push the request past
+ * the planner's palette cap, a hard 400 (`palette_too_large`) for a distinction
+ * the design itself never draws. So bead roles are trimmed to the reachable
+ * set, enumerated through `beadRoleIndex` itself — the same function the
+ * render-side mapping consults, which is what keeps the trim and the render
+ * from ever disagreeing about which roles exist. (Every column renders exactly
+ * one heaven bead and `earth` earth beads, so columns × types is the exact
+ * domain.) The surviving keys stay a dense prefix — `bead-0 … bead-n` in order —
+ * so the index-based FilamentMap projection is undisturbed.
  */
 export function designRoles(design: AbacusDesign): PrintRole[] {
   const p = design.params
   const roleHexes = beadRoleColors(p.color_scheme, p.color_palette)
   const roleNames = beadRoleNames(p.color_scheme)
 
+  const reachableBeadRoles = new Set<number>()
+  for (let i = 0; i < p.cols; i += 1) {
+    reachableBeadRoles.add(beadRoleIndex(i, true, p.color_scheme, p.cols, p.color_palette))
+    reachableBeadRoles.add(beadRoleIndex(i, false, p.color_scheme, p.cols, p.color_palette))
+  }
+
   const roles: PrintRole[] = [
     { kind: 'markerBlack', key: 'marker-black', label: 'ArUco black', intrinsicHex: '#000000' },
     { kind: 'markerWhite', key: 'marker-white', label: 'ArUco white', intrinsicHex: '#ffffff' },
     { kind: 'frame', key: 'frame', label: 'Frame', intrinsicHex: design.resolvedColors.frame },
-    ...roleHexes.map((intrinsicHex, r) => ({
-      kind: 'bead' as const,
-      key: `bead-${r}`,
-      label: roleNames[r] ?? `bead ${r}`,
-      intrinsicHex,
-    })),
+    ...roleHexes.flatMap((intrinsicHex, r) =>
+      // `r` must stay the ORIGINAL role index — `beadRoleIndex` resolves to it on
+      // the render side. A filter-then-map would silently renumber the keys if a
+      // future scheme's reachable set ever stopped being a dense prefix.
+      reachableBeadRoles.has(r)
+        ? [
+            {
+              kind: 'bead' as const,
+              key: `bead-${r}`,
+              label: roleNames[r] ?? `bead ${r}`,
+              intrinsicHex,
+            },
+          ]
+        : []
+    ),
   ]
 
   // Printed feet (Gitea #23). The intrinsic hex is a fixed dark slate and is

--- a/apps/web/src/hooks/__tests__/useFilamentPlan.test.tsx
+++ b/apps/web/src/hooks/__tests__/useFilamentPlan.test.tsx
@@ -13,6 +13,9 @@
  *   • the read never fires against a roster we haven't seen
  *   • failures degrade to a reason, never to a throw or an endless spinner
  *   • a key change holds the previous answer rather than blanking the studio
+ *   • a coded refusal ({detail:{code,message}}) is carried with the service's
+ *     own words, not collapsed into a status — told apart by SHAPE, because the
+ *     proxy's own 4xx wear a different envelope
  */
 import type { FilamentPlanRequestV1 } from '@eink/print-dialog'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -65,6 +68,10 @@ function ok(body: unknown): Response {
 }
 function err(status: number): Response {
   return { ok: false, status, json: async () => ({}) } as unknown as Response
+}
+/** A THH-minted refusal, relayed byte-faithfully by the proxy. */
+function refusal(status: number, code: string, message: string): Response {
+  return { ok: false, status, json: async () => ({ detail: { code, message } }) } as unknown as Response
 }
 
 let queryClient: QueryClient
@@ -225,6 +232,7 @@ describe('useFilamentPlan — degrading', () => {
     [502, 'unreachable'],
     [401, 'unauthorized'],
     [403, 'unauthorized'],
+    [400, 'error'], // an UNSTRUCTURED 400 — no {detail} envelope, so no refusal
     [500, 'error'],
   ])('turns HTTP %i into the %s reason, never a throw', async (status, reason) => {
     mockApi.mockResolvedValue(err(status as number))
@@ -256,5 +264,74 @@ describe('useFilamentPlan — degrading', () => {
     await waitFor(() => expect(result.current.plan).not.toBeNull())
     expect(result.current.plan?.status).toBe('degraded')
     expect(result.current.unavailable).toBeNull()
+  })
+})
+
+describe('useFilamentPlan — a refusal is not a failure', () => {
+  it("a coded 4xx becomes 'refused' and carries the service's words", async () => {
+    mockApi.mockResolvedValue(
+      refusal(400, 'palette_too_large', 'palette supports at most 8 entries')
+    )
+    const { result } = renderHook(() => useFilamentPlan(base), { wrapper })
+    await waitFor(() => expect(result.current.unavailable).toBe('refused'))
+    expect(result.current.unavailableDetail).toBe('palette supports at most 8 entries')
+    expect(result.current.plan).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("a 400 the PROXY emitted (ambiguous connection) stays 'error'", async () => {
+    // Shape, not status: the proxy's own failures are {error: string}, and an
+    // ambiguous connection needs the Settings remediation, not refusal copy.
+    mockApi.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'Multiple connections — pass ?connectionId=' }),
+    } as unknown as Response)
+    const { result } = renderHook(() => useFilamentPlan(base), { wrapper })
+    await waitFor(() => expect(result.current.unavailable).toBe('error'))
+    expect(result.current.unavailableDetail).toBeNull()
+  })
+
+  it("a coded 401 is still 'unauthorized' — an expired token is not a refusal", async () => {
+    // THH relays its auth failures in the SAME {detail:{code,message}} envelope.
+    // Classifying by shape alone would eat the re-pair remediation.
+    mockApi.mockResolvedValue(refusal(401, 'unauthorized', 'token expired'))
+    const { result } = renderHook(() => useFilamentPlan(base), { wrapper })
+    await waitFor(() => expect(result.current.unavailable).toBe('unauthorized'))
+    expect(result.current.unavailableDetail).toBeNull()
+  })
+
+  it('a non-JSON error body still degrades by status', async () => {
+    // A 502 whose body is an HTML error page must stay 'unreachable' — the body
+    // read is guarded on its own, not left to the outer catch.
+    mockApi.mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new SyntaxError('Unexpected token <')
+      },
+    } as unknown as Response)
+    const { result } = renderHook(() => useFilamentPlan(base), { wrapper })
+    await waitFor(() => expect(result.current.unavailable).toBe('unreachable'))
+  })
+
+  it('a refusal clears when a new question is answered', async () => {
+    mockApi.mockResolvedValue(
+      refusal(400, 'palette_too_large', 'palette supports at most 8 entries')
+    )
+    const { result, rerender } = renderHook((props: { sig: string }) =>
+      useFilamentPlan({ ...base, rosterSignature: props.sig }), {
+      wrapper,
+      initialProps: { sig: 'roster-a' },
+    })
+    await waitFor(() => expect(result.current.unavailable).toBe('refused'))
+
+    mockApi.mockResolvedValue(ok(planBody('0.1')))
+    rerender({ sig: 'roster-b' })
+    await waitFor(() => expect(result.current.plan).not.toBeNull())
+    // reason and detail come off the same query.data, so both clear together —
+    // no stale sentence can survive a success
+    expect(result.current.unavailable).toBeNull()
+    expect(result.current.unavailableDetail).toBeNull()
   })
 })

--- a/apps/web/src/hooks/useFilamentPlan.ts
+++ b/apps/web/src/hooks/useFilamentPlan.ts
@@ -28,13 +28,37 @@ import { abacusPrintKeys } from '@/lib/queryKeys'
 
 type PlanResult =
   | { ok: true; value: FilamentPlanResponseV1 }
-  | { ok: false; reason: PrintUnavailableReason }
+  | { ok: false; reason: PrintUnavailableReason; detail?: string }
 
 function degradeReason(status: number): PrintUnavailableReason {
   if (status === 404) return 'not-configured'
   if (status === 502) return 'unreachable'
   if (status === 401 || status === 403) return 'unauthorized'
   return 'error'
+}
+
+/**
+ * The planner's REFUSAL, told apart from every other 4xx by SHAPE, not status.
+ *
+ * abaci's own proxy emits `{error: string}` for its failures (an ambiguous
+ * connection is a 400), while THH's are relayed byte-faithfully as
+ * `{detail: {code, message}}` — so the envelope, not the number, is what says
+ * "the planner read this request and said no".
+ *
+ * Statuses `degradeReason` already answers precisely are left to it: THH relays
+ * its auth 4xx in this same envelope, and an expired token must stay
+ * `unauthorized` (which has a real remediation) rather than becoming a refusal
+ * with none. 5xx never refuses — a 500 with a detail is a fault, not a verdict,
+ * and retrying may help.
+ */
+function refusalMessage(status: number, body: unknown): string | null {
+  if (status < 400 || status >= 500) return null
+  if (status === 404 || status === 401 || status === 403) return null
+  const detail = (body as { detail?: unknown } | null)?.detail
+  if (typeof detail !== 'object' || detail === null) return null
+  const { code, message } = detail as { code?: unknown; message?: unknown }
+  if (typeof code !== 'string' || typeof message !== 'string' || message === '') return null
+  return message
 }
 
 async function fetchPlan(path: string, request: FilamentPlanRequestV1): Promise<PlanResult> {
@@ -45,9 +69,17 @@ async function fetchPlan(path: string, request: FilamentPlanRequestV1): Promise<
       body: JSON.stringify(request),
     })
     // A plan the printer can't fully satisfy is a 200 carrying `degraded` /
-    // `unresolved` — the studio renders those as warnings. Only transport and
-    // validation failures land here.
-    if (!res.ok) return { ok: false, reason: degradeReason(res.status) }
+    // `unresolved` — the studio renders those as warnings. What lands here is
+    // transport failures, and the planner's own refusal of a request it read.
+    if (!res.ok) {
+      // Guarded separately: a 502 whose body is an HTML error page must still
+      // degrade to `unreachable`, not fall into the outer catch as `error`.
+      const body = await res.json().catch(() => null)
+      const message = refusalMessage(res.status, body)
+      return message !== null
+        ? { ok: false, reason: 'refused', detail: message }
+        : { ok: false, reason: degradeReason(res.status) }
+    }
     // Guard the boundary: `readFilamentPlanResponse` throws on anything that
     // isn't a plan, which is what keeps a proxy error page or a stray HTML body
     // from being consumed as assignments. It becomes a degrade, not a crash.
@@ -126,6 +158,10 @@ export function useFilamentPlan({
   return {
     plan: query.data?.ok ? query.data.value : null,
     unavailable: query.data && !query.data.ok ? query.data.reason : null,
+    /** The service's own sentence for a `refused`; null for every other reason.
+     *  Read from the same `query.data` as `unavailable`, so the pair can never
+     *  disagree and a resolved success replaces both atomically. */
+    unavailableDetail: query.data && !query.data.ok ? (query.data.detail ?? null) : null,
     isLoading: ready && query.isLoading,
     isFetching: query.isFetching,
     /** True while `plan` is the PREVIOUS key's answer and a fresh one is in flight. */

--- a/apps/web/src/lib/abacus/print/filament-wire.ts
+++ b/apps/web/src/lib/abacus/print/filament-wire.ts
@@ -123,15 +123,22 @@ export interface ThhFilamentsResponse {
 }
 
 /**
- * Why the live roster isn't available. The studio silently falls back to the
- * params-derived catalog on any of these — a missing print service is a
- * degraded state, never an error page.
+ * Why a live service read isn't available — shared by the roster read
+ * (`useThhFilamentCatalog`) and the plan read (`useFilamentPlan`). The studio
+ * silently falls back to the params-derived catalog on any of these — a missing
+ * print service is a degraded state, never an error page.
  */
 export type PrintUnavailableReason =
   | 'not-configured' // no paired connection
   | 'unreachable' // proxy could not reach the service
   | 'unauthorized' // service rejected the connection's token
   | 'no-printer' // service reachable but reports no printers
+  // the PLANNER read the request and refused it (a 4xx carrying the service's
+  // own {code, message}) — e.g. a palette past its cap. Deterministic: the same
+  // design gets the same answer, so there is nothing to retry. Only
+  // `useFilamentPlan` produces this; the roster read's own 400 (an ambiguous
+  // connection, minted by our proxy in a different shape) stays 'error'.
+  | 'refused'
   // any other failure (ambiguous-connection 400, 5xx, malformed response):
   // surfaced with remediation, never masked as success
   | 'error'


### PR DESCRIPTION
Two-sided fix for the silent filament-plan 400 in prod (a 3-column place-value design showing "8 FILAMENTS LOADED / PRINTS TRUE" while every plan request died on `palette_too_large`).

## Commit 1 — only mint bead roles a column can actually resolve to

`designRoles` minted all 5 place-value bead roles regardless of column count, but `beadRoleIndex` maps column `i` to `(cols-1-i) % paletteLen` — a 3-column abacus can only ever render roles 0–2. The phantoms joined the all-bead-pairs `different` constraints (10 pairs instead of 3), each demanding a distinct spool for a color no bead will ever print in, and pushed the request past THH's 8-entry palette cap into a hard 400.

The reachable set is enumerated through `beadRoleIndex` itself over columns × {heaven, earth} — not an arithmetic shortcut, which is wrong for heaven-earth (both roles are type-indexed and resolve at any column count). Surviving roles keep their original indices (`flatMap`, not filter-then-map) so the render side's index-based projection can never be silently rewired.

## Commit 2 — surface the planner's refusal instead of failing silently

A THH refusal (`{"detail":{"code","message"}}`) was swallowed twice: `fetchPlan` discarded the body into a generic `'error'`, and the plan hook's `unavailable` was never exposed — the panel's unavailable state came only from the roster read, which succeeded.

Now `'refused'` is a first-class `PrintUnavailableReason`, classified by **shape, not status** (the proxy's own failures wear `{error: string}`; coded 401/403/404 keep their precise reasons so an expired token still gets the re-pair remediation). The pinned plan's refusal takes the panel over, quotes the service's own sentence, blocks submit, and deliberately offers no retry — the answer is deterministic. The 3MF download stays open as the escape hatch.

## Checks

- vitest: 84/84 on touched suites, 1215/1215 across the abacus+hooks blast radius
- tsc: output byte-identical to pre-change baseline (stash-diffed)
- biome@2.4.5 lint (CI's pinned gate): exit 0, zero diagnostics on touched files; eslint clean

## Notes

- Even trimmed, this design sends 12 entries, so it stays refused — **visibly** now — until the service raises its cap: the THH half is ticketed as [things-haunt-house#444](https://git.dev.abaci.one/antialias/things-haunt-house/issues/444) ("bound the search, not the input").
- Part of the filament-plan/v1 integration (tracker soroban-abacus-flashcards#160 on Gitea).

🤖 Generated with [Claude Code](https://claude.com/claude-code)