### PR TITLE
fix: require the frame weld to retain inset text and marker fields

### DIFF
--- a/apps/web/src/components/create/abacus/__tests__/abacus-plan-request.test.ts
+++ b/apps/web/src/components/create/abacus/__tests__/abacus-plan-request.test.ts
@@ -228,6 +228,17 @@ describe('buildFilamentPlanRequest — the welded interfaces', () => {
     expect(req.interfaces?.every((i) => i.kind === 'bonded')).toBe(true)
   })
 
+  it('names the frame as the substrate of every bond — weld is the ONLY retention', () => {
+    // Inset text and marker fields have no mechanical lock: the weld alone holds
+    // them in the frame. `substrate` turns each bond from advisory into a hard
+    // constraint (things-haunt-house#448) so an unweldable spool (TPU into a PLA
+    // pocket) comes back unresolved instead of placed as a plug that falls out.
+    expect(req.interfaces?.length).toBeGreaterThan(0)
+    for (const i of req.interfaces ?? []) {
+      expect((i as { substrate?: string }).substrate).toBe('frame')
+    }
+  })
+
   it('declares NO bead interface — beads are captive on a clearance gap, never welded', () => {
     expect(
       (req.interfaces ?? []).some((i) => i.paletteIds.some((id) => id.startsWith('bead-')))

--- a/apps/web/src/components/create/abacus/abacus-plan-request.ts
+++ b/apps/web/src/components/create/abacus/abacus-plan-request.ts
@@ -281,10 +281,18 @@ export function buildFilamentPlanRequest(
   // question about two specific filaments, which is exactly what an interface
   // declares. Beads are deliberately absent: they are captive on a print
   // clearance gap, never welded, so they carry no bond requirement.
-  const interfaces: FilamentPaletteInterface[] = []
+  //
+  // `substrate: frameKey` makes each bond a HARD retention constraint
+  // (things-haunt-house#448): inset text and marker fields are held in the frame
+  // by the weld ALONE — the design has no mechanical lock — so a spool the
+  // planner cannot certify to fuse (e.g. TPU into a PLA pocket) must come back
+  // `unresolved`, never placed as a plug that falls out of the print. If the
+  // design ever gains a mechanical retention feature, drop `substrate` to return
+  // these bonds to advisory.
+  const interfaces: (FilamentPaletteInterface & { substrate?: string })[] = []
   if (frameKey) {
     for (const key of [...keyOf('markerBlack'), ...keyOf('markerWhite'), ...textKeys]) {
-      interfaces.push({ paletteIds: [frameKey, key], kind: 'bonded', label: `frame+${key}` })
+      interfaces.push({ paletteIds: [frameKey, key], kind: 'bonded', label: `frame+${key}`, substrate: frameKey })
     }
   }
 


### PR DESCRIPTION
Companion to things-haunt-house#448 / PR #449 (server side).

## What

Every bonded interface the abacus request declares (frame↔text-N, frame↔marker-black, frame↔marker-white) now names the frame as its `substrate`. That turns the bond from advisory into a hard retention constraint on THH's planner: inset text and the ArUco fields have **no mechanical lock** — the weld alone holds them — so a spool whose fuse can't be certified (TPU into a PLA pocket, a release-engineered support material) comes back `unresolved` and renders as the dashed no-spool tile, instead of being placed as a plug that falls out of the finished part.

Beads and feet stay interface-free, as before: beads are captive on a clearance gap, feet are retained by the crossbar.

## Behavior on the live x1c roster (verified against the THH branch)

- Green text group: **TPU for AMS → unresolved** (the reported problem).
- A second text group and marker-black leave **Support for PLA** (engineered to detach).
- Trade-off, deliberate: marker-black lands on PLA Basic Dark at ΔE≈18 — every true-black spool on this roster (PA-CF, PETG, PLA-S) can't weld to a PLA frame. A brown marker beats a detached one; drop `substrate` from the marker bonds if that call reverses.

## Compatibility

Additive field, `schemaVersion` stays 1. The deployed planner ignores it (advisory as today) until THH #449 ships, so this can merge in either order. Typed as an intersection so it compiles against the current `@eink/print-dialog` pin (1.1157.0) and against the release that adds the field — the pin bump becomes optional hygiene, not a blocker.

Checks: tsc clean, biome clean, abacus-plan-request vitest 31/31 (includes a new test locking `substrate: 'frame'` on every bond).

🤖 Generated with [Claude Code](https://claude.com/claude-code)